### PR TITLE
qualification: generate figures in reporter.py

### DIFF
--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -22,9 +22,10 @@ import json
 import logging
 import subprocess
 import time
-from typing import AsyncGenerator, Tuple
+from typing import AsyncGenerator, Generator, Tuple
 
 import aiokatcp
+import matplotlib.style
 import pytest
 from async_timeout import timeout
 from katsdpservices import get_interface_address
@@ -118,6 +119,13 @@ def pdf_report(request) -> Reporter:
     data = [{"$msg_type": "test_info", "blurb": inspect.getdoc(request.node.function), "test_start": time.time()}]
     request.node.user_properties.append(("pdf_report_data", data))
     return Reporter(data)
+
+
+@pytest.fixture(autouse=True)
+def matplotlib_report_style() -> Generator[None, None, None]:
+    """Set the style of all matplotlib plots."""
+    with matplotlib.style.context("ggplot"):
+        yield
 
 
 @pytest.fixture(scope="session")

--- a/qualification/requirements.in
+++ b/qualification/requirements.in
@@ -1,5 +1,7 @@
 -r ../requirements-dev.txt
 async-timeout
+matplotlib
 pytest-expectr
 pytest-reportlog
 spead2>=3.9.1
+tikzplotlib

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -48,6 +48,8 @@ coverage[toml]==6.3.2
     # via
     #   -r ../requirements-dev.txt
     #   pytest-cov
+cycler==0.11.0
+    # via matplotlib
 decorator==5.1.1
     # via
     #   -r ../requirements-dev.txt
@@ -75,6 +77,8 @@ filelock==3.6.0
     # via
     #   -r ../requirements-dev.txt
     #   virtualenv
+fonttools==4.33.3
+    # via matplotlib
 identify==2.5.0
     # via
     #   -r ../requirements-dev.txt
@@ -105,6 +109,8 @@ jinja2==3.1.2
     # via
     #   -r ../requirements-dev.txt
     #   sphinx
+kiwisolver==1.4.2
+    # via matplotlib
 latexcodec==2.0.1
     # via
     #   -r ../requirements-dev.txt
@@ -117,6 +123,10 @@ markupsafe==2.1.1
     # via
     #   -r ../requirements-dev.txt
     #   jinja2
+matplotlib==3.5.2
+    # via
+    #   -r requirements.in
+    #   tikzplotlib
 matplotlib-inline==0.1.3
     # via
     #   -r ../requirements-dev.txt
@@ -130,11 +140,14 @@ numba==0.55.1
 numpy==1.21.6
     # via
     #   -r ../requirements-dev.txt
+    #   matplotlib
     #   numba
     #   spead2
+    #   tikzplotlib
 packaging==21.3
     # via
     #   -r ../requirements-dev.txt
+    #   matplotlib
     #   pytest
     #   sphinx
 parso==0.8.3
@@ -153,6 +166,10 @@ pickleshare==0.7.5
     # via
     #   -r ../requirements-dev.txt
     #   ipython
+pillow==9.1.1
+    # via
+    #   matplotlib
+    #   tikzplotlib
 pip-tools==6.6.0
     # via -r ../requirements-dev.txt
 platformdirs==2.5.2
@@ -201,6 +218,7 @@ pygments==2.12.0
 pyparsing==3.0.8
     # via
     #   -r ../requirements-dev.txt
+    #   matplotlib
     #   packaging
 pytest==7.1.2
     # via
@@ -228,6 +246,8 @@ pytest-reportlog==0.1.2
     # via -r requirements.in
 pytest-xdist==2.5.0
     # via -r ../requirements-dev.txt
+python-dateutil==2.8.2
+    # via matplotlib
 pytz==2022.1
     # via
     #   -r ../requirements-dev.txt
@@ -247,6 +267,7 @@ six==1.16.0
     #   asttokens
     #   latexcodec
     #   pybtex
+    #   python-dateutil
     #   virtualenv
 snowballstemmer==2.2.0
     # via
@@ -294,6 +315,8 @@ stack-data==0.2.0
     # via
     #   -r ../requirements-dev.txt
     #   ipython
+tikzplotlib==0.10.1
+    # via -r requirements.in
 toml==0.10.2
     # via
     #   -r ../requirements-dev.txt
@@ -321,6 +344,8 @@ wcwidth==0.2.5
     # via
     #   -r ../requirements-dev.txt
     #   prompt-toolkit
+webcolors==1.12
+    # via tikzplotlib
 wheel==0.37.1
     # via
     #   -r ../requirements-dev.txt


### PR DESCRIPTION
This allows each test to use all the features of matplotlib (at least if
they're supported by tikzplotlib), rather than trying to funnel
everything into one function call.

See NGC-635.
