### PR TITLE
Adapt fgpu scratch scripts to run on cbfgpu01

### DIFF
--- a/scratch/fgpu/config/cbfgpu01.sh
+++ b/scratch/fgpu/config/cbfgpu01.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+iface1=enp193s0f0np0
+iface2=enp193s0f1np1
+cuda1=0
+cuda2=0

--- a/scratch/fgpu/config/gareth.sh
+++ b/scratch/fgpu/config/gareth.sh
@@ -7,4 +7,4 @@
 iface1=enp193s0f0
 iface2=enp193s0f1
 cuda1=0
-cuda2=0
+cuda2=1

--- a/scratch/fgpu/run-dsim.sh
+++ b/scratch/fgpu/run-dsim.sh
@@ -26,8 +26,11 @@ case "$1" in
         ;;
 esac
 
-cpu="$1"
+nproc="$(nproc)"
+cpu="$(($nproc * $1 / 4))"
 addresses="239.102.$1.64+7:7148 239.102.$1.72+7:7148"
+
+set -x
 exec spead2_net_raw numactl -C $cpu dsim \
     --ibv \
     --interface $iface \

--- a/scratch/fgpu/run-fgpu.sh
+++ b/scratch/fgpu/run-fgpu.sh
@@ -5,11 +5,15 @@ set -e -u
 # Load variables for machine-specific config
 . config/$(hostname -s).sh
 
-src_affinity="$((6*$1)),$((6*$1+1))"
+nproc=$(nproc)
+step=$(($nproc / 4))
+hstep=$(($step / 2))
+
+src_affinity="$(($step*$1)),$(($step*$1+1))"
 src_comp=$src_affinity
-dst_affinity="$((6*$1+3))"
+dst_affinity="$(($step*$1+$hstep))"
 dst_comp=$dst_affinity
-other_affinity="$((6*$1+4))"
+other_affinity="$(($step*$1+$hstep+1))"
 srcs="239.102.$1.64+7:7148 239.102.$1.72+7:7148"
 dst="239.102.$((200+$1)).0+15:7148"
 katcp_port="$(($1+7140))"


### PR DESCRIPTION
Apart from specifying the interface names, the scripts had to be adapted
as they hard-coded the assumption of a 24-core CPU. It now uses `nproc`
to get the number of cores.
