### PR TITLE
dsim: add a Prometheus gauge tracking time error

### DIFF
--- a/src/katgpucbf/dsim/main.py
+++ b/src/katgpucbf/dsim/main.py
@@ -202,9 +202,11 @@ async def async_main() -> None:
         # time that elapsed from calling time.time until calling time.sleep,
         # but that's small change.
         time.sleep(max(0, start_time - time.time()))
+    else:
+        args.sync_time = time.time()
     logger.info("First timestamp will be %#x", timestamp)
 
-    sender = send.Sender(stream, heap_sets[0], timestamp, args.heap_samples)
+    sender = send.Sender(stream, heap_sets[0], timestamp, args.heap_samples, args.sync_time, args.adc_sample_rate)
     server = DeviceServer(
         sender=sender,
         spare=heap_sets[1],

--- a/test/dsim/conftest.py
+++ b/test/dsim/conftest.py
@@ -16,6 +16,7 @@
 
 """Common fixtures for dsim tests."""
 
+import time
 from typing import Generator, Sequence
 from unittest import mock
 
@@ -107,4 +108,4 @@ def sender(
     send_stream: "spead2.send.asyncio.AsyncStream", heap_sets: Sequence[send.HeapSet]
 ) -> send.Sender:  # noqa: D401
     """A :class:`~katgpucbf.dsim.Sender` using the first of :func:`heaps_sets`."""
-    return send.Sender(send_stream, heap_sets[0], 0, HEAP_SAMPLES)
+    return send.Sender(send_stream, heap_sets[0], 0, HEAP_SAMPLES, time.time(), ADC_SAMPLE_RATE)


### PR DESCRIPTION
It measures the difference between the time specified by the current ADC
timestamps and wall clock time, which will make it obvious when the dsim
is not keeping up with the required rate.

Partially addresses NGC-473 (it will still need a Grafana dashboard to
show it, and possibly raise an alarm).
