### PR TITLE
Add --adc-rate parameter for script for running on gareth

### DIFF
--- a/scratch/fgpu/gareth/run-fgpu.sh
+++ b/scratch/fgpu/gareth/run-fgpu.sh
@@ -33,6 +33,7 @@ exec cap_net_raw taskset -c $other_affinity fgpu \
     --dst-interface $iface --dst-ibv \
     --src-affinity $src_affinity --src-comp-vector=$src_comp \
     --dst-affinity $dst_affinity --dst-comp-vector=$dst_comp \
+    --adc-rate 1712000000 \
     --channels 32768 \
     --quant-scale 0.0001 \
     --dst-packet-payload 8192 \


### PR DESCRIPTION
I'd taken it out thinking that 1712e6 was the default, but in fact the
default is to transmit as fast as possible.