### PR TITLE
Improvements to coverage reporting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,14 +97,14 @@ pipeline {
       when { not { anyOf { changeRequest target: 'main'; branch 'main' } } }
       options { timeout(time: 10, unit: 'MINUTES') }
       steps {
-        sh 'pytest -v -ra --junitxml=reports/result.xml --cov=katgpucbf --cov-report=xml --cov-branch'
+        sh 'pytest -v -ra --junitxml=reports/result.xml --cov=katgpucbf --cov=test --cov-report=xml --cov-branch'
       }
     }
     stage('Run pytest (full)') {
       when { anyOf { changeRequest target: 'main'; branch 'main' } }
       options { timeout(time: 60, unit: 'MINUTES') }
       steps {
-        sh 'pytest -v -ra --all-combinations --junitxml=reports/result.xml --cov=katgpucbf --cov-report=xml --cov-branch'
+        sh 'pytest -v -ra --all-combinations --junitxml=reports/result.xml --cov=test --cov=katgpucbf --cov-report=xml --cov-branch'
       }
     }
     stage('Publish test results') {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,10 @@ source = [
 	"src",
 	"*/site-packages",
 ]
+
+[tool.coverage.report]
+exclude_lines = [
+	'#\s*(pragma|PRAGMA)[:\s]?\s*(no|NO)\s*(cover|COVER)',  # Default from coverage
+	'@(?:numba\.)?(?:njit|cfunc)',  # Compiled so coverage can't see the code being executed
+	'@(abc\.)?abstractmethod',
+]

--- a/src/katgpucbf/dsim/signal.py
+++ b/src/katgpucbf/dsim/signal.py
@@ -423,7 +423,7 @@ def make_dither(n_pols: int, n: int, entropy: Optional[int] = None) -> xr.DataAr
 
 
 @numba.njit
-def _clip(a, a_min, a_max):  # pragma: nocover
+def _clip(a, a_min, a_max):
     """Like np.clip, but for scalars.
 
     It's not working in numba: https://github.com/numba/numba/issues/3469.
@@ -437,7 +437,7 @@ def _clip(a, a_min, a_max):  # pragma: nocover
 
 
 @numba.njit(nogil=True)
-def _quantise_chunk(chunk: np.ndarray, dither: np.ndarray, scale: np.float32) -> np.ndarray:  # pragma: nocover
+def _quantise_chunk(chunk: np.ndarray, dither: np.ndarray, scale: np.float32) -> np.ndarray:
     out = np.empty_like(chunk, dtype=np.int32)
     for i in range(chunk.shape[0]):
         scaled = chunk[i] * scale + dither[i]
@@ -468,7 +468,7 @@ def quantise(
 
 
 @numba.njit(nogil=True)
-def _packbits(data: np.ndarray, bits: int) -> np.ndarray:  # pragma: nocover
+def _packbits(data: np.ndarray, bits: int) -> np.ndarray:
     # Note: needs lots of explicit casting to np.uint64, as otherwise
     # numba seems to want to infer double precision.
     out = np.zeros(data.size * bits // BYTE_BITS, np.uint8)

--- a/src/katgpucbf/fgpu/recv.py
+++ b/src/katgpucbf/fgpu/recv.py
@@ -122,7 +122,7 @@ class Layout(BaseLayout):
             types.void(types.CPointer(chunk_place_data), types.uintp, types.CPointer(user_data_type)),
             nopython=True,
         )
-        def chunk_place_impl(data_ptr, data_size, user_data_ptr):  # pragma: nocover
+        def chunk_place_impl(data_ptr, data_size, user_data_ptr):
             data = numba.carray(data_ptr, 1)
             items = numba.carray(intp_to_voidptr(data[0].items), 2, dtype=np.int64)
             timestamp = items[0]


### PR DESCRIPTION
- Exclude numba.njit, numba.cfunc and abc.abstractmethod from coverage,
  since the former is invisible to coverage.py and the latter is not
  expected to be executable (closes NGC-644).
- Remove some manual `pragma: nocover` annotations that are obsoleted by
  the above.
- Add `--cov=test` to Jenkins run so that test code shows up in coverage
  reports.
