### PR TITLE
Make lack of --src-ibv work for fgpu

### DIFF
--- a/src/katgpucbf/fgpu/_katfgpu/py_recv.cpp
+++ b/src/katgpucbf/fgpu/_katfgpu/py_recv.cpp
@@ -204,15 +204,14 @@ py::module register_module(py::module &parent)
             filename
                 Name of PCAP file to open.
             )pydocstring")
-        .def("add_udp_ibv_reader", &py_stream::add_udp_ibv_reader,
-            "endpoints"_a, "interface_address"_a, "buffer_size"_a,
+        .def("add_udp_reader", &py_stream::add_udp_reader,
+            "endpoints"_a, "interface_address"_a, "buffer_size"_a, "ibv"_a,
             "comp_vector"_a = 0,
             "max_poll"_a = spead2::recv::udp_ibv_config::default_max_poll,
             R"pydocstring(
-            Add the ibv_udp transport.
+            Add the UDP transport.
 
-            The receiver will read UDP packets off of the specified interface
-            using the ibverbs library to offload processing from the CPU.
+            The receiver will read UDP packets off of the specified interface.
 
             Parameters
             ----------
@@ -224,6 +223,9 @@ py::module register_module(py::module &parent)
             buffer_size
                 The size in bytes of buffer where packets are received before
                 being transferred to a chunk.
+            ibv
+                If true, use ibverbs to bypass the kernel for higher efficiency.
+                If false, `comp_vector` and `max_poll` are ignored.
             comp_vector
                 The completion channel vector (interrupt) for asynchronous
                 operation. Use a negative value to poll continuously. If a

--- a/src/katgpucbf/fgpu/_katfgpu/recv.h
+++ b/src/katgpucbf/fgpu/_katfgpu/recv.h
@@ -191,10 +191,10 @@ public:
 
     void add_udp_pcap_file_reader(const std::string &filename);
 
-    void add_udp_ibv_reader(const std::vector<std::pair<std::string, std::uint16_t>> &endpoints,
-                            const std::string &interface_address,
-                            std::size_t buffer_size, int comp_vector = 0,
-                            int max_poll = spead2::recv::udp_ibv_config::default_max_poll);
+    void add_udp_reader(const std::vector<std::pair<std::string, std::uint16_t>> &endpoints,
+                        const std::string &interface_address,
+                        std::size_t buffer_size, bool ibv, int comp_vector = 0,
+                        int max_poll = spead2::recv::udp_ibv_config::default_max_poll);
 
     /// Get the referenced ringbuffer
     ringbuffer_t &get_ringbuffer();

--- a/src/katgpucbf/fgpu/_katfgpu/recv.pyi
+++ b/src/katgpucbf/fgpu/_katfgpu/recv.pyi
@@ -53,11 +53,12 @@ class Stream:
     def chunk_bytes(self) -> int: ...
     def add_chunk(self, chunk: Chunk) -> None: ...
     def add_udp_pcap_file_reader(self, filename: str) -> None: ...
-    def add_udp_ibv_reader(
+    def add_udp_reader(
         self,
         endpoints: Sequence[Tuple[str, int]],
         interface_address: str,
         buffer_size: int,
+        ibv: bool,
         comp_vector: int = ...,
         max_poll: int = ...,
     ) -> None: ...

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -282,6 +282,7 @@ class Engine(aiokatcp.DeviceServer):
         self._src_comp_vector = list(src_comp_vector)
         self._src_interface = src_interface
         self._src_buffer = src_buffer
+        self._src_ibv = src_ibv
         self._src_streams = [
             recv.Stream(
                 pol,
@@ -419,8 +420,9 @@ class Engine(aiokatcp.DeviceServer):
                 else:
                     if self._src_interface is None:
                         raise ValueError("src_interface is required for UDP sources")
-                    # TODO: use src_ibv                     ...?
-                    stream.add_udp_ibv_reader(src, self._src_interface, self._src_buffer, self._src_comp_vector[pol])
+                    stream.add_udp_reader(
+                        src, self._src_interface, self._src_buffer, self._src_ibv, self._src_comp_vector[pol]
+                    )
             tasks = [
                 loop.create_task(self._processor.run_processing(self._src_streams)),
                 loop.create_task(self._processor.run_receive(self._src_streams)),


### PR DESCRIPTION
Previously it was ignored and ibverbs was always assumed. Fix by
replacing add_udp_ibv_reader with an add_udp_reader that takes a flag
and emplaces the appropriate reader(s).

Closes NGC-271.