### PR TITLE
Fix the dither seed at startup

### DIFF
--- a/src/katgpucbf/dsim/main.py
+++ b/src/katgpucbf/dsim/main.py
@@ -157,6 +157,8 @@ async def async_main() -> None:
     descriptor_sender = descriptors.DescriptorSender(stream=descriptor_stream, descriptor_heap=descriptor_heap)
     descriptor_task = asyncio.create_task(descriptor_sender.run())
 
+    if args.dither_seed is None:
+        args.dither_seed = np.random.SeedSequence().entropy  # Generate a random seed
     async with signal.SignalService([heap_sets[0].data["payload"]]) as signal_service:
         await signal_service.sample(
             args.signals,

--- a/src/katgpucbf/dsim/server.py
+++ b/src/katgpucbf/dsim/server.py
@@ -18,7 +18,7 @@
 
 import asyncio
 import logging
-from typing import Optional, Sequence
+from typing import Sequence
 
 import aiokatcp
 import pyparsing as pp
@@ -68,7 +68,7 @@ class DeviceServer(aiokatcp.DeviceServer):
         adc_sample_rate: float,
         sample_bits: int,
         first_timestamp: int,
-        dither_seed: Optional[int],
+        dither_seed: int,
         signals_str: str,
         signals: Sequence[Signal],
         *args,
@@ -102,6 +102,15 @@ class DeviceServer(aiokatcp.DeviceServer):
         )
         self.sensors.add(self._signals_orig_sensor)
         self.sensors.add(self._signals_sensor)
+        self.sensors.add(
+            aiokatcp.Sensor(
+                int,
+                "dither-seed",
+                "Random seed used in dithering for quantisation",
+                initial_status=aiokatcp.Sensor.Status.NOMINAL,
+                default=dither_seed,
+            )
+        )
         self.sensors.add(
             aiokatcp.Sensor(
                 int,


### PR DESCRIPTION
Previously, if no dither seed was given on a command line, one would be
computed every time the signals changed, making reproduction of results
difficult. Also added a sensor so that the seed can be retrieved (e.g.
it could be reported in test results).
