### PR TITLE
Simplify calls to create_task

### DIFF
--- a/scratch/fgpu/showf/server_lifecycle.py
+++ b/scratch/fgpu/showf/server_lifecycle.py
@@ -12,5 +12,5 @@ def on_server_loaded(server_context):
         args.address, args.interface, args.channels, args.substreams, args.acc_len, args.keep_ratio, server_context
     )
     print(type(server_context))
-    asyncio.get_event_loop().create_task(backend.run())
+    asyncio.create_task(backend.run())
     print("Server loaded")

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -445,7 +445,6 @@ class Engine(aiokatcp.DeviceServer):
           doing cleanup from an exception then I think you lose one of the
           exceptions. Which is a problem.
         """
-        loop = asyncio.get_event_loop()
         await self.start()
         try:
             for pol, stream in enumerate(self._src_streams):
@@ -472,9 +471,9 @@ class Engine(aiokatcp.DeviceServer):
                             interface_address=self._src_interface or "",
                         )
             tasks = [
-                loop.create_task(self._processor.run_processing(self._src_streams)),
-                loop.create_task(self._processor.run_receive(self._src_streams, self._src_layout)),
-                loop.create_task(self._processor.run_transmit(self._send_stream)),
+                asyncio.create_task(self._processor.run_processing(self._src_streams)),
+                asyncio.create_task(self._processor.run_receive(self._src_streams, self._src_layout)),
+                asyncio.create_task(self._processor.run_transmit(self._send_stream)),
             ]
             await asyncio.gather(*tasks)
         finally:

--- a/src/katgpucbf/fgpu/process.py
+++ b/src/katgpucbf/fgpu/process.py
@@ -632,7 +632,7 @@ class Processor:
                     item.samples = []
                     chunks = item.chunks
                     item.chunks = []
-                    asyncio.get_event_loop().create_task(self._push_chunks(streams, chunks, event))
+                    asyncio.create_task(self._push_chunks(streams, chunks, event))
                 else:
                     item.events.append(event)
                 self.in_free_queue.put_nowait(item)
@@ -736,7 +736,7 @@ class Processor:
             n_bytes = n_frames * np.product(out_item.spectra.shape[1:]) * out_item.spectra.dtype.itemsize
             out_item.reset()
             self.out_free_queue.put_nowait(out_item)
-            task = asyncio.get_event_loop().create_task(chunk.send(stream, n_frames))
+            task = asyncio.create_task(chunk.send(stream, n_frames))
 
             def chunk_finished(future):
                 self.send_free_queue.put_nowait(chunk)

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -222,9 +222,8 @@ async def async_main(args: argparse.Namespace) -> None:
 
     logger.info("Starting main processing loop")
 
-    loop = asyncio.get_event_loop()
-    main_task = loop.create_task(xbengine.run())
-    descriptor_task = loop.create_task(xbengine.run_descriptors_loop(5))
+    main_task = asyncio.create_task(xbengine.run())
+    descriptor_task = asyncio.create_task(xbengine.run_descriptors_loop(5))
     await main_task
     await descriptor_task
 

--- a/src/katgpucbf/xbgpu/xbengine.py
+++ b/src/katgpucbf/xbgpu/xbengine.py
@@ -915,12 +915,11 @@ class XBEngine(DeviceServer):
             raise AttributeError("Transport for sending data has not yet been set.")
 
         self.running = True
-        loop = asyncio.get_event_loop()
         await self.start()
         tasks = [
-            loop.create_task(self._receiver_loop()),
-            loop.create_task(self._gpu_proc_loop()),
-            loop.create_task(self._sender_loop()),
+            asyncio.create_task(self._receiver_loop()),
+            asyncio.create_task(self._gpu_proc_loop()),
+            asyncio.create_task(self._sender_loop()),
         ]
         self.task = asyncio.gather(*tasks)
 

--- a/test/xbgpu/test_spead2_send.py
+++ b/test/xbgpu/test_spead2_send.py
@@ -232,8 +232,8 @@ def test_send_simple(context, event_loop, num_ants, num_channels):
     # 6. Function that will launch the send_process() and recv_process() in a parallel on a single asyncio loop.
     async def run():
         """Launch the send_process() function and recv_process() function in parallel in a single asyncio loop."""
-        task1 = event_loop.create_task(send_process())
-        task2 = event_loop.create_task(recv_process())
+        task1 = asyncio.create_task(send_process())
+        task2 = asyncio.create_task(recv_process())
         await task1
         await task2
 

--- a/test/xbgpu/test_xbengine.py
+++ b/test/xbgpu/test_xbengine.py
@@ -457,8 +457,8 @@ def test_xbengine(context, event_loop, num_ants, num_spectra_per_heap, num_chann
         The recv_process() has an end point while the xbengine runs forever. Waits for the recv_process() finish and
         then stops the xbengine.
         """
-        task1 = event_loop.create_task(xbengine.run())
-        task2 = event_loop.create_task(recv_process())
+        task1 = asyncio.create_task(xbengine.run())
+        task2 = asyncio.create_task(recv_process())
         await task2
         task1.cancel()
 


### PR DESCRIPTION
Prior to Python 3.7 one had to do
asyncio.get_event_loop().create_task(...), but Python 3.7 introduced
asyncio.create_task which is less typing.