### PR TITLE
Avoid running flake8 on .venv directory

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 120
-exclude = 3rdparty
+exclude = 3rdparty, .venv
 
 # configure the maximum complexity to allow
 # 15 is recommended for more complex modules


### PR DESCRIPTION
This isn't an issue when it's run by pre-commit, but when I ran flake8
manually it started scanning everything in the .venv directory.