### PR TITLE
Use consistent version of pandas in requirements

### DIFF
--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -170,7 +170,7 @@ packaging==21.3
     #   matplotlib
     #   pytest
     #   sphinx
-pandas==1.4.2
+pandas==1.4.3
     # via prometheus-api-client
 parso==0.8.3
     # via


### PR DESCRIPTION
For some reason the previous version bump PR brought pandas to different
versions in the main requirements.txt versus
qualification/requirements.txt.
