### PR TITLE
Better handling of negative delays

### DIFF
--- a/src/katgpucbf/fgpu/delay.py
+++ b/src/katgpucbf/fgpu/delay.py
@@ -152,6 +152,8 @@ class LinearDelayModel(AbstractDelayModel):
         # correction.
         rel_orig = (rel_time - self.delay) / (self.delay_rate + 1)
         rel_orig_rnd = np.rint(rel_orig).astype(np.int64)
+        # Prevent coarse delay from becoming negative
+        np.minimum(rel_orig_rnd, rel_time, out=rel_orig_rnd)
         residual = rel_orig_rnd - rel_orig
 
         # Calculate the phase

--- a/test/fgpu/test_katcp_interface.py
+++ b/test/fgpu/test_katcp_interface.py
@@ -163,6 +163,7 @@ class TestKatcpRequests:
             "3.76,0.12:7.322-1.91",  # Missing comma, phase half
             "3.76,0.12:apple,1.91",  # Non-float value for phase
             "3.76,pear:7.322,1.91",  # Non-float value for delay rate
+            "-1.0,0.0:0.0,0.0",  # Negative delay
         ],
     )
     async def test_delay_model_update_malformed(self, engine_client, malformed_delay_string):


### PR DESCRIPTION
- If the initial delay is negative, fail the katcp request.
- Warn if the delay will become negative soon (due to negative
  delay-rate).
- Clamp the coarse delay to non-negative. If the total delay becomes
  negative, it'll be handled purely as a fine delay. That probably won't
  give great results but it will prevent the pipeline from doing
  anything that will break it so badly it can't be recovered, and it
  will degrade gracefully if the delay is only fractionally negative. It
  would be nice to give a warning in this case, but a log message would
  spam the log system at a very high rate. It is probably better to roll
  it up into a health sensor.

Closes NGC-415.
