### PR TITLE
Bump ipython to a newer version in requirements-dev

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -62,7 +62,7 @@ imagesize==1.2.0
     # via sphinx
 iniconfig==1.1.1
     # via pytest
-ipython==7.25.0
+ipython==7.31.1
     # via -r requirements-dev.in
 ipython-genutils==0.2.0
     # via traitlets


### PR DESCRIPTION
This is basically to make dependabot shut up about a security
vulnerability in ipython.

I didn't go to the latest (8.0.1) because that drags in a whole bunch of
extra dependencies and I wanted a minimal change.
