### PR TITLE
Updates to scripts for running fgpu/dsim in the lab

### DIFF
--- a/scratch/fgpu/gareth/run-fgpu.sh
+++ b/scratch/fgpu/gareth/run-fgpu.sh
@@ -11,6 +11,7 @@ dst_comp=$dst_affinity
 other_affinity="$((6*$1+4))"
 srcs="239.102.$1.64+7:7148 239.102.$1.72+7:7148"
 dst="239.102.$((200+$1)).0+15:7148"
+port="$(($1+7140))"
 
 case "$1" in
     0|1)
@@ -28,7 +29,7 @@ case "$1" in
 esac
 
 set -x
-exec cap_net_raw taskset -c $other_affinity fgpu \
+exec spead2_net_raw taskset -c $other_affinity fgpu \
     --src-interface $iface --src-ibv \
     --dst-interface $iface --dst-ibv \
     --src-affinity $src_affinity --src-comp-vector=$src_comp \
@@ -37,6 +38,6 @@ exec cap_net_raw taskset -c $other_affinity fgpu \
     --channels 32768 \
     --quant-gain 0.0001 \
     --dst-packet-payload 8192 \
-    --katcp-port 0 \
+    --katcp-port $port \
     --sync-epoch 0 \
     $srcs $dst

--- a/scratch/fgpu/qgpu01/run-dsim.sh
+++ b/scratch/fgpu/qgpu01/run-dsim.sh
@@ -19,4 +19,4 @@ esac
 cpu="$1"
 addresses="239.102.$1.64+7:7148 239.102.$1.72+7:7148"
 ip="10.100.$((41+2*($1%2))).1"
-exec cap_net_raw numactl -C $cpu ../../../src/tools/dsim --ibv --interface $ip --adc-sample-rate 1712000000 --ttl 2 $addresses
+exec spead2_net_raw numactl -C $cpu ../../../src/tools/dsim --ibv --interface $ip --adc-sample-rate 1712000000 --ttl 2 $addresses


### PR DESCRIPTION
- Replace outdated reference to cap_net_raw with spead2_net_raw
- Use fixed port numbers for fgpu (7140..7143) to faciliate querying the
  sensors.