### PR TITLE
Make xbgpu report network stats via Prom counters

### DIFF
--- a/src/katgpucbf/__init__.py
+++ b/src/katgpucbf/__init__.py
@@ -28,6 +28,5 @@ except PackageNotFoundError:
 
 __all__ = ["__version__"]
 
-COMPLEX: Final[int] = 2
-N_POLS: Final[int] = 2
-METRIC_NAMESPACE: Final[str] = "kat"
+COMPLEX: Final = 2
+N_POLS: Final = 2

--- a/src/katgpucbf/fgpu/__init__.py
+++ b/src/katgpucbf/fgpu/__init__.py
@@ -16,5 +16,8 @@
 # limitations under the License.
 ################################################################################
 
-SAMPLE_BITS = 10
-BYTE_BITS = 8
+from typing import Final
+
+SAMPLE_BITS: Final = 10
+BYTE_BITS: Final = 8
+METRIC_NAMESPACE: Final = "fgpu"

--- a/src/katgpucbf/fgpu/recv.py
+++ b/src/katgpucbf/fgpu/recv.py
@@ -30,10 +30,9 @@ from prometheus_client import Counter
 from spead2.numba import intp_to_voidptr
 from spead2.recv.numba import chunk_place_data
 
-from .. import METRIC_NAMESPACE
 from ..monitor import Monitor
 from ..spead import TIMESTAMP_ID
-from . import BYTE_BITS
+from . import BYTE_BITS, METRIC_NAMESPACE
 
 logger = logging.getLogger(__name__)
 #: Number of partial chunks to allow at a time. Using 1 would reject any out-of-order

--- a/src/katgpucbf/fgpu/send.py
+++ b/src/katgpucbf/fgpu/send.py
@@ -26,8 +26,9 @@ from katsdpsigproc.accel import DeviceArray
 from katsdptelstate.endpoint import Endpoint
 from prometheus_client import Counter
 
-from .. import METRIC_NAMESPACE, N_POLS
+from .. import N_POLS
 from ..spead import FENG_ID_ID, FENG_RAW_ID, FLAVOUR, FREQUENCY_ID, TIMESTAMP_ID
+from . import METRIC_NAMESPACE
 
 #: Number of non-payload bytes per packet (header, 8 items pointers, 3 padding pointers)
 PREAMBLE_SIZE = 96

--- a/src/katgpucbf/xbgpu/__init__.py
+++ b/src/katgpucbf/xbgpu/__init__.py
@@ -1,3 +1,5 @@
+# noqa: D104
+
 ################################################################################
 # Copyright (c) 2020-2021, National Research Foundation (SARAO)
 #
@@ -14,8 +16,6 @@
 # limitations under the License.
 ################################################################################
 
-"""
-The existence of this file tells setuptools to treat the directory this file is in as a package.
+from typing import Final
 
-Without this file the submodules will not install.
-"""
+METRIC_NAMESPACE: Final = "xbgpu"

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -28,8 +28,10 @@ object. The XBEngine object then manages everything required to run the XB-Engin
 import argparse
 import asyncio
 import logging
+from typing import Optional
 
 import katsdpsigproc.accel
+import prometheus_async
 from katsdpservices import get_interface_address, setup_logging
 from katsdptelstate.endpoint import endpoint_parser
 
@@ -59,6 +61,11 @@ def parse_args() -> argparse.Namespace:
         type=int,
         default=DEFAULT_KATCP_PORT,
         help="TCP port on which to listen for KATCP C&M connections [%(default)s]",
+    )
+    parser.add_argument(
+        "--prometheus-port",
+        type=int,
+        help="Network port on which to serve Prometheus metrics [none]",
     )
     parser.add_argument(
         "--adc-sample-rate",
@@ -219,12 +226,18 @@ async def async_main(args: argparse.Namespace) -> None:
         thread_affinity=args.dst_affinity,
     )
 
+    prometheus_server: Optional[prometheus_async.aio.web.MetricsHTTPServer] = None
+    if args.prometheus_port is not None:
+        prometheus_server = await prometheus_async.aio.web.start_http_server(port=args.prometheus_port)
+
     logger.info("Starting main processing loop")
 
     main_task = asyncio.create_task(xbengine.run())
     descriptor_task = asyncio.create_task(xbengine.run_descriptors_loop(5))
     await main_task
     await descriptor_task
+    if prometheus_server:
+        await prometheus_server.close()
 
 
 def main() -> None:

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -28,8 +28,8 @@ import pytest
 import spead2.send
 from numpy.typing import ArrayLike
 
-from katgpucbf import COMPLEX, METRIC_NAMESPACE, N_POLS
-from katgpucbf.fgpu import SAMPLE_BITS, send
+from katgpucbf import COMPLEX, N_POLS
+from katgpucbf.fgpu import METRIC_NAMESPACE, SAMPLE_BITS, send
 from katgpucbf.fgpu.delay import wrap_angle
 from katgpucbf.fgpu.engine import Engine
 from katgpucbf.spead import FLAVOUR

--- a/test/fgpu/test_recv.py
+++ b/test/fgpu/test_recv.py
@@ -28,7 +28,7 @@ import spead2.recv.asyncio
 from numpy.typing import ArrayLike
 
 from katgpucbf import N_POLS
-from katgpucbf.fgpu import recv
+from katgpucbf.fgpu import METRIC_NAMESPACE, recv
 from katgpucbf.fgpu.recv import Chunk, Layout
 from katgpucbf.monitor import NullMonitor
 from katgpucbf.spead import DIGITISER_ID_ID, DIGITISER_STATUS_ID, FLAVOUR, RAW_DATA_ID, TIMESTAMP_ID
@@ -277,7 +277,9 @@ class TestChunkSets:
         add_chunk(21, 0)
         ringbuffer.stop()
 
-        with caplog.at_level(logging.WARNING, logger="katgpucbf.fgpu.recv"), PromDiff() as prom_diff:
+        with caplog.at_level(logging.WARNING, logger="katgpucbf.fgpu.recv"), PromDiff(
+            namespace=METRIC_NAMESPACE
+        ) as prom_diff:
             sets = [
                 chunk_set
                 async for chunk_set in recv.chunk_sets(


### PR DESCRIPTION
Some refactoring was required because the tests broke down when both
fgpu and xbgpu tried to register counters called input_heaps. To cope
with that, the METRICS_NAMESPACE is changed from the generic `kat` to be
`fgpu` or `xbgpu` (I also considered moving the input counters up a
level in the hierarchy, but they have different labels so would still
have conflicted).

Also removed the logging of dropped heaps, to match fgpu. If an f-engine
fails this can make the logs extremely noisy very quickly.

See NGC-325.
