### PR TITLE
Remove unnecssary parameter from xbgpu.recv.Layout's docstring

### DIFF
--- a/src/katgpucbf/xbgpu/recv.py
+++ b/src/katgpucbf/xbgpu/recv.py
@@ -76,8 +76,6 @@ class Layout(BaseLayout):
     ----------
     n_ants
         The number of antennas that data will be received from
-    n_channels
-        The total number of frequency channels out of the F-Engine.
     n_channels_per_stream
         The number of frequency channels contained in the stream.
     n_spectra_per_heap


### PR DESCRIPTION
This looks to have been done quite a few PRs ago, and was a result of shifting docstrings around between entities without checking all the attributes.

I'm just going to go ahead and merge this one, won't bother with a review.