### PR TITLE
Increase spead2 max_heaps for xbgpu

### DIFF
--- a/src/katgpucbf/xbgpu/recv.py
+++ b/src/katgpucbf/xbgpu/recv.py
@@ -120,7 +120,7 @@ def make_stream(
     # could be multiple heaps from one F-Engine during the time it takes
     # another to transmit.
     stream_config = spead2.recv.StreamConfig(
-        max_heaps=n_ants * (spead2.send.StreamConfig.DEFAULT_BURST_SIZE // heap_bytes + 1) * 4,
+        max_heaps=n_ants * (spead2.send.StreamConfig.DEFAULT_BURST_SIZE // heap_bytes + 1) * 16,
         memcpy=spead2.MEMCPY_NONTEMPORAL,
     )
     stats_base = stream_config.next_stat_index()


### PR DESCRIPTION
When experimenting with spead2, the previous value seemed possibly a bit
small, although it was hard to tell due to NGC-465. Larger values
probably don't cause too much harm though.
