### PR TITLE
Update katsdpservices to latest version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 aiohttp
 aiokatcp
 dask
-katsdpservices[aiomonitor]
+katsdpservices[aiomonitor]>=1.2
 katsdpsigproc[CUDA]>=1.4.2
 katsdptelstate
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ hiredis==2.0.0
     # via katsdptelstate
 idna==3.3
     # via yarl
-katsdpservices[aiomonitor]==1.1
+katsdpservices[aiomonitor]==1.2
     # via -r requirements.in
 katsdpsigproc[cuda]==1.4.2
     # via -r requirements.in


### PR DESCRIPTION
Fixes NGC-542 by no longer doing a DNS query for every log message.
