### PR TITLE
Add steady-state-timestamp to dsim

### DIFF
--- a/src/katgpucbf/dsim/server.py
+++ b/src/katgpucbf/dsim/server.py
@@ -99,7 +99,6 @@ class DeviceServer(aiokatcp.DeviceServer):
             initial_status=aiokatcp.Sensor.Status.NOMINAL,
             default=signals_str,
         )
-        # TODO: it's not reproducible because the random dither is not captured
         self._signals_sensor = aiokatcp.Sensor(
             str,
             "signals",
@@ -107,8 +106,16 @@ class DeviceServer(aiokatcp.DeviceServer):
             initial_status=aiokatcp.Sensor.Status.NOMINAL,
             default=format_signals(signals),
         )
+        self._steady_state_sensor = aiokatcp.Sensor(
+            int,
+            "steady-state-timestamp",
+            "Heaps with this timestamp or greater are guaranteed to reflect the effects of previous katcp requests.",
+            default=0,
+            initial_status=aiokatcp.Sensor.Status.NOMINAL,
+        )
         self.sensors.add(self._signals_orig_sensor)
         self.sensors.add(self._signals_sensor)
+        self.sensors.add(self._steady_state_sensor)
         self.sensors.add(
             aiokatcp.Sensor(
                 int,
@@ -187,4 +194,5 @@ class DeviceServer(aiokatcp.DeviceServer):
             self.spare = spare
             self._signals_orig_sensor.value = signals_str
             self._signals_sensor.value = format_signals(signals)
+            self._steady_state_sensor.value = max(self._steady_state_sensor.value, timestamp)
             return timestamp

--- a/test/dsim/test_server.py
+++ b/test/dsim/test_server.py
@@ -90,6 +90,8 @@ async def test_signals(
     set_heaps = mocker.patch.object(sender, "set_heaps", autospec=True, return_value=1234567)
     reply, _ = await katcp_client.request("signals", signals_str)
     assert reply == [b"1234567"]
+    _, informs = await katcp_client.request("sensor-value", "steady-state-timestamp")
+    assert informs[0].arguments[4] == b"1234567"
     set_heaps.assert_called_once_with(heap_sets[1])
     # Check that pol 0 is now indeed all zeros (and pol 1 is not).
     np.testing.assert_equal(heap_sets[1].data["payload"].isel(pol=0).data, 0)


### PR DESCRIPTION
This duplicates the information returned by the `?signals` request. The
advantage is that it can be fetched later, independently of the code
that made the request.

See NGC-642.
