### PR TITLE
Update Sphinx apidocs with new modules

### DIFF
--- a/doc/katgpucbf.dsim.rst
+++ b/doc/katgpucbf.dsim.rst
@@ -11,6 +11,7 @@ Submodules
    katgpucbf.dsim.main
    katgpucbf.dsim.send
    katgpucbf.dsim.server
+   katgpucbf.dsim.shared_array
    katgpucbf.dsim.signal
 
 Module contents

--- a/doc/katgpucbf.dsim.shared_array.rst
+++ b/doc/katgpucbf.dsim.shared_array.rst
@@ -1,0 +1,7 @@
+katgpucbf.dsim.shared\_array module
+===================================
+
+.. automodule:: katgpucbf.dsim.shared_array
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/katgpucbf.meerkat.rst
+++ b/doc/katgpucbf.meerkat.rst
@@ -1,0 +1,7 @@
+katgpucbf.meerkat module
+========================
+
+.. automodule:: katgpucbf.meerkat
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/katgpucbf.rst
+++ b/doc/katgpucbf.rst
@@ -17,6 +17,7 @@ Submodules
 .. toctree::
    :maxdepth: 4
 
+   katgpucbf.meerkat
    katgpucbf.monitor
    katgpucbf.recv
    katgpucbf.ringbuffer


### PR DESCRIPTION
The katgpucbf.meerkat and katgpucbf.dsim.shared_array modules weren't
updated in the apidocs when they were added.
