### PR TITLE
Use full band in channel shape qualification test

### DIFF
--- a/qualification/antenna_channelised_voltage/test_channel_shape.py
+++ b/qualification/antenna_channelised_voltage/test_channel_shape.py
@@ -33,19 +33,25 @@ def _cutoff_interp(x0: float, y0: float, x1: float, y1: float, cutoff: float) ->
 def cutoff_bandwidth(data: np.ndarray, cutoff: float, step: float) -> float:
     """Measure width of the response at a given power level.
 
-    Estimate the width of the central portion where `data` is above `cutoff`,
-    in units of channels. If there are sidelobes that rise about `cutoff`,
-    they're included in the width. `step` is the step between samples.
+    Estimate the width of the region where `data` is above `cutoff`. If the
+    cutoff is crossed multiple times, the distance between the two most extreme
+    values is used.
+
+    The return value is in unit of channels, but the `data` may have sub-channel
+    resolution, with a step of `step` channels between samples.
     """
     above = np.nonzero(data >= cutoff)[0]
     assert len(above) > 0
+    # Minimum and maximum index that contain data above the cutoff
     left = above[0]
     right = above[-1]
+    # Use linear interpolation to find fractional index values where the
+    # cutoff is crossed.
     if left > 0:
         left = _cutoff_interp(left - 1, data[left - 1], left, data[left], cutoff)
     if right < len(data) - 1:
         right = _cutoff_interp(right + 1, data[right + 1], right, data[right], cutoff)
-    return (right - left) * step
+    return (right - left) * step  # Scale from indices to channels
 
 
 async def test_channel_shape(


### PR DESCRIPTION
Previously the test only considered the 5 channels around the input
tone. It now uses the whole band, and the 5-channel slice is used only
for the plot.

This required some small changes to the cutoff_bandwidth function to
remove the assumption that it is given centred data.