### PR TITLE
Bump sphinxcontrib-tikz to the latest version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -182,7 +182,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sphinxcontrib-tikz==0.4.13
+sphinxcontrib-tikz==0.4.15
     # via -r requirements-dev.in
 toml==0.10.2
     # via


### PR DESCRIPTION
For some reason when doing a fresh install, trying to install
sphinxcontrib-tikz gave an error about use_2to3 being unknown (possibly
setuptools removed it in a new version)? Anyway it's fixed in the latest
version.