### PR TITLE
Add siunitx to the preamble for qual reports

### DIFF
--- a/qualification/report/preamble.tex
+++ b/qualification/report/preamble.tex
@@ -2,6 +2,7 @@
 \usepackage{mathtools}
 \usepackage{graphicx}
 \usepackage{fancybox}
+\usepackage[per-mode=symbol]{siunitx}
 
 \usepackage{tablefootnote}
 \usepackage{color}


### PR DESCRIPTION
This will let me use `\ang{1}` for 1 degree or
`\SI{75}{\micro\second}` for nice-looking units (in test docstrings).
