### PR TITLE
Reuse correlators between qualification tests

### DIFF
--- a/qualification/__init__.py
+++ b/qualification/__init__.py
@@ -80,6 +80,7 @@ class CorrelatorRemoteControl:
     product_controller_client: aiokatcp.Client
     dsim_client: aiokatcp.Client
     n_ants: int
+    n_inputs: int
     n_chans: int
     n_bls: int
     n_chans_per_substream: int
@@ -104,7 +105,8 @@ class CorrelatorRemoteControl:
         done.
         """
         # Some metadata we know already from the config.
-        n_ants = len(correlator_config["outputs"]["antenna_channelised_voltage"]["src_streams"]) // 2
+        n_inputs = len(correlator_config["outputs"]["antenna_channelised_voltage"]["src_streams"])
+        n_ants = n_inputs // 2
         n_chans = correlator_config["outputs"]["antenna_channelised_voltage"]["n_chans"]
 
         # But some can't.
@@ -129,6 +131,7 @@ class CorrelatorRemoteControl:
             product_controller_client=pcc,
             dsim_client=dsim_client,
             n_ants=n_ants,
+            n_inputs=n_inputs,
             n_chans=n_chans,
             n_bls=n_bls,
             n_chans_per_substream=n_chans_per_substream,


### PR DESCRIPTION
The sizing fixtures, plus an internal fixture that actually creates a
correlator, are made session-scoped. The `correlator` fixture just takes
the session-scoped fixture and resets the correlator to a known state
(resetting delays and gains, enabling the output stream, and setting the
dsim to output zeros).

This does change the test ordering, such that the correlator config is
the slowest-changing thing, slower than the particular test. Potentially
the reporting should re-sort the data to group together all parametric
versions of a test, but that can be done on the display side.

This depends on #259.

Closes NGC-592.
