### PR TITLE
Bind to 127.0.0.1 in unit test

### DIFF
--- a/test/fgpu/test_katcp_interface.py
+++ b/test/fgpu/test_katcp_interface.py
@@ -11,6 +11,7 @@ class TestKatcpRequests:
     """Unit tests for the Engine's KATCP requests."""
 
     engine_arglist = [
+        "--katcp-host=127.0.0.1",
         "--katcp-port=0",
         "--src-interface=lo",
         "--dst-interface=lo",


### PR DESCRIPTION
The katcp test uses the socket's dynamically determined host and port to
decide where to connect. But since no host was specified, the socket's
host is `::`, and I don't know what happens when one tries to connect
there. It seems to go wrong a lot of the time when used inside Docker.

Fix by explicitly binding to localhost (and explicitly to IPv4 localhost
since I've had issues with resolving `localhost` in Docker CI
environments in the past).