### PR TITLE
Allow multiple qualification tests in parallel

### DIFF
--- a/qualification/README.rst
+++ b/qualification/README.rst
@@ -37,6 +37,7 @@ you're deploying on, and it'll look something like this:
    asyncio_mode = auto
    master_controller_host = lab5.sdp.kat.ac.za
    master_controller_port = 5001
+   product_name = bobs_qualification_correlator  # Use your own name
    interface = enp193s0f0
    use_ibv = true
    log_cli = true

--- a/qualification/baseline_correlation_products/conftest.py
+++ b/qualification/baseline_correlation_products/conftest.py
@@ -19,7 +19,7 @@
 import pytest
 
 
-@pytest.fixture(scope="session", params=[4, 8, 14])
+@pytest.fixture(scope="session", params=[4, 8])
 def n_antennas(request):  # noqa: D401
     """Number of antennas, i.e. size of the array."""
     return request.param

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -51,6 +51,7 @@ def pytest_addoption(parser, pluginmanager):  # noqa: D103
     # forget.
     parser.addini("interface", "Name of network to use for ingest.", type="string")
     parser.addini("use_ibv", "Use ibverbs", type="bool", default="false")
+    parser.addini("product_name", "Name of subarray product", type="string", default="qualification_correlator")
 
 
 def pytest_report_collectionfinish(config):  # noqa: D103
@@ -197,10 +198,7 @@ async def session_correlator(
         logger.exception("unable to connect to master controller!")
         raise
 
-    # We'll always name the correlator the same thing, so that if there are
-    # zombies left behind from past runs, it'll bail straight away and alert
-    # the user that there's a problem.
-    product_name = "qualification_correlator"
+    product_name = pytestconfig.getini("product_name")
     try:
         reply, _ = await master_controller_client.request(
             "product-configure", product_name, json.dumps(correlator_config)


### PR DESCRIPTION
- Reduce maximum array size tested to 8
- Add `product_name` ini option so that each user can name their
  product independently to avoid conflicts.