### PR TITLE
Update TCC v0.3 Kernel to recognise newer GPU arch

### DIFF
--- a/src/katgpucbf/xbgpu/kernels/tensor_core_correlation_kernel.mako
+++ b/src/katgpucbf/xbgpu/kernels/tensor_core_correlation_kernel.mako
@@ -41,7 +41,7 @@
 #error this architecture has no tensor cores
 #endif
 
-#if __CUDA_ARCH__ != 700 && __CUDA_ARCH__ != 720 && __CUDA_ARCH__ != 750
+#if __CUDA_ARCH__ != 700 && __CUDA_ARCH__ != 720 && __CUDA_ARCH__ != 750 && __CUDA_ARCH__ != 800 && __CUDA_ARCH__ != 860
 #define PORTABLE // unknown architecture -> write visibilities in portable way (via shared memory)
 #endif
 
@@ -222,7 +222,7 @@ __device__ inline void storeVisibilities(Visibilities visibilities, unsigned cha
   unsigned statX    = firstStationX + statXoffset + NR_STATIONS_PER_TCM_X * x + ((threadIdx.x >> 2) & 2);
   unsigned polY     = threadIdx.x & 1;
   unsigned polX     = (threadIdx.x >> 1) & 1;
-#elif (__CUDA_ARCH__ == 720 && NR_BITS == 8) || __CUDA_ARCH__ == 750
+#elif (__CUDA_ARCH__ == 720 && NR_BITS == 8) || __CUDA_ARCH__ == 750 || __CUDA_ARCH__ == 800 || __CUDA_ARCH__ == 860
   unsigned statY    = firstStationY + statYoffset + NR_STATIONS_PER_TCM_Y * y + ((threadIdx.x >> 3) & 3);
   unsigned statX    = firstStationX + statXoffset + NR_STATIONS_PER_TCM_X * x + ((threadIdx.x >> 1) & 1);
   unsigned polY     = (threadIdx.x >> 2) & 1;
@@ -236,7 +236,7 @@ __device__ inline void storeVisibilities(Visibilities visibilities, unsigned cha
   storeVisibility(visibilities, channel, baseline, statY, statX, 0, 1, polY, polX, skipCheckY, skipCheckX, sum.x[4], sum.x[5]);
   storeVisibility(visibilities, channel, baseline, statY, statX, 1, 0, polY, polX, skipCheckY, skipCheckX, sum.x[2], sum.x[3]);
   storeVisibility(visibilities, channel, baseline, statY, statX, 1, 1, polY, polX, skipCheckY, skipCheckX, sum.x[6], sum.x[7]);
-#elif (__CUDA_ARCH__ == 720 && NR_BITS == 8) || __CUDA_ARCH__ == 750
+#elif (__CUDA_ARCH__ == 720 && NR_BITS == 8) || __CUDA_ARCH__ == 750 || __CUDA_ARCH__ == 800 || __CUDA_ARCH__ == 860
   storeVisibility(visibilities, channel, baseline, statY, statX, 0, 0, polY, polX, skipCheckY, skipCheckX, sum.x[0], sum.x[1]);
 #if NR_BITS == 8 || NR_BITS == 16
   storeVisibility(visibilities, channel, baseline, statY, statX, 0, 2, polY, polX, skipCheckY, skipCheckX, sum.x[4], sum.x[5]);


### PR DESCRIPTION
These updates allow the v0.3 Tensor Core kernel to recognise newer GPU
architectures, such as the sm_86 on the RTX 3060. No changes have been
made regarding older GPU architectures, such as sm_75 and _72.

The relevant unit tests have been run and confirmed to work on GPUs
representing both architectures, namely a 2060 Super and an RTX 3060.

Resolves: NGC-301.

Added @bmerry as a reviewer more as a "Letting you know these are the changes I was alluding to last week".