### PR TITLE
Add capture-{start, stop} for xbgpu

### DIFF
--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -835,11 +835,11 @@ class XBEngine(DeviceServer):
             await asyncio.sleep(interval_s)
 
     async def request_capture_start(self, ctx) -> None:
-        """Start transmission of a data stream."""
+        """Start transmission of this baseline-correlation-products stream."""
         self.send_stream.tx_enabled = True
 
     async def request_capture_stop(self, ctx) -> None:
-        """Stop transmission of a data stream."""
+        """Stop transmission of this baseline-correlation-products stream."""
         self.send_stream.tx_enabled = False
 
     async def start(self) -> None:

--- a/src/katgpucbf/xbgpu/xsend.py
+++ b/src/katgpucbf/xbgpu/xsend.py
@@ -211,7 +211,7 @@ class XSend:
         stream_factory: Callable[[spead2.send.StreamConfig, Sequence[np.ndarray]], "spead2.send.asyncio.AsyncStream"],
         n_send_heaps_in_flight: int = 5,
         packet_payload: int = DEFAULT_PACKET_PAYLOAD_BYTES,
-        tx_enabled: bool = False,
+        tx_enabled: bool = True,
     ) -> None:
         if dump_interval_s < 0:
             raise ValueError("Dump interval must be 0 or greater.")


### PR DESCRIPTION
Additions seemed simple enough and were tested by
running an fsim and xbgpu.

Contributes to: NGC-283.