### PR TITLE
dsim: fix use of dither_seed

### DIFF
--- a/src/katgpucbf/dsim/signal.py
+++ b/src/katgpucbf/dsim/signal.py
@@ -541,7 +541,7 @@ def sample(
     n = out.isel(pol=0).data.size * BYTE_BITS // sample_bits
 
     if dither is True:
-        dither = make_dither(len(signals), n)
+        dither = make_dither(len(signals), n, entropy=dither_seed)
     elif dither is False:
         dither = xr.DataArray(da.zeros((n_pols, n), np.float32, chunks=CHUNK_SIZE), dims=["pol", "data"])
     else:


### PR DESCRIPTION
The dither_seed parameter to `sample` wasn't being used (after some
refactoring). I don't think this would have made any difference to the
dsim service, because SignalService pre-computes a dither, but I
happened to spot the omission.
