### PR TITLE
Add timeout to test stage in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,6 +33,10 @@ pipeline {
   environment {
     DEBIAN_FRONTEND = 'noninteractive' // Required for zero interaction when installing or upgrading software packages
   }
+  
+  options {
+    timeout(time: 2, unit: 'HOURS')
+  }
 
   stages {
     stage('Install Python packages') {
@@ -101,14 +105,14 @@ pipeline {
      */
     stage('Run pytest (quick)') {
       when { not { anyOf { changeRequest target: 'main'; branch 'main' } } }
-      options { timeout(time: 5, unit: 'MINUTES') }
+      options { timeout(time: 10, unit: 'MINUTES') }
       steps {
         sh 'pytest -v -rs --junitxml=reports/result.xml'
       }
     }
     stage('Run pytest (full)') {
       when { anyOf { changeRequest target: 'main'; branch 'main' } }
-      options { timeout(time: 30, unit: 'MINUTES') }
+      options { timeout(time: 60, unit: 'MINUTES') }
       steps {
         sh 'pytest -v -rs --all-combinations --junitxml=reports/result.xml'
       }


### PR DESCRIPTION
I added a timeout to the test stage of the Jenkinsfile for quick and full tests. The timeout duration I choose is based on the duration of the tests that were run in the past.