### PR TITLE
Fix bug introduced with source transport upgrade

### DIFF
--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -23,9 +23,8 @@ actual running of the processing.
 
 import argparse
 import asyncio
-import ipaddress
 import logging
-from typing import Callable, List, Optional, Sequence, Tuple, TypeVar, Union
+from typing import Callable, List, Optional, Sequence, Tuple, TypeVar
 
 import katsdpservices
 import katsdpsigproc.accel as accel
@@ -37,22 +36,11 @@ from katsdptelstate.endpoint import endpoint_list_parser
 
 from .. import DEFAULT_KATCP_HOST, DEFAULT_KATCP_PORT, DEFAULT_PACKET_PAYLOAD_BYTES, DEFAULT_TTL, N_POLS, __version__
 from ..monitor import FileMonitor, Monitor, NullMonitor
-from ..utils import add_signal_handlers
+from ..utils import add_signal_handlers, parse_source
 from .engine import Engine
 
 _T = TypeVar("_T")
 logger = logging.getLogger(__name__)
-
-
-def parse_source(value: str) -> Union[List[Tuple[str, int]], str]:
-    """Parse a string into a list of IP endpoints."""
-    try:
-        endpoints = endpoint_list_parser(7148)(value)
-        for endpoint in endpoints:
-            ipaddress.IPv4Address(endpoint.host)  # Raises if invalid syntax
-        return [(ep.host, ep.port) for ep in endpoints]
-    except ValueError:
-        return value
 
 
 def comma_split(base_type: Callable[[str], _T], count: Optional[int] = None) -> Callable[[str], List[_T]]:

--- a/src/katgpucbf/utils.py
+++ b/src/katgpucbf/utils.py
@@ -16,11 +16,14 @@
 
 """A collection of utility functions for katgpucbf."""
 
+import ipaddress
 import logging
 import signal
 from asyncio import get_event_loop
+from typing import List, Tuple, Union
 
 from aiokatcp import DeviceServer
+from katsdptelstate.endpoint import endpoint_list_parser
 
 logger = logging.getLogger(__name__)
 
@@ -40,3 +43,14 @@ def add_signal_handlers(server: DeviceServer) -> None:
     loop = get_event_loop()
     for signum in signums:
         loop.add_signal_handler(signum, handler)
+
+
+def parse_source(value: str) -> Union[List[Tuple[str, int]], str]:
+    """Parse a string into a list of IP endpoints."""
+    try:
+        endpoints = endpoint_list_parser(7148)(value)
+        for endpoint in endpoints:
+            ipaddress.IPv4Address(endpoint.host)  # Raises if invalid syntax
+        return [(ep.host, ep.port) for ep in endpoints]
+    except ValueError:
+        return value

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -236,7 +236,7 @@ class XBEngine(DeviceServer):
         sample_bits: int,
         heap_accumulation_threshold: int,
         channel_offset_value: int,
-        src: Tuple[str, int],
+        src: List[Tuple[str, int]],  # It's a list but it should be length 1 in xbgpu case.
         src_interface: str,
         src_ibv: bool,
         src_affinity: int,
@@ -751,9 +751,7 @@ class XBEngine(DeviceServer):
         """
         base_recv.add_reader(
             self.receiver_stream,
-            src=[
-                self._src,
-            ],
+            src=self._src,
             interface=self._src_interface,
             ibv=self._src_ibv,
             comp_vector=self._src_comp_vector,

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -53,7 +53,7 @@ from .. import (
     __version__,
 )
 from ..monitor import FileMonitor, Monitor, NullMonitor
-from ..utils import add_signal_handlers
+from ..utils import add_signal_handlers, parse_source
 from .correlation import device_filter
 
 logger = logging.getLogger(__name__)
@@ -205,7 +205,7 @@ def parse_args(arglist: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser.add_argument("--dst-ibv", action="store_true", help="Use ibverbs for output [no].")
     parser.add_argument("--monitor-log", type=str, help="File to write performance-monitoring data to")
     parser.add_argument("--version", action="version", version=__version__)
-    parser.add_argument("src", type=endpoint_parser(7148), help="Multicast address data is received from.")
+    parser.add_argument("src", type=parse_source, help="Multicast address data is received from.")
     parser.add_argument("dst", type=endpoint_parser(7148), help="Multicast address data is sent on.")
 
     args = parser.parse_args(arglist)


### PR DESCRIPTION
There were still subtle differences between xgpu and fgpu in the way
that the sources were specified, which I missed with unit testing
because of the mockers.

Imagine my surprise when I tried to build a correlator for qualification
testing and it just crashes and burns. I guess this is why we have
tests.

I've moved parse_source() from fgpu's main to the util module, it seemed
more robust than manually casting the Endpoint to a tuple of str and int.

Closes NGC-595.