### PR TITLE
Fix errors in implementing dsim support for constants

### DIFF
--- a/src/katgpucbf/dsim/signal.py
+++ b/src/katgpucbf/dsim/signal.py
@@ -134,15 +134,10 @@ class CombinedSignal(Signal):
 class Constant(Signal):
     """Fixed value."""
 
-    value: complex
-
-    @staticmethod
-    def _sample_chunk(offset: np.int64, *, value: complex, chunk_size: int) -> np.ndarray:
-        """Compute a single chunk."""
-        return np.full(chunk_size, value, np.complex64)
+    value: float
 
     def sample(self, n: int, sample_rate: float) -> da.Array:  # noqa: D102
-        return da.full((n,), self.value, np.complex64)
+        return da.full((n,), self.value, dtype=np.float32, chunks=CHUNK_SIZE)
 
     def __str__(self) -> str:
         return f"{self.value}"
@@ -367,7 +362,7 @@ def parse_signals(prog: str) -> List[Signal]:
     variable_expr = variable.copy()
     variable_expr.set_parse_action(get_variable)
     real_expr = real.copy()
-    real_expr.set_parse_action(lambda s, loc, tokens: Constant(complex(tokens[0])))
+    real_expr.set_parse_action(lambda s, loc, tokens: Constant(float(tokens[0])))
 
     atom = real_expr | cw | wgn | variable_expr
     expr = pp.infix_notation(

--- a/test/dsim/test_signal.py
+++ b/test/dsim/test_signal.py
@@ -44,9 +44,8 @@ class TestConstant:
     @pytest.mark.parametrize("n", [123, 4096, 12345])
     def test_sample(self, n: int) -> None:
         """Test basic functionality."""
-        n = 12345
-        sig = Constant(3 + 4j)
-        expected = np.full(n, 3 + 4j, np.complex64)
+        sig = Constant(3.5)
+        expected = np.full(n, 3.5, np.float32)
         np.testing.assert_equal(sig.sample(n, 1e9), expected)
 
 


### PR DESCRIPTION
My brain was on holiday when I wrote #259.

- Signals are real, not complex.
- There's an unused helper function.
- The da.full call didn't specify a chunk size, so it ends up being one
  big chunk, which is going to (possibly) waste memory and reduce
  parallelism.
- The test is parametrised, but ignores (overwrites) the parameter.
