### PR TITLE
Bump aiokatcp to the latest version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
         types: []
         types_or: [python, pyi]
         additional_dependencies: [
-            'aiokatcp==1.0.0',
+            'aiokatcp==1.1.0',
             'dask==2021.11.2',
             'katsdpsigproc==1.4.2',
             'katsdptelstate==0.11',

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 aiohttp
-aiokatcp
+aiokatcp>=1.1.0
 dask
 katsdpservices[aiomonitor]>=1.2
 katsdpsigproc[CUDA]>=1.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ aioconsole==0.4.1
     # via aiomonitor
 aiohttp==3.8.0
     # via -r requirements.in
-aiokatcp==1.0.0
+aiokatcp==1.1.0
     # via -r requirements.in
 aiomonitor==0.4.5
     # via katsdpservices
@@ -136,6 +136,7 @@ toolz==0.11.2
     #   partd
 typing-extensions==3.10.0.0
     # via
+    #   aiokatcp
     #   async-timeout
     #   katsdpsigproc
 vkgdr @ git+ssh://git@github.com/ska-sa/vkgdr

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ package_dir =
     = src
 packages = find:
 install_requires =
-    aiokatcp
+    aiokatcp>=1.1.0
     dask
     katsdpservices[aiomonitor]
     katsdpsigproc[CUDA]>=1.4.1

--- a/test/dsim/test_server.py
+++ b/test/dsim/test_server.py
@@ -16,7 +16,6 @@
 
 """Unit tests for katcp server."""
 
-import asyncio.base_events
 from typing import AsyncGenerator, Sequence
 
 import aiokatcp
@@ -62,9 +61,7 @@ async def katcp_server(
 @pytest.fixture
 async def katcp_client(katcp_server: DeviceServer) -> AsyncGenerator[aiokatcp.Client, None]:  # noqa: D401
     """A katcp client connection to :func:`katcp_server`."""
-    assert isinstance(katcp_server.server, asyncio.base_events.Server)
-    assert katcp_server.server.sockets is not None
-    host, port = katcp_server.server.sockets[0].getsockname()[:2]
+    host, port = katcp_server.sockets[0].getsockname()[:2]
     async with async_timeout.timeout(5):  # To fail the test quickly if unable to connect
         client = await aiokatcp.Client.connect(host, port)
     yield client

--- a/test/fgpu/conftest.py
+++ b/test/fgpu/conftest.py
@@ -16,7 +16,6 @@
 
 """Fixtures for use in fgpu unit tests."""
 
-import asyncio
 from typing import AsyncGenerator, List, Optional, Tuple, Union
 
 import aiokatcp
@@ -134,9 +133,7 @@ async def engine_server(
 @pytest.fixture
 async def engine_client(engine_server: Engine) -> AsyncGenerator[aiokatcp.Client, None]:
     """Create a KATCP client for communicating with the dummy server."""
-    assert isinstance(engine_server.server, asyncio.base_events.Server)
-    assert engine_server.server.sockets is not None
-    host, port = engine_server.server.sockets[0].getsockname()[:2]
+    host, port = engine_server.sockets[0].getsockname()[:2]
     async with async_timeout.timeout(5):  # To fail the test quickly if unable to connect
         client = await aiokatcp.Client.connect(host, port)
     yield client


### PR DESCRIPTION
This simplified accessing the server's socket in test setup.

Closes NGC-556.
