### PR TITLE
Add .coveragerc to remap paths to src directory

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+# Rewrite paths to point at src directory, just to get saner filenames in
+# coverage reports.
+[paths]
+source =
+    src
+    */site-packages


### PR DESCRIPTION
This makes Jenkins pick up the source code and present readable paths.

Closes NGC-372.