### PR TITLE
Update combinations to test in xbgpu

### DIFF
--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -125,6 +125,16 @@ def generate_expected_output(
     return output_array
 
 
+def valid_end_to_end_combination(combo: dict) -> bool:
+    """Check whether a combination for :meth:`TestEngine.test_xengine_end_to_end` is valid."""
+    n_ants = combo["n_ants"]
+    missing_antenna = combo["missing_antenna"]
+    if missing_antenna is None:
+        return True
+    # Don't want to delete all the data, or an out-of-range antenna
+    return n_ants > 1 and missing_antenna < n_ants
+
+
 class TestEngine:
     r"""Grouping of unit tests for :class:`.XBEngine`\'s various functionality."""
 
@@ -370,6 +380,7 @@ class TestEngine:
         test_parameters.num_channels,
         test_parameters.num_spectra_per_heap,
         [None, 0, 3],
+        filter=valid_end_to_end_combination,
     )
     async def test_xengine_end_to_end(
         self,

--- a/test/xbgpu/test_parameters.py
+++ b/test/xbgpu/test_parameters.py
@@ -19,12 +19,10 @@
 # These are the estimated subarray sizes that will be run.  Values 5, 23, 61 and
 # 19 are just there to test that various non-power-of-two array sizes will
 # run.
-array_size = [5, 23, 61, 19, 4, 8, 16, 32, 64, 84]
+array_size = [1, 3, 4, 19, 33, 64, 80]
 
-# This is always set to 256 for the MeerKAT case. There is a chance that for
-# the MeerKAT extension this could be configured to other values. All these
-# cases need to be tested.
-num_spectra_per_heap = [256, 512, 1024]
+# This is always set to 256 for the MeerKAT case.
+num_spectra_per_heap = [256]
 
 # Number of FFT channels out of the F-Engine
-num_channels = [1024, 4096, 8192, 32768]
+num_channels = [1024, 8192, 32768]

--- a/test/xbgpu/test_spead2_send.py
+++ b/test/xbgpu/test_spead2_send.py
@@ -125,10 +125,10 @@ class TestSend:
         ig = spead2.ItemGroup()
 
         # 5.1 Wait for the first packet to arrive - it is expected to be the
-        # SPEAD descriptor. Without the desciptor the recv_stream cannot
+        # SPEAD descriptor. Without the descriptor the recv_stream cannot
         # interpret the heaps correctly.
         heap = await recv_stream.get()
-        assert heap.cnt % n_engines == 4, "The heap IDs are not correctly strided"
+        assert heap.cnt % n_engines == 4 % n_engines, "The heap IDs are not correctly strided"
         items = ig.update(heap)
         assert len(list(items.values())) == 0, "This heap contains item values not just the expected descriptors."
 


### PR DESCRIPTION
This is mostly to reduce testing time (see NGC-655 for motivation of
choice), but it also adds tests for very few antennas.

The `combinations` pytest marker was semi-rewritten to allow the possible
combinations to be filtered, so that it is possible to test 1 antenna
and to test antenna 3's data being missing, while avoiding testing the
combination of the two (`pytest.skip` would have potentially left some
individual parameter values completely untested).

Closes NGC-655.
