### PR TITLE
Improvements to dev-setup.sh script

### DIFF
--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -18,9 +18,8 @@ echo "Installing the repo in editable mode"
 pip install -e .
 
 echo "Compiling the C modules needed to run xbengine tests"
-cd test/xbgpu
-make
-cd -
+make -C test/xbgpu
+
 
 echo "Setting up pre-commit"
 pre-commit install


### PR DESCRIPTION
Add an editable install for convenience (some seem to favour adding `-e .` to `requirements-dev.txt`, but since we've got this script already let's use it.

The other change is to actually compile the C module needed to run some of the tests. They just fail without it and you are left scratching your head if you forgot.

Just a small quality-of-life improvement, nothing major.