### PR TITLE
Bump coverage and pytest-cov versions in requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,7 +32,7 @@ charset-normalizer==2.0.7
     #   requests
 click==8.0.1
     # via pip-tools
-coverage[toml]==5.5
+coverage[toml]==6.3.2
     # via
     #   -r requirements-dev.in
     #   pytest-cov
@@ -149,7 +149,7 @@ pytest==6.2.4
     #   pytest-xdist
 pytest-asyncio==0.18.3
     # via -r requirements-dev.in
-pytest-cov==2.12.1
+pytest-cov==3.0.0
     # via -r requirements-dev.in
 pytest-forked==1.3.0
     # via pytest-xdist
@@ -202,12 +202,12 @@ sphinxcontrib-tikz==0.4.15
     # via -r requirements-dev.in
 toml==0.10.2
     # via
-    #   coverage
     #   pre-commit
     #   pytest
-    #   pytest-cov
 tomli==1.0.4
-    # via pep517
+    # via
+    #   coverage
+    #   pep517
 traitlets==5.0.5
     # via
     #   ipython


### PR DESCRIPTION
For some reason, the old versions were causing tests to fail when
running pytest with the --cov flag, but bumping the versions up to the
latest caused things to Just Work (TM). So I didn't look too closely
into why that might be, I just took what I was given and carried on.