### PR TITLE
Make `--import-mode=prepend` explicit for pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ skip_glob = ["3rdparty/*"]
 
 [tool.pytest.ini_options]
 testpaths = "test"
-addopts = "--cov-context=test --cov-report html"
+addopts = "--cov-context=test --cov-report html --import-mode=prepend"
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
The default may eventually change to `importlib`, which doesn't work
with our code because there are relative imports between tests. However,
there are no plans to remove prepend mode (the current default),
according to
[this](https://github.com/pytest-dev/pytest/issues/7245#issuecomment-884882656).

This may make NGC-275 obsolete, but it's probably a good idea to at
least look at what's being imported and see if it makes more sense to
separate utility code for actual tests and/or have fixtures in
conftest.py.