### PR TITLE
pytest: suppress warnings from 3rd-party packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ skip_glob = ["3rdparty/*"]
 [tool.pytest.ini_options]
 testpaths = "test"
 addopts = "--cov-context=test --cov-report html --import-mode=prepend"
+filterwarnings = [
+	'ignore:`np\..*` is a deprecated alias::pycuda\.compyte\.dtypes',
+	'ignore:`np\..*` is a deprecated alias::skcuda\.misc',
+	'ignore:creating CUBLAS context to get version number::skcuda\.cublas',
+]
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
Suppress a number of warnings from pycuda and scikit-cuda that we can't
do anything about until there are new releases, so that warnings we can
do something about will stand out.

Closes NGC-295.