### PR TITLE
Change block size of correlation kernel to 32

### DIFF
--- a/test/xbgpu/test_correlation.py
+++ b/test/xbgpu/test_correlation.py
@@ -84,7 +84,7 @@ def test_correlator(
     """Parameterised unit test of the Tensor-Core correlation kernel."""
     # TODO: A lot of this is duplicated in other functions. It would be nice to
     # move it into a test fixture.
-    n_chans_per_stream = num_channels // num_ants // 4
+    n_chans_per_stream = num_channels // num_ants
 
     template = CorrelationTemplate(
         context, n_ants=num_ants, n_channels=n_chans_per_stream, n_spectra_per_heap=num_spectra_per_heap


### PR DESCRIPTION
Benchmarking shows that this mostly performs better than the old value
of 64.

Additionally implemented the block count calculation for 32 (it's the
same as for 48 - it's only 64 that is weird because the blocks are
actually non-square).

Closes NGC-339.