### PR TITLE
Update pytest-asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ line_length = 120
 testpaths = "test"
 addopts = "--cov-context=test --cov-report html --import-mode=prepend"
 markers = ["mask_timestamp", "use_vkgdr", "cmdline_args"]
+asyncio_mode = "auto"
 filterwarnings = [
 	'ignore:`np\..*` is a deprecated alias::pycuda\.compyte\.dtypes',
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -147,7 +147,7 @@ pytest==6.2.4
     #   pytest-forked
     #   pytest-mock
     #   pytest-xdist
-pytest-asyncio==0.15.1
+pytest-asyncio==0.18.3
     # via -r requirements-dev.in
 pytest-cov==2.12.1
     # via -r requirements-dev.in

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ vkgdr = vkgdr
 test =
     async-timeout
     pytest
-    pytest-asyncio
+    pytest-asyncio>=0.18
     pytest-mock
 
 [options.packages.find]

--- a/test/dsim/test_send.py
+++ b/test/dsim/test_send.py
@@ -21,7 +21,6 @@ import itertools
 from typing import Optional, Sequence
 
 import numpy as np
-import pytest
 import spead2.recv.asyncio
 import spead2.send.asyncio
 
@@ -30,8 +29,6 @@ from katgpucbf.dsim import send
 
 from .. import PromDiff
 from .conftest import HEAP_SAMPLES, N_ENDPOINTS_PER_POL, N_POLS, SAMPLE_BITS, SIGNAL_HEAPS
-
-pytestmark = [pytest.mark.asyncio]
 
 
 async def test_sender(

--- a/test/dsim/test_server.py
+++ b/test/dsim/test_server.py
@@ -30,8 +30,6 @@ from katgpucbf.dsim.signal import parse_signals
 from .. import get_sensor
 from .conftest import ADC_SAMPLE_RATE, HEAP_SAMPLES, SAMPLE_BITS, SIGNAL_HEAPS
 
-pytestmark = [pytest.mark.asyncio]
-
 
 @pytest.fixture
 async def katcp_server(

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -33,7 +33,7 @@ from katgpucbf.fgpu.engine import Engine
 
 from .test_recv import gen_heaps
 
-pytestmark = [pytest.mark.cuda_only, pytest.mark.asyncio]
+pytestmark = [pytest.mark.cuda_only]
 # Command-line arguments
 SYNC_EPOCH = 1632561921
 CHANNELS = 1024

--- a/test/fgpu/test_katcp_interface.py
+++ b/test/fgpu/test_katcp_interface.py
@@ -30,7 +30,7 @@ from katgpucbf.fgpu.engine import Engine
 
 from .. import get_sensor
 
-pytestmark = [pytest.mark.asyncio, pytest.mark.cuda_only]
+pytestmark = [pytest.mark.cuda_only]
 
 CHANNELS = 4096
 SYNC_EPOCH = 1632561921

--- a/test/fgpu/test_recv.py
+++ b/test/fgpu/test_recv.py
@@ -34,8 +34,6 @@ from katgpucbf.spead import DIGITISER_ID_ID, DIGITISER_STATUS_ID, FLAVOUR, RAW_D
 
 from .. import PromDiff
 
-pytestmark = [pytest.mark.asyncio]
-
 
 @pytest.fixture
 def layout(request) -> Layout:

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -40,7 +40,7 @@ from katgpucbf.xbgpu.engine import XBEngine
 
 from . import test_parameters
 
-pytestmark = [pytest.mark.device_filter.with_args(device_filter), pytest.mark.asyncio]
+pytestmark = [pytest.mark.device_filter.with_args(device_filter)]
 
 get_baseline_index = njit(Correlation.get_baseline_index)
 

--- a/test/xbgpu/test_recv.py
+++ b/test/xbgpu/test_recv.py
@@ -30,8 +30,6 @@ from katgpucbf.spead import FENG_ID_ID, FENG_RAW_ID, FLAVOUR, FREQUENCY_ID, IMME
 from katgpucbf.xbgpu import METRIC_NAMESPACE, recv
 from katgpucbf.xbgpu.recv import Chunk, Layout, recv_chunks
 
-pytestmark = [pytest.mark.asyncio]
-
 
 @pytest.fixture
 def layout() -> Layout:

--- a/test/xbgpu/test_spead2_send.py
+++ b/test/xbgpu/test_spead2_send.py
@@ -63,8 +63,6 @@ from katgpucbf.xbgpu.xsend import XSend
 
 from . import test_parameters
 
-pytestmark = [pytest.mark.asyncio]
-
 TOTAL_HEAPS: Final[int] = 20
 DUMP_INTERVAL_S: Final[int] = 0
 SEND_RATE_FACTOR: Final[float] = 1.1


### PR DESCRIPTION
I was getting warnings after upgrading pytest-asyncio on my machine. It
wants the `asyncio_mode` to be set in the config. The good news is that
with the `auto` mode, it's no longer necessary to use pytest marks to
indicate that pytest-asyncio should handle async tests and fixtures.
