### PR TITLE
Fix a deadlock in fgpu recv code

### DIFF
--- a/src/katgpucbf/recv.py
+++ b/src/katgpucbf/recv.py
@@ -226,7 +226,7 @@ def make_stream(
     spead_items: List[int],
     max_active_chunks: int,
     data_ringbuffer: spead2.recv.asyncio.ChunkRingbuffer,
-    free_ringbuffer: spead2.recv.asyncio.ChunkRingbuffer,
+    free_ringbuffer: spead2.recv.ChunkRingbuffer,
     affinity: int,
     stream_stats: List[str],
     **kwargs: Any,

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -46,7 +46,7 @@ import katsdpsigproc.abc
 import katsdpsigproc.accel
 import katsdpsigproc.resource
 import numpy as np
-import spead2
+import spead2.recv
 from aiokatcp import DeviceServer
 
 from .. import DESCRIPTOR_TASK_NAME, GPU_PROC_TASK_NAME, RECV_TASK_NAME, SEND_TASK_NAME, __version__
@@ -311,9 +311,7 @@ class XBEngine(DeviceServer):
         data_ringbuffer = ChunkRingbuffer(
             self.max_active_chunks, name="recv_data_ringbuffer", task_name=RECV_TASK_NAME, monitor=monitor
         )
-        free_ringbuffer = ChunkRingbuffer(
-            n_free_chunks, name="recv_free_ringbuffer", task_name=RECV_TASK_NAME, monitor=monitor
-        )
+        free_ringbuffer = spead2.recv.ChunkRingbuffer(n_free_chunks)
         layout = recv.Layout(
             n_ants=self.n_ants,
             n_channels_per_stream=self.n_channels_per_stream,

--- a/src/katgpucbf/xbgpu/recv.py
+++ b/src/katgpucbf/xbgpu/recv.py
@@ -162,7 +162,7 @@ class Layout(BaseLayout):
 def make_stream(
     layout: Layout,
     data_ringbuffer: spead2.recv.asyncio.ChunkRingbuffer,
-    free_ringbuffer: spead2.recv.asyncio.ChunkRingbuffer,
+    free_ringbuffer: spead2.recv.ChunkRingbuffer,
     src_affinity: int,
     max_active_chunks: int,
 ) -> spead2.recv.ChunkRingStream:

--- a/test/xbgpu/test_recv.py
+++ b/test/xbgpu/test_recv.py
@@ -70,7 +70,7 @@ def stream(layout, queue) -> Generator[spead2.recv.ChunkRingStream, None, None]:
     max_active_chunks = 5
     data_ringbuffer = spead2.recv.asyncio.ChunkRingbuffer(max_active_chunks)
     n_chunks_total = max_active_chunks + 8  # 8 is just a few more.
-    free_ringbuffer = spead2.recv.asyncio.ChunkRingbuffer(n_chunks_total)
+    free_ringbuffer = spead2.recv.ChunkRingbuffer(n_chunks_total)
     stream = recv.make_stream(layout, data_ringbuffer, free_ringbuffer, -1, max_active_chunks)
     for _ in range(n_chunks_total):
         data = np.empty(layout.chunk_bytes, np.int8)


### PR DESCRIPTION
This was introduced in #174, which allowed `chunk_sets` to keep chunks
around for arbitrarily long to match them up. If a large number of
chunks was received on one polarisation and none on the other, they
could absorb all the available chunks in the system, and the other
polarisation could then never make forward progress.

This is fixed by using a separate free_ringbuffer for each stream,
instead of a shared one. Whichever pol has the oldest newest chunk in
chunk_sets can only have one chunk buffered, and so forward progress is
always possible.

This can in theory lead to more data loss from the polarisations
de-synchronising, as there is now only half as much leeway. This should
thus be tested in the lab.

Closes NGC-598.
