### PR TITLE
Install ibverbs-providers in the runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,6 +130,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
     libboost-system1.71.0 \
     libibverbs1 \
     librdmacm1 \
+    ibverbs-providers \
     libpcap0.8 \
     libcap2 \
     libcap2-bin \


### PR DESCRIPTION
The image was broken by #189, which added `--no-install-recommends` to
the apt-get command to avoid pulling in a bunch of useless stuff along
with libvulkan1, but that also prevented ibverbs-providers from being
installed, preventing ibverbs from being used by the Docker image.
