### PR TITLE
Remove an invalid pytest ini setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ skip_glob = ["3rdparty/*"]
 [tool.pytest.ini_options]
 testpaths = "test"
 addopts = "--cov-context=test --cov-report html"
-import_mode = "importlib"
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
It's not a valid configuration setting, and adding it to `addopt` caused
the tests to fail because they can't import each other.