### PR TITLE
Make more use of `expect` in qual tests

### DIFF
--- a/qualification/antenna_channelised_voltage/test_channel_shape.py
+++ b/qualification/antenna_channelised_voltage/test_channel_shape.py
@@ -56,6 +56,7 @@ async def test_channel_shape(
     correlator: CorrelatorRemoteControl,
     receive_baseline_correlation_products: BaselineCorrelationProductsReceiver,
     pdf_report: Reporter,
+    expect,
 ) -> None:
     r"""Test the shape of the response to a single channel.
 
@@ -156,4 +157,4 @@ async def test_channel_shape(
     pdf_report.detail(
         f"-53 dB bandwidth is {width_53db:.3f} channels ({width_53db / width_3db:.3f}x the pass bandwidth)."
     )
-    assert width_53db <= 2 * width_3db
+    expect(width_53db <= 2 * width_3db)

--- a/qualification/baseline_correlation_products/test_accum_length.py
+++ b/qualification/baseline_correlation_products/test_accum_length.py
@@ -30,6 +30,7 @@ async def test_accum_length(
     correlator: CorrelatorRemoteControl,
     receive_baseline_correlation_products: BaselineCorrelationProductsReceiver,
     pdf_report: Reporter,
+    expect,
 ) -> None:
     """Test that accumulations are set to the correct length.
 
@@ -50,7 +51,7 @@ async def test_accum_length(
     pdf_report.step("Retrieve the reported accumulation time and check it.")
     pdf_report.detail(f"Integration time is {receiver.int_time * 1000:.3f} ms.")
     # Requirement doesn't list an upper bound, but assume a symmetric limit
-    assert 0.48 <= receiver.int_time <= 0.52
+    expect(0.48 <= receiver.int_time <= 0.52)
 
     pdf_report.step("Inject a white noise signal.")
     level = 32  # Expected magnitude of F-engine outputs
@@ -75,7 +76,7 @@ async def test_accum_length(
     delta = chunks[1][0] - chunks[0][0]
     delta_s = delta / receiver.scale_factor_timestamp
     pdf_report.detail(f"Difference is {delta} samples, {delta_s * 1000:.3f} ms.")
-    assert delta_s == receiver.int_time
+    expect(delta_s == receiver.int_time)
 
     pdf_report.step("Compare power against expected value.")
     # Sum over channels, but use only one baseline and real part because
@@ -89,5 +90,5 @@ async def test_accum_length(
     # quantisation and saturation in both the time and frequency domain, and
     # the values are not fully independent in either time or channel. But 1%
     # variation seems safe.
-    assert total_power == pytest.approx(expected_power, rel=0.01)
+    expect(total_power == pytest.approx(expected_power, rel=0.01))
     pdf_report.detail("Power agrees to within 1%.")


### PR DESCRIPTION
This is practical now that NGC-631 has been addressed.