### PR TITLE
Store and take updates to two delay models

### DIFF
--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -322,7 +322,8 @@ class TestEngine:
         # Based on katpoint.delay.DelayCorrection.corrections
         phase = -2.0 * np.pi * sky_centre_frequency * -delay_s
         phase_correction = -phase
-        await engine_client.request("delays", SYNC_EPOCH, f"{delay_s},0.0:{phase_correction},0.0")
+        coeffs = f"{delay_s},0.0:{phase_correction},0.0"
+        await engine_client.request("delays", SYNC_EPOCH, coeffs, coeffs)
 
         src_layout = engine_server._src_layout
         n_samples = 20 * src_layout.chunk_samples
@@ -439,7 +440,8 @@ class TestEngine:
         delay_rate = 1e-5  # Should be high enough to cause multiple coarse delay changes per chunk
         phase_rate_per_sample = 30 / n_samples  # Should wrap multiple times over the test
         phase_rate = phase_rate_per_sample * ADC_SAMPLE_RATE
-        await engine_client.request("delays", SYNC_EPOCH, f"0.0,{delay_rate}:0.0,{phase_rate}")
+        coeffs = f"0.0,{delay_rate}:0.0,{phase_rate}"
+        await engine_client.request("delays", SYNC_EPOCH, coeffs, coeffs)
 
         first_timestamp = 100 * src_layout.chunk_samples
         out_data, timestamps = await self._send_data(
@@ -485,7 +487,8 @@ class TestEngine:
         update_times = [0, 123456, 400000, 1234567, 1234567890]  # in samples
         update_phases = [1.0, 0.2, -0.2, -2.0, 0.0]
         for time, phase in zip(update_times, update_phases):
-            await engine_client.request("delays", SYNC_EPOCH + time / ADC_SAMPLE_RATE, f"0.0,0.0:{phase},0.0")
+            coeffs = f"0.0,0.0:{phase},0.0"
+            await engine_client.request("delays", SYNC_EPOCH + time / ADC_SAMPLE_RATE, coeffs, coeffs)
 
         out_data, timestamps = await self._send_data(
             mock_recv_streams,

--- a/test/fgpu/test_katcp_interface.py
+++ b/test/fgpu/test_katcp_interface.py
@@ -41,7 +41,7 @@ class TestKatcpRequests:
 
     async def test_quant_gain_set(self, engine_client, engine_server):
         """Test that the quant gain is correctly set."""
-        _reply, _informs = await engine_client.request("quant-gain", 0.2)
+        await engine_client.request("quant-gain", 0.2)
         assert engine_server._processor.compute.quant_gain == 0.2
 
     @pytest.mark.parametrize(
@@ -61,13 +61,22 @@ class TestKatcpRequests:
         """
         start_time = SYNC_EPOCH + 10
         with pytest.raises(aiokatcp.FailReply):
-            _reply, _informs = await engine_client.request("delays", start_time, malformed_delay_string)
+            await engine_client.request("delays", start_time, malformed_delay_string, malformed_delay_string)
 
     async def test_delay_model_update_missing_argument(self, engine_client):
         """Test that a delay request with a missing argument is rejected."""
         with pytest.raises(aiokatcp.FailReply):
             # Missing start time argument
-            _reply, _informs = await engine_client.request("delays", "3.76,0.12:7.322,1.91")
+            await engine_client.request("delays", "3.76,0.12:7.322,1.91")
+        with pytest.raises(aiokatcp.FailReply):
+            # Only one of the two models
+            await engine_client.request("delays", "123456789.0", "3.76,0.12:7.322,1.91")
+
+    async def test_delay_model_update_too_many_arguments(self, engine_client):
+        """Test that a delay request with too many arguments is rejected."""
+        coeffs = "3.76,0.12:7.322,1.91"
+        with pytest.raises(aiokatcp.FailReply):
+            await engine_client.request("delays", "123456789.0", coeffs, coeffs, coeffs)
 
 
 class TestKatcpSensors:


### PR DESCRIPTION
Only the first delay model is actually used so far, but the katcp
interface now takes both of them.

The unit tests set both delay models the same for now, so that they will
continue to work once the delay models are both applied.

Relates to NGC-404.