### PR TITLE
Reuse gen_heaps from test_recv in test_engine

### DIFF
--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -220,10 +220,8 @@ class TestEngine:
             sample_array = sample_array.view(np.int8)
             sample_array = np.reshape(sample_array, heap_shape)
 
-            # Create the heap, configure it to send immediate values in each
-            # packet, add it to a list of HeapReferences.
+            # Create the heap, add it to a list of HeapReferences.
             heap = gen_heap(timestamp, ant_index, n_channels_per_stream * CHANNEL_OFFSET, sample_array)
-            heap.repeat_pointers = True
             heaps.append(spead2.send.HeapReference(heap))
 
         return heaps

--- a/test/xbgpu/test_recv.py
+++ b/test/xbgpu/test_recv.py
@@ -105,6 +105,7 @@ def gen_heap(timestamp: int, feng_id: int, frequency: int, feng_raw: np.ndarray)
     heap.add_item(spead2.Item(FENG_ID_ID, "", "", shape=(), format=IMMEDIATE_FORMAT, value=feng_id))
     heap.add_item(spead2.Item(FREQUENCY_ID, "", "", shape=(), format=IMMEDIATE_FORMAT, value=frequency))
     heap.add_item(spead2.Item(FENG_RAW_ID, "", "", shape=feng_raw.shape, dtype=feng_raw.dtype, value=feng_raw))
+    heap.repeat_pointers = True
     return heap
 
 


### PR DESCRIPTION
Fewer lines of code.

I am ever so slightly uncomfortable importing just from another test file, but it seems weird to have `gen_heaps()` in `__init__.py` all by itself.

Closes NGC-629