### PR TITLE
Normalise the coefficients of the PFB

### DIFF
--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -216,7 +216,7 @@ def parse_args(arglist: Optional[Sequence[str]] = None) -> argparse.Namespace:
         default=1048576,
         help="Maximum supported difference between delays across polarisations (in samples) [%(default)s]",
     )
-    parser.add_argument("--gain", type=float, default=0.001, help="Initial eq gains [%(default)s]")
+    parser.add_argument("--gain", type=float, default=1.0, help="Initial eq gains [%(default)s]")
     parser.add_argument(
         "--sync-epoch",
         type=int,  # AFAIK, the digitisers sync on PPS signals, so it makes sense for this to be an int.

--- a/src/katgpucbf/fgpu/process.py
+++ b/src/katgpucbf/fgpu/process.py
@@ -67,6 +67,9 @@ def _invert_models(
 def generate_weights(channels: int, taps: int) -> np.ndarray:
     """Generate Hann-window weights for the F-engine's PFB-FIR.
 
+    The resulting weights are normalised such that the sum of
+    squares is 1.
+
     Parameters
     ----------
     channels
@@ -86,6 +89,7 @@ def generate_weights(channels: int, taps: int) -> np.ndarray:
     hann = np.square(np.sin(np.pi * idx / (window_size - 1)))
     sinc = np.sinc((idx + 0.5) / step - taps / 2)
     weights = hann * sinc
+    weights /= np.sqrt(np.sum(np.square(weights)))
     return weights.astype(np.float32)
 
 


### PR DESCRIPTION
This should make incoherent gain (ratio of input to output standard
deviation for independent Gaussian noise) consistent across
channel and tap counts).

Closes NGC-535.
