### PR TITLE
Ban delay model load times prior to SYNC_EPOCH

### DIFF
--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -90,7 +90,9 @@ async def test_delay_application_time(
 
         pdf_report.detail("Did not receive all the expected chunks; reset delay and try again.")
         delays = ["0,0:0,0", "0,0:0,0"] * receiver.n_ants
-        await correlator.product_controller_client.request("delays", "antenna_channelised_voltage", 0, *delays)
+        await correlator.product_controller_client.request(
+            "delays", "antenna_channelised_voltage", receiver.sync_time, *delays
+        )
     else:
         pytest.fail(f"Give up after {attempts} attempts.")
 
@@ -144,7 +146,9 @@ async def test_delay_enable_disable(
 
     async def set_delays(delays: List[str]) -> None:
         start = asyncio.get_running_loop().time()
-        await correlator.product_controller_client.request("delays", "antenna_channelised_voltage", 0, *delays)
+        await correlator.product_controller_client.request(
+            "delays", "antenna_channelised_voltage", receiver.sync_time, *delays
+        )
         finish = asyncio.get_running_loop().time()
         elapsed.append(finish - start)
 

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -372,8 +372,9 @@ async def correlator(
     for name, conf in session_correlator.config["outputs"].items():
         if conf["type"] == "gpucbf.antenna_channelised_voltage":
             n_inputs = len(conf["src_streams"])
+            sync_time = session_correlator.sensors[f"{name}-sync-time"].value
             await pcc.request("gain-all", name, "default")
-            await pcc.request("delays", name, 0, *(["0,0:0,0"] * n_inputs))
+            await pcc.request("delays", name, sync_time, *(["0,0:0,0"] * n_inputs))
         elif conf["type"] == "gpucbf.baseline_correlation_products":
             await pcc.request("capture-start", name)
 

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -509,7 +509,9 @@ class Engine(aiokatcp.DeviceServer):
         # of this delta and the delay_rate (same for phase).
         # This may be too small to be a concern, but if it is a concern,
         # then we'd need to compensate for that here.
-        start_sample_count = int((start_time - self.sync_epoch) * self.adc_sample_rate)
+        start_sample_count = round((start_time - self.sync_epoch) * self.adc_sample_rate)
+        if start_sample_count < 0:
+            raise aiokatcp.FailReply("Start time cannot be prior to the sync epoch")
 
         # Collect them in a temporary until they're all validated
         new_linear_models = []

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -771,7 +771,7 @@ class TestEngine:
         n_samples = 8 * CHUNK_SAMPLES
         dig_data = self._make_tone(n_samples, CW(frac_channel=0.5, magnitude=100), 0)
 
-        timestamp_list = self._patch_next_in(monkeypatch, engine_client, "delays", 0, "0,0:3,0", "0,0:3,0")
+        timestamp_list = self._patch_next_in(monkeypatch, engine_client, "delays", SYNC_EPOCH, "0,0:3,0", "0,0:3,0")
         out_data, timestamps = await self._send_data(
             mock_recv_streams,
             mock_send_stream,

--- a/test/fgpu/test_katcp_interface.py
+++ b/test/fgpu/test_katcp_interface.py
@@ -166,7 +166,7 @@ class TestKatcpRequests:
             await engine_client.request("gain-all")
 
     @pytest.mark.parametrize("correct_delay_strings", [("3.76e-9,0.12e-9:7.322,1.91", "2.67e-9,0.02e-9:5.678,1.81")])
-    async def test_delay_model_update_correct(self, engine_client, correct_delay_strings):
+    async def test_delay_model_update_correct(self, engine_server, engine_client, correct_delay_strings):
         """Test correctly-formed delay strings and validate the updates.
 
         The validation is done by comparing it against the corresponding delay sensor readings.
@@ -178,8 +178,13 @@ class TestKatcpRequests:
             phase, phase_rate = [float(value) for value in phase_str.split(",")]
             return delay, delay_rate, wrap_angle(phase), phase_rate
 
-        start_time = 0
+        start_time = SYNC_EPOCH
         await engine_client.request("delays", start_time, correct_delay_strings[0], correct_delay_strings[1])
+        # The delay model won't become current until some data is received, but
+        # we're not simulating any. Poke the delay model manually to make it
+        # update the sensor.
+        for model in engine_server.delay_models:
+            model(1)
 
         for pol in range(N_POLS):
             sensor_reading = await get_sensor(engine_client, f"input{pol}-delay")
@@ -216,10 +221,15 @@ class TestKatcpRequests:
             await engine_client.request("delays", "3.76,0.12:7.322,1.91")
         with pytest.raises(aiokatcp.FailReply):
             # Only one of the two models
-            await engine_client.request("delays", "123456789.0", "3.76,0.12:7.322,1.91")
+            await engine_client.request("delays", SYNC_EPOCH, "3.76,0.12:7.322,1.91")
 
     async def test_delay_model_update_too_many_arguments(self, engine_client):
         """Test that a delay request with too many arguments is rejected."""
         coeffs = "3.76,0.12:7.322,1.91"
         with pytest.raises(aiokatcp.FailReply):
-            await engine_client.request("delays", "123456789.0", coeffs, coeffs, coeffs)
+            await engine_client.request("delays", SYNC_EPOCH, coeffs, coeffs, coeffs)
+
+    async def test_delay_model_update_before_sync_epoch(self, engine_client):
+        """Test that a delay model loaded prior to the sync epoch is rejected."""
+        with pytest.raises(aiokatcp.FailReply):
+            await engine_client.request("delays", SYNC_EPOCH - 1.0, "0,0:0,0", "0,0:0,0")


### PR DESCRIPTION
Some tests were using a load time of 0 (Jan 1970), but this can lead to
numerical stability problems with delay and delay-rate (the product of
the rate and the elapsed time is enormous and when taken mod 2pi the
result has poor accuracy).

See NGC-698.