### PR TITLE
Bump build-time requirements to the latest version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = [
 	"setuptools>=45",
 	"wheel",
 	"setuptools_scm[toml]>=6.0",
-	"jinja2==2.10.1",  # required to run bootstrap.sh when installing the spead2 submodule
-	"pycparser==2.19",  # required to run bootstrap.sh when installing the spead2 submodule
-	"pybind11==2.6.0",  # wrapping C++ functions in python
+	"jinja2==3.0.1",  # required to run bootstrap.sh when installing the spead2 submodule
+	"pycparser==2.20",  # required to run bootstrap.sh when installing the spead2 submodule
+	"pybind11==2.6.2",  # wrapping C++ functions in python
 ]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
I figure that since we're making big changes and will need to test
everything anyway, we might as well pick up the latest bug fixes (mainly
for pybind11; the others probably make zero difference).

Relates to NGC-203.