### PR TITLE
Make chunk_sets more robust to desynchronisation

### DIFF
--- a/test/fgpu/test_recv.py
+++ b/test/fgpu/test_recv.py
@@ -286,9 +286,9 @@ class TestChunkSets:
         add_chunk(10, 1)
         add_chunk(11, 1)
         add_chunk(12, 1, 1)
+        add_chunk(20, 1)
         add_chunk(12, 0, 2)
         add_chunk(20, 0)
-        add_chunk(20, 1)
         add_chunk(21, 0)
         ringbuffer.stop()
 


### PR DESCRIPTION
When the chunk size is reduced (e.g. to accomodate the Vulkan allocator
in NGC-295), there is a risk of one receiver thread getting more than a
chunk ahead of the other. The previous implementation of chunk_sets
didn't handle that well, throwing away chunks that could later have been
matched.

The new approach keeps chunks around as long as they could potentially
match (specifically, until we see a higher-ID chunk on the other pol).
If one thread runs ahead, it will naturally throttle because it will run
out of chunks on its free_ring, giving the other thread a chance to
catch up.
