### PR TITLE
Improve accuracy of dsim timing

### DIFF
--- a/src/katgpucbf/dsim/main.py
+++ b/src/katgpucbf/dsim/main.py
@@ -212,13 +212,9 @@ async def async_main() -> None:
     timestamp = 0
     if args.sync_time is not None:
         timestamp, start_time = first_timestamp(args.sync_time, time.time(), args.adc_sample_rate, args.max_period)
-        # Sleep until start_time. Python doesn't seem to have an interface
-        # for sleeping until an absolute time, so this will be wrong by the
-        # time that elapsed from calling time.time until calling time.sleep,
-        # but that's small change.
-        await asyncio.sleep(max(0, start_time - time.time()))
     else:
         args.sync_time = time.time()
+        start_time = args.sync_time
     logger.info("First timestamp will be %#x", timestamp)
 
     # Set spead stream to have heap id in even numbers for dsim data.
@@ -248,6 +244,11 @@ async def async_main() -> None:
 
     add_signal_handlers(server)
 
+    # Sleep until start_time. Python doesn't seem to have an interface
+    # for sleeping until an absolute time, so this will be wrong by the
+    # time that elapsed from calling time.time until calling
+    # asyncio.sleep, but that's small change.
+    await asyncio.sleep(max(0, start_time - time.time()))
     logger.info("Starting transmission")
     await asyncio.gather(sender.run(), descriptor_task, server.join())
 


### PR DESCRIPTION
There are two changes:

1. The measurement is made more accurate. The previous approach compared
   the first timestamp of a bunch of samples to the time they were
   submitted for transmission, ignoring that there were other samples
   still in the queue for transmission. The new approach is to compare
   the completion time of transmission to timestamp of the end. This
   changed typical time_error_gauge values from -33ms to +5ms.
2. The sleep that's done before transmission starts is moved later to
   eliminate the skew from the time taken to start up the device server.
   This reduces time_error_gauge by 2-3ms.

This is somewhat related to NGC-625.
