### PR TITLE
Fix calculation of max_active_chunks

### DIFF
--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -326,7 +326,7 @@ class XBEngine(DeviceServer):
             layout=layout,
             data_ringbuffer=self.ringbuffer,
             src_affinity=src_affinity,
-            rx_reorder_tol=rx_reorder_tol,
+            max_active_chunks=self.max_active_chunks,
         )
 
         self.context = context

--- a/test/xbgpu/test_recv.py
+++ b/test/xbgpu/test_recv.py
@@ -76,10 +76,7 @@ def stream(layout, ringbuffer, queue) -> Generator[spead2.recv.ChunkRingStream, 
     It is connected to the :func:`queue` fixture for input and
     :func:`ringbuffer` for output.
     """
-    # We want reorder tolerance enough to be able to deal with 5 chunks at a time.
-
-    reorder_tol = 5 * layout.timestamp_step * layout.heaps_per_fengine_per_chunk
-    stream = recv.make_stream(layout, ringbuffer, -1, reorder_tol)
+    stream = recv.make_stream(layout, ringbuffer, -1, 5)
     for _ in range(40):
         data = np.empty(layout.chunk_bytes, np.int8)
         # Use np.ones to make sure the bits get zeroed out


### PR DESCRIPTION
xbgpu.engine calculated the max_active_chunks (correctly), but
xbgpu.recv.make_stream recalculated it using a bogus formula for the
timestamp step (both NGC-294 and NGC-337). In some situations
(particularly with fewer than 4 antennas) that led to fewer available
chunks than max_active_chunks, leading to a deadlock.

Closes NGC-532.
