### PR TITLE
Duplicate fine_delay and phase

### DIFF
--- a/src/katgpucbf/fgpu/postproc.py
+++ b/src/katgpucbf/fgpu/postproc.py
@@ -77,6 +77,10 @@ class Postproc(accel.Operation):
     **out** : (spectra // spectra_per_heap, channels, spectra_per_heap, 2, 2), int8
         Output F-engine data, quantised and corner-turned, ready for
         transmission on the network.
+    **fine_delay** : spectra × 2, float32
+        Fine delay in samples (one value per pol).
+    **phase** : spectra × 2, float32
+        Fixed phase adjustment in radians (one value per pol).
 
     The inputs need to have dimension `channels+1` because cuFFT calculates
     N/2+1 output channels, i.e. the Nyquist frequency is included.  The kernel
@@ -125,8 +129,8 @@ class Postproc(accel.Operation):
         self.slots["in0"] = accel.IOSlot(in_shape, np.complex64)
         self.slots["in1"] = accel.IOSlot(in_shape, np.complex64)
         self.slots["out"] = accel.IOSlot((spectra // spectra_per_heap, channels, spectra_per_heap, pols, cplx), np.int8)
-        self.slots["fine_delay"] = accel.IOSlot((spectra,), np.float32)
-        self.slots["phase"] = accel.IOSlot((spectra,), np.float32)
+        self.slots["fine_delay"] = accel.IOSlot((spectra, pols), np.float32)
+        self.slots["phase"] = accel.IOSlot((spectra, pols), np.float32)
         self.quant_gain = 1.0
 
     def _run(self) -> None:

--- a/src/katgpucbf/fgpu/process.py
+++ b/src/katgpucbf/fgpu/process.py
@@ -619,11 +619,16 @@ class Processor:
             # - The PFB-FIR.
             if batch_spectra > 0:
                 logging.debug("Processing %d spectra", batch_spectra)
+                # TODO: here we're just duplicating the fine delay and phase
+                # across the polarisations. We should actually use separate
+                # delay models.
                 self._out_item.fine_delay[
                     self._out_item.n_spectra : self._out_item.n_spectra + batch_spectra
-                ] = fine_delays
+                ] = fine_delays[:, np.newaxis]
+                # Divide by pi because the arguments of sincospif() used in the
+                # kernel are in radians/PI.
                 self._out_item.phase[self._out_item.n_spectra : self._out_item.n_spectra + batch_spectra] = (
-                    phase / np.pi  # because the arguments of sincospif() used in the kernel are in radians/PI
+                    phase[:, np.newaxis] / np.pi
                 )
                 self.compute.run_frontend(self._in_items[0].samples, offset, self._out_item.n_spectra, batch_spectra)
                 self._out_item.n_spectra += batch_spectra


### PR DESCRIPTION
This is the first step to address NGC-404. The postprocess now takes
fine delay and phase as float2 (value per pol). The processor still only
has one delay model.