### PR TITLE
Fold .coveragerc into pyproject.toml

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,0 @@
-# Rewrite paths to point at src directory, just to get saner filenames in
-# coverage reports.
-[paths]
-source =
-    src
-    */site-packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,9 @@ source = [
 
 [tool.coverage.html]
 show_contexts = true
+
+[tool.coverage.paths]
+source = [
+	"src",
+	"*/site-packages",
+]


### PR DESCRIPTION
PR #248 added some coverage.py config in a .coveragerc file, but there
is already some config for coverage.py in pyproject.toml. Remove
.coveragerc and add its config to pyproject.toml.
