### PR TITLE
Make fsim packet size configurable

### DIFF
--- a/src/tools/fsim.cpp
+++ b/src/tools/fsim.cpp
@@ -119,20 +119,20 @@ static options parse_options(int argc, const char **argv)
     boost::program_options::options_description desc, hidden, all("F- to X- Engine simulator");
     desc.add_options()("help", "produce help message");
     desc.add_options()("interface", boost::program_options::value(&opts.strInterface)->required(),
-                       "Interface address to send data out on.");
-    desc.add_options()("max-heaps", make_opt(opts.iMaxHeaps), "Maximum number of heaps per F-Engine.");
+                       "Interface address to send data out on");
+    desc.add_options()("max-heaps", make_opt(opts.iMaxHeaps), "Maximum number of heaps per F-Engine");
     desc.add_options()("adc-sample-rate", make_opt(opts.dAdcSampleRate), "Sampling rate of digitisers feeding the F-Engine");
     desc.add_options()("ttl", make_opt(opts.iTtl), "Output TTL (Time to live)");
     desc.add_options()("array-size", make_opt(opts.n_ants), "Number of antennas in the array");
     desc.add_options()("fft-channels", make_opt(opts.n_chans_total),
                        "Number of channels out of the FFT. (Normally half of FFT size)");
     desc.add_options()("channels-per-substream", make_opt(opts.n_chans_per_output_stream),
-                       "Each F-Engine output substream transmits a subset of the FFT channels.");
+                       "Each F-Engine output substream transmits a subset of the FFT channels");
     desc.add_options()("spectra-per-heap", make_opt(opts.n_spectra_per_heap),
-                       "The F-Engine cornerturn groups a number of samples into each channel per packet.");
+                       "The F-Engine cornerturn groups a number of samples into each channel per packet");
     desc.add_options()("packet-size", make_opt(opts.packet_payload_size_bytes),
                        "The number of payload bytes per packet");
-    desc.add_options()("run-once", make_opt(opts.bRunOnce), "Transmit a single collection of heaps before exiting.");
+    desc.add_options()("run-once", make_opt(opts.bRunOnce), "Transmit a single collection of heaps before exiting");
     hidden.add_options()(
         "address", boost::program_options::value<std::string>(&opts.strAddress)->composing(),
         "destination address, in form x.x.x.x[+y]:port where y represents the number of additional multicast streams "
@@ -169,6 +169,7 @@ static options parse_options(int argc, const char **argv)
      */
     opts.heap_size_bytes =
         opts.n_chans_per_output_stream * opts.n_spectra_per_heap * n_pols * complexity * sample_bits / 8;
+    // Round up when dividing
     opts.packets_per_heap = (opts.heap_size_bytes + opts.packet_payload_size_bytes - 1) / opts.packet_payload_size_bytes;
     opts.timestamp_step =
         opts.n_chans_total * 2 * opts.n_spectra_per_heap; // The *2 is due to the spectrum being cut in half due


### PR DESCRIPTION
Also change the default to 8192, to match what katsdpcontroller is
using.

Closes NGC-423.