### PR TITLE
Update to latest numba

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -74,7 +74,7 @@ jinja2==3.0.1
     #   sphinx
 latexcodec==2.0.1
     # via pybtex
-llvmlite==0.36.0
+llvmlite==0.38.0
     # via
     #   -c requirements.txt
     #   numba
@@ -86,7 +86,7 @@ matplotlib-inline==0.1.2
     # via ipython
 nodeenv==1.6.0
     # via pre-commit
-numba==0.53.1
+numba==0.55.1
     # via
     #   -c requirements.txt
     #   -r requirements-dev.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ katsdpsigproc[cuda]==1.4.2
     # via -r requirements.in
 katsdptelstate==0.11
     # via -r requirements.in
-llvmlite==0.36.0
+llvmlite==0.38.0
     # via numba
 locket==0.2.1
     # via partd
@@ -73,7 +73,7 @@ netifaces==0.11.0
     # via
     #   katsdpservices
     #   katsdptelstate
-numba==0.53.1
+numba==0.55.1
     # via katsdpsigproc
 numpy==1.21.0
     # via

--- a/src/katgpucbf/recv.py
+++ b/src/katgpucbf/recv.py
@@ -23,7 +23,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple, Union
 
-import numba
+import numba.core.ccallback
 import numpy as np
 import scipy
 import spead2.recv


### PR DESCRIPTION
It needed a change to an import because newer versions weren't
implicitly importing a particular submodule.

Closes NGC-472.
