### PR TITLE
Fix several issues with x-engine descriptors

### DIFF
--- a/src/katgpucbf/xbgpu/xsend.py
+++ b/src/katgpucbf/xbgpu/xsend.py
@@ -279,7 +279,7 @@ class XSend:
 
         stream_config = spead2.send.StreamConfig(
             max_packet_size=packet_payload + XSend.header_size,
-            max_heaps=self._n_send_heaps_in_flight,
+            max_heaps=self._n_send_heaps_in_flight + 1,  # + 1 to allow for descriptors
             rate_method=spead2.send.RateMethod.AUTO,
             rate=send_rate_bytes_per_second,
         )
@@ -376,7 +376,7 @@ class XSend:
         await asyncio.wait([future])
         return buffer_wrapper
 
-    def send_descriptor_heap(self) -> None:
+    async def send_descriptor_heap(self) -> None:
         """
         Send the SPEAD descriptor over the spead2 transport.
 
@@ -387,12 +387,8 @@ class XSend:
 
         This function has no associated unit test - it will likely need to be
         revisited later as its need and function become clear.
-
-        .. todo::
-            This async_send_heap should really be await'ed.
         """
-        if self.tx_enabled:
-            self.source_stream.async_send_heap(self.descriptor_heap)
+        await self.source_stream.async_send_heap(self.descriptor_heap)
 
     async def send_stop_heap(self) -> None:
         """Send a Stop Heap over the spead2 transport."""

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -476,7 +476,7 @@ class TestEngine:
 
         # 7. Add transports to xbengine.
         xbengine.add_inproc_sender_transport(queue)
-        xbengine.send_stream.send_descriptor_heap()
+        await xbengine.send_stream.send_descriptor_heap()
 
         buffer = source_stream.getvalue()
         xbengine.add_buffer_receiver_transport(buffer)

--- a/test/xbgpu/test_spead2_send.py
+++ b/test/xbgpu/test_spead2_send.py
@@ -81,7 +81,7 @@ class TestSend:
 
         # 4.1 Send the descriptor as the recv_stream object needs it to
         # interpret the received heaps correctly.
-        send_stream.send_descriptor_heap()
+        await send_stream.send_descriptor_heap()
 
         # 4.2 Run until a set number of heaps have been transferred.
         while num_sent < TOTAL_HEAPS:


### PR DESCRIPTION
- Allocate an extra element in `max_heaps` to account for them. I think
  this should fix NGC-530 (although it is a rare failure so hard to
  prove).

- Make send_descriptor_heap asynchronous, and await it. Apart from
  allowing errors to be propagated, this will prevent putting two
  descriptors into the queue if there is a backlog (which could again
  lead to failures like NGC-530).

- Send descriptors regardless of whether `?capture-start` has been
  called. I'm not 100% sure about this, but I think that's consistent
  with MeerKAT, and gives the downstream receiver a better chance of
  receiving descriptors before the data firehouse starts.