### PR TITLE
Add a 'test' extras_require

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,9 @@ python_requires = >=3.8
 
 [options.extras_require]
 gdrcopy = gdrcopy
+test =
+    pytest
+    pytest-asyncio
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
This serves as executable documentation of the packages *needed* to run
the unit tests (executable as `pip install .[test]`), as opposed to
requirements-dev.in which contains other packages like pre-commit that
are not directly related to the unit tests.

I'm assuming that pytest-xdist is listed in requirements-dev.in just
because it can help speed things up, rather than because it is a
requirement.

Relates to NGC-243.