### PR TITLE
Rework dither calculation for better performance

### DIFF
--- a/src/katgpucbf/dsim/main.py
+++ b/src/katgpucbf/dsim/main.py
@@ -159,14 +159,14 @@ async def async_main() -> None:
 
     if args.dither_seed is None:
         args.dither_seed = np.random.SeedSequence().entropy  # Generate a random seed
-    async with signal.SignalService([heap_sets[0].data["payload"]]) as signal_service:
+    async with signal.SignalService(
+        [heap_sets[0].data["payload"]], args.sample_bits, args.dither_seed
+    ) as signal_service:
         await signal_service.sample(
             args.signals,
             0,
             args.adc_sample_rate,
-            args.sample_bits,
             heap_sets[0].data["payload"],
-            dither_seed=args.dither_seed,
         )
 
     stream = send.make_stream(

--- a/src/katgpucbf/dsim/server.py
+++ b/src/katgpucbf/dsim/server.py
@@ -83,7 +83,11 @@ class DeviceServer(aiokatcp.DeviceServer):
         self.first_timestamp = first_timestamp
         self.dither_seed = dither_seed
         self._signals_lock = asyncio.Lock()  # Serialises request_signals
-        self._signal_service = SignalService([self.sender.heap_set.data["payload"], self.spare.data["payload"]])
+        self._signal_service = SignalService(
+            [self.sender.heap_set.data["payload"], self.spare.data["payload"]],
+            sample_bits,
+            dither_seed,
+        )
 
         self._signals_orig_sensor = aiokatcp.Sensor(
             str,
@@ -173,9 +177,7 @@ class DeviceServer(aiokatcp.DeviceServer):
                 signals,
                 self.first_timestamp,
                 self.adc_sample_rate,
-                self.sample_bits,
                 self.spare.data["payload"],
-                dither_seed=self.dither_seed,
             )
             spare = self.sender.heap_set
             timestamp = await self.sender.set_heaps(self.spare)


### PR DESCRIPTION
There is a lot of refactoring here, but the ultimate goal is that
SignalService computes the dither at startup and reuses it in future.

The Dither subclass of Signal is removed, and replaced with
`make_dither` that directly generates a dask array (wrapped in
xr.DataArray so that the axes can be named). quantise now takes the
dither as input rather than generating it itself.

See NGC-633.
