### PR TITLE
Added fix to test if any zeros in the linearity test results prior to…

### DIFF
--- a/qualification/antenna_channelised_voltage/test_linearity.py
+++ b/qualification/antenna_channelised_voltage/test_linearity.py
@@ -78,8 +78,9 @@ async def test_linearity(
     pdf_report.detail(f"MSE is: {mse}")
 
     # Check for any zeros at the end of the sequence prior to plotting. Remove if so.
-    zero_locations = np.where(linear_test_result == 0)
-    linear_test_result = linear_test_result[: np.max(zero_locations[0]) - len(zero_locations[0])]
+    zero_locations = np.where(linear_test_result == 0)[0]
+    if len(zero_locations):
+        linear_test_result = linear_test_result[: zero_locations[0]]
 
     # Generate plot with reference
     labels = [f"$2^{{-{i}}}$" for i in range(len(cw_scales))]


### PR DESCRIPTION
… plotting (to prevent warnings due to log10(0)).

If present, the sequence is truncated. New report attached.

[report.pdf](https://github.com/ska-sa/katgpucbf/files/9039987/report.pdf)
.