### PR TITLE
Update pre-commit tools to the latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
       - id: check-merge-conflict
       - id: check-shebang-scripts-are-executable
@@ -14,17 +14,14 @@ repos:
       - id: no-commit-to-branch # without arguments, master/main will be protected.
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 21.6b0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
-    rev: 5.9.1
+    rev: 5.10.1
     hooks:
       - id: isort
-        name: isort (python)
-      - id: isort
-        name: isort (pyi)
-        types: [pyi]
+        name: isort
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:
@@ -34,12 +31,12 @@ repos:
           'pep8-naming==0.12.0'
         ]
   - repo: https://github.com/pycqa/pydocstyle
-    rev: 6.0.0
+    rev: 6.1.1
     hooks:
       - id: pydocstyle
         exclude: 'setup.py|scratch/'  # Because complaining about docstrings here is annoying.
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.910'
+    rev: 'v0.942'
     hooks:
       - id: mypy
         # Passing filenames to mypy can do odd things. See
@@ -58,14 +55,14 @@ repos:
             'katsdptelstate==0.11',
             'numpy==1.21.0',
             'pyparsing==3.0.6',
-            'spead2==3.7.0',
+            'spead2==3.9.0',
             'types-decorator==0.1.5',
             'types-redis==3.5.4',
             'types-setuptools==57.0.0',
             'types-six==0.1.7',
         ]
   - repo: https://github.com/jazzband/pip-tools
-    rev: 6.2.0
+    rev: 6.5.1
     hooks:
       - id: pip-compile
         name: pip-compile requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -138,7 +138,7 @@ typing-extensions==3.10.0.0
     # via
     #   async-timeout
     #   katsdpsigproc
-git+ssh://git@github.com/ska-sa/vkgdr
+vkgdr @ git+ssh://git@github.com/ska-sa/vkgdr
     # via -r requirements.in
 wrapt==1.13.3
     # via prometheus-async

--- a/scratch/fgpu/fftbench.py
+++ b/scratch/fgpu/fftbench.py
@@ -60,7 +60,7 @@ def benchmark_real(args):
     fmt = "{0}: Time: {1} Speed: {2} GFlop/s BW: {3} GiB/s Scratch: {4} MiB"
 
     time = time_gpu(lambda: fft.fft(x_gpu, X_gpu, plan), args.passes)
-    print(fmt.format("R2C", time, flops / time / 1e9, bw / time / 1e9, cufftGetSize(plan.handle) / 1024 ** 2))
+    print(fmt.format("R2C", time, flops / time / 1e9, bw / time / 1e9, cufftGetSize(plan.handle) / 1024**2))
 
 
 parser = argparse.ArgumentParser()

--- a/src/katgpucbf/dsim/signal.py
+++ b/src/katgpucbf/dsim/signal.py
@@ -17,7 +17,7 @@ from .. import BYTE_BITS
 
 logger = logging.getLogger(__name__)
 #: Dask chunk size for sampling signals (must be a multiple of 8)
-CHUNK_SIZE = 2 ** 20
+CHUNK_SIZE = 2**20
 
 
 class Signal(ABC):

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -197,14 +197,14 @@ def parse_args(arglist: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--src-chunk-samples",
         type=int,
-        default=2 ** 24,
+        default=2**24,
         metavar="SAMPLES",
         help="Number of digitiser samples to process at a time (per pol). [%(default)s]",
     )
     parser.add_argument(
         "--dst-chunk-jones",
         type=int,
-        default=2 ** 23,
+        default=2**23,
         metavar="VECTORS",
         help="Number of Jones vectors in output chunks. If not a multiple of "
         "2*channels*spectra-per-heap, it will be rounded up to the next multiple. [%(default)s]",

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -146,7 +146,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--rx-reorder-tol",
         type=int,
-        default=2 ** 29,
+        default=2**29,
         help="Maximum time (in ADC ticks) that packets can be delayed relative to others "
         "and still be accepted. [%(default)s]",
     )

--- a/test/dsim/test_server.py
+++ b/test/dsim/test_server.py
@@ -16,6 +16,7 @@
 
 """Unit tests for katcp server."""
 
+import asyncio.base_events
 from typing import AsyncGenerator, Sequence
 
 import aiokatcp
@@ -57,7 +58,7 @@ async def katcp_server(
 @pytest.fixture
 async def katcp_client(katcp_server: DeviceServer) -> AsyncGenerator[aiokatcp.Client, None]:  # noqa: D401
     """A katcp client connection to :func:`katcp_server`."""
-    assert katcp_server.server is not None
+    assert isinstance(katcp_server.server, asyncio.base_events.Server)
     assert katcp_server.server.sockets is not None
     host, port = katcp_server.server.sockets[0].getsockname()[:2]
     async with async_timeout.timeout(5):  # To fail the test quickly if unable to connect

--- a/test/dsim/test_signal.py
+++ b/test/dsim/test_signal.py
@@ -69,7 +69,7 @@ class TestWGN:
         # scipy.stats.chi2.isf(1e-6, df=10000, scale=9)
         # (where 9 is the expected population variance). The values are
         # hardcoded to avoid a dependence on scipy just for this test.
-        assert 84079 <= np.sum(data ** 2) <= 96180
+        assert 84079 <= np.sum(data**2) <= 96180
 
     def test_entropy(self) -> None:
         """Test that different instances with the same entropy give the same results."""
@@ -184,13 +184,13 @@ class TestPackbits:
     def test_bits(self, bits: int) -> None:
         """Test with a variety of bit counts."""
         rng = np.random.default_rng(1)
-        data = da.from_array(rng.integers(0, 2 ** bits, dtype=np.int32, size=200), chunks=64)
+        data = da.from_array(rng.integers(0, 2**bits, dtype=np.int32, size=200), chunks=64)
         packed = signal.packbits(data, bits).compute()
         # Unpack and check that the original data is returned
         big_int = int.from_bytes(packed, byteorder="big")
         unpacked = []
         for _ in range(len(data)):
-            unpacked.append(big_int & (2 ** bits - 1))
+            unpacked.append(big_int & (2**bits - 1))
             big_int >>= bits
         unpacked.reverse()
         np.testing.assert_equal(data.compute(), unpacked)

--- a/test/fgpu/conftest.py
+++ b/test/fgpu/conftest.py
@@ -16,6 +16,7 @@
 
 """Fixtures for use in fgpu unit tests."""
 
+import asyncio
 from typing import AsyncGenerator, List, Optional, Tuple, Union
 
 import aiokatcp
@@ -133,7 +134,7 @@ async def engine_server(
 @pytest.fixture
 async def engine_client(engine_server: Engine) -> AsyncGenerator[aiokatcp.Client, None]:
     """Create a KATCP client for communicating with the dummy server."""
-    assert engine_server.server is not None
+    assert isinstance(engine_server.server, asyncio.base_events.Server)
     assert engine_server.server.sockets is not None
     host, port = engine_server.server.sockets[0].getsockname()[:2]
     async with async_timeout.timeout(5):  # To fail the test quickly if unable to connect

--- a/test/fgpu/test_recv.py
+++ b/test/fgpu/test_recv.py
@@ -54,9 +54,9 @@ class TestLayout:
         assert layout.heap_bytes == 5120
         assert layout.chunk_bytes == 81920
         assert layout.chunk_heaps == 16
-        assert layout.timestamp_mask == 2 ** 64 - 1
+        assert layout.timestamp_mask == 2**64 - 1
         masked = dataclasses.replace(layout, mask_timestamp=True)
-        assert masked.timestamp_mask == 2 ** 64 - 4096
+        assert masked.timestamp_mask == 2**64 - 4096
 
 
 @pytest.fixture

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -384,7 +384,7 @@ class TestEngine:
             n_engines *= 2
         n_channels_per_stream = num_channels // n_engines
         n_spectra_per_heap = num_spectra_per_heap
-        rx_reorder_tol = 2 ** 26  # Increase if needed; this is small to keep memory usage manageable
+        rx_reorder_tol = 2**26  # Increase if needed; this is small to keep memory usage manageable
         heap_accumulation_threshold = 4
         n_accumulations = 3
 


### PR DESCRIPTION
The previous version of black wasn't working with the latest version of
click, and something also broke pip-tools.

Some other minor fixes:
- Removed the .pyi checking since there aren't any any more.
- Updated the spead2 version used for type annotation checking to
  match what's in requirements.txt.

A few Python files changed because black decided to reformat them or the
newer mypy didn't like them.
