### PR TITLE
Add minor documentation updates missed in PR #164

### DIFF
--- a/src/katgpucbf/fgpu/compute.py
+++ b/src/katgpucbf/fgpu/compute.py
@@ -92,9 +92,10 @@ class Compute(accel.OperationSequence):
     samples
         Number of samples that will be processed each time the operation is run.
     spectra
-        Number of spectra that we will get from each chunk of samples.
+        Number of spectra that will be produced from a chunk of incoming
+        digitiser data.
     spectra_per_heap
-        Number of spectra to send out per heap.
+        Number of spectra to send in each output heap.
     channels
         Number of channels into which the input data will be decomposed.
     """

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -133,7 +133,7 @@ class Engine(aiokatcp.DeviceServer):
     channels
         Number of output channels to produce.
     taps
-        Number of taps in each branch of the PFB-FIR
+        Number of taps in each branch of the PFB-FIR.
     max_delay_diff
         Maximum supported difference between delays across polarisations (in samples).
     gain

--- a/src/katgpucbf/fgpu/process.py
+++ b/src/katgpucbf/fgpu/process.py
@@ -378,6 +378,19 @@ class Processor:
 
     Parameters
     ----------
+    context
+        The GPU context that we'll operate in.
+    taps
+        Number of taps in each branch of the PFB-FIR.
+    samples
+        Number of samples that will be processed each time the operation is run.
+    spectra
+        Number of spectra that will be produced from a chunk of incoming
+        digitiser data.
+    spectra_per_heap
+        Number of spectra to send in each output heap.
+    channels
+        Number of output channels to produce.
     delay_models
         The delay models which should be applied to the data.
     use_gdrcopy


### PR DESCRIPTION
There were some... minor discrepancies in how
Parameters are described in `engine.py` vs
`compute.py`.

Still, let me know what you think (of these updates).