### PR TITLE
Use pip-compile in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,3 +61,14 @@ repos:
             'types-setuptools==57.0.0',
             'types-six==0.1.7',
         ]
+  - repo: https://github.com/jazzband/pip-tools
+    rev: 6.2.0
+    hooks:
+      - id: pip-compile
+        name: pip-compile requirements.in
+        args: [requirements.in]
+        files: ^requirements\.(in|txt)$
+      - id: pip-compile
+        name: pip-compile requirements-dev.in
+        args: [requirements-dev.in]
+        files: ^requirements(-dev)?\.(in|txt)$

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -7,7 +7,7 @@ echo "Activating the virtual env"
 source .venv/bin/activate
 
 pip install --upgrade pip # stops pip from complaining
-pip install wheel pip-tools # Makes the process a bit slicker.
+pip install wheel # Makes the process a bit slicker.
 echo "Installing requirements for running and development"
 pip install -r requirements.txt -r requirements-dev.txt
 

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,6 +1,7 @@
 -c requirements.txt
 coverage[toml]  # It's pulled in by pytest-cov, but I want the toml ability.
 ipython
+pip-tools
 pre-commit
 pytest
 pytest-asyncio

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,6 +22,8 @@ cfgv==3.3.0
     # via pre-commit
 charset-normalizer==2.0.3
     # via requests
+click==8.0.1
+    # via pip-tools
 coverage[toml]==5.5
     # via
     #   -r requirements-dev.in
@@ -74,10 +76,14 @@ packaging==21.0
     #   sphinx
 parso==0.8.2
     # via jedi
+pep517==0.11.0
+    # via pip-tools
 pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
+pip-tools==6.2.0
+    # via -r requirements-dev.in
 pluggy==0.13.1
     # via pytest
 pre-commit==2.13.0
@@ -165,6 +171,8 @@ toml==0.10.2
     #   pre-commit
     #   pytest
     #   pytest-cov
+tomli==1.0.4
+    # via pep517
 traitlets==5.0.5
     # via
     #   ipython
@@ -175,6 +183,9 @@ virtualenv==20.4.7
     # via pre-commit
 wcwidth==0.2.5
     # via prompt-toolkit
+wheel==0.36.2
+    # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools


### PR DESCRIPTION
This ensures that requirements.txt and requirements-dev.txt are always
up to date with respect to the corresponding .in files. In particular,
if a requirement is updated in requirements.txt, it will ensure that
requirements-dev.txt gets the same version (if it appears in both).

Removed pip-tools from dev-setup.py (no longer used there) but added it
to requirements-dev.txt so that one can call it directly to update
requirements.