### PR TITLE
Reduce default fgpu chunk size

### DIFF
--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -195,7 +195,7 @@ def parse_args(arglist: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--chunk-samples",
         type=int,
-        default=2 ** 26,
+        default=2 ** 24,
         metavar="SAMPLES",
         help="Number of digitiser samples to process at a time (per pol). If not a multiple of 2*channels*acc-len,"
         "it will be rounded up to the next multiple. [%(default)s]",


### PR DESCRIPTION
See NGC-505. This is just the quick first pass, which reduces it from
64Mi to 16Mi, which is a number that works up to 32K channels without
being internally rounded up.