### PR TITLE
Update doc/conf.py with intersphinx links

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -75,6 +75,10 @@ intersphinx_mapping = {
     "spead2": ("https://spead2.readthedocs.io/en/latest", None),
     "katsdpsigproc": ("https://katsdpsigproc.readthedocs.io/en/latest", None),
     "katsdptelstate": ("https://katsdptelstate.readthedocs.io/en/latest", None),
+    "black": ("https://black.readthedocs.io/en/stable/", None),
+    "flake8": ("https://flake8.pycqa.org/en/latest/", None),
+    "pydocstyle": ("http://www.pydocstyle.org/en/stable/", None),
+    "mypy": ("https://mypy.readthedocs.io/en/stable/", None),
 }
 
 


### PR DESCRIPTION
Erroneously left out during PR #319 as during debugging and rebuilds I
must have populated the .inv's correctly - but those files do not live
in the repo itself (just the local directory).

I confirmed the update is working correctly by running a `make clean`
in the `doc/` directory, followed by a `make html` - no errors reported.

Resolves: NGC-672.