### PR TITLE
Update dev-guide's pre-commit documentation

### DIFF
--- a/doc/dev-guide.rst
+++ b/doc/dev-guide.rst
@@ -69,8 +69,8 @@ The installation and initialisation of the pre-commit flow is handled in
     This is in place in order to keep the code-base consistent so we can focus
     on the work at hand - rather than maintaining code readability and appearance.
 
-Initial Setup
-^^^^^^^^^^^^^
+Configuration Files
+^^^^^^^^^^^^^^^^^^^
 
 This repo contains the following configuration files for the pre-commit flow
 to monitor Python development.
@@ -92,8 +92,8 @@ to monitor Python development.
 
 .. _isort: https://pycqa.github.io/isort/
 
-Install Prerequisites
-^^^^^^^^^^^^^^^^^^^^^
+Installation Prerequisites
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Although :external+black:doc:`black <getting_started>`, :external+flake8:doc:`flake8 <user/index>`,
 :external+pydocstyle:doc:`pydocstyle <usage>` and :external+mypy:doc:`mypy <getting_started>`


### PR DESCRIPTION
Specifically with the README from @tyronevb's [python-pre-commit-workflow](https://github.com/tyronevb/python-pre-commit-workflow) repo.
It has been tweaked slightly to fit the document, but still pending review.

If you don't have a `.rst` preview extension handy, you might as well
`make -C doc html` in `katgpucbf`'s root directory and view the HTML
in your browser - or with vscode's native previewer (`Ctrl+K V`).

I've added you both more as a 'whoever gets to it first, please do'.

Resolves: NGC-672.