### PR TITLE
qual: make next_complete_chunk return data only

### DIFF
--- a/qualification/antenna_channelised_voltage/__init__.py
+++ b/qualification/antenna_channelised_voltage/__init__.py
@@ -118,11 +118,9 @@ async def sample_tone_response(
                 signal += tasks[i * N_POLS + j][1]
             requests.append(asyncio.create_task(receiver.correlator.dsim_clients[i].request("signals", signal)))
         await asyncio.gather(*requests)
-        _, chunk = await receiver.next_complete_chunk()
-        assert isinstance(chunk.data, np.ndarray)  # Keep mypy happy
+        _, data = await receiver.next_complete_chunk()
         for task, bl_idx in zip(tasks, autos):
-            out[task[0]] = chunk.data[:, bl_idx, 0]  # Only keep real part
-        receiver.stream.add_free_chunk(chunk)
+            out[task[0]] = data[:, bl_idx, 0]  # Only keep real part
 
     with np.nditer([freqs, amplitude], flags=["multi_index"]) as it:
         for f, a in it:

--- a/qualification/antenna_channelised_voltage/test_gain.py
+++ b/qualification/antenna_channelised_voltage/test_gain.py
@@ -48,11 +48,9 @@ async def test_gains(
     """
 
     async def next_chunk_data() -> NDArray[np.complex128]:
-        _, chunk = await receiver.next_complete_chunk()
-        assert isinstance(chunk.data, np.ndarray)  # Keeps mypy happy
+        _, chunk_data = await receiver.next_complete_chunk()
         # Turn 2-element axis into complex number
-        data = chunk.data.astype(np.float64).view(np.complex128)[..., 0]
-        receiver.stream.add_free_chunk(chunk)
+        data = chunk_data.astype(np.float64).view(np.complex128)[..., 0]
         return data
 
     receiver = receive_baseline_correlation_products

--- a/qualification/baseline_correlation_products/test_baselines.py
+++ b/qualification/baseline_correlation_products/test_baselines.py
@@ -89,13 +89,11 @@ async def test_baseline_correlation_products(
         for inp, g in gains.items():
             await pc_client.request("gain", "antenna_channelised_voltage", inp, *g)
 
-        _, chunk = await receiver.next_complete_chunk()
-        # This assert isn't particularly important, but keeps mypy happy.
-        assert isinstance(chunk.data, np.ndarray)
+        _, data = await receiver.next_complete_chunk()
         for i in range(start_idx, end_idx):
             channel = i - start_idx + 1
             bl = receiver.bls_ordering[i]
-            loud_bls = np.nonzero(chunk.data[channel, :, 0])[0]
+            loud_bls = np.nonzero(data[channel, :, 0])[0]
             pdf_report.detail(
                 f"Checking {bl}: {len(loud_bls)} baseline{'s' if len(loud_bls) != 1 else ''} "
                 f"had signal in {'them' if len(loud_bls) != 1 else 'it'}: {loud_bls}"
@@ -109,7 +107,6 @@ async def test_baseline_correlation_products(
                     is_signal_expected_in_baseline(bl, receiver.bls_ordering[loud_bl], pdf_report),
                     "Signal found in unexpected baseline.",
                 )
-        receiver.stream.add_free_chunk(chunk)
 
 
 def is_signal_expected_in_baseline(

--- a/qualification/baseline_correlation_products/test_consistency.py
+++ b/qualification/baseline_correlation_products/test_consistency.py
@@ -50,15 +50,13 @@ async def test_consistency(
     pdf_report.step("Collect two accumulations of data.")
     data = []
     for _ in range(2):
-        timestamp, chunk = await receiver.next_complete_chunk()
+        timestamp, chunk_data = await receiver.next_complete_chunk()
         pdf_report.detail(f"Received accumulation with timestamp {timestamp}")
-        assert isinstance(chunk.data, np.ndarray)
         # Separate axes into antenna baseline and Jones term. The dsim uses
         # different random dithers for the pols so we don't expect consistency
         # between Jones terms.
-        chunk_data = chunk.data.reshape(chunk.data.shape[0], -1, 4, 2)
-        data.append(chunk_data.copy())  # Copy since we've returning the chunk
-        receiver.stream.add_free_chunk(chunk)
+        chunk_data = chunk_data.reshape(chunk_data.shape[0], -1, 4, 2)
+        data.append(chunk_data)
 
     pdf_report.step("Verify consistency")
     expected = data[0][:, 0:1, ...].repeat(data[0].shape[1], axis=1)

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -414,7 +414,6 @@ async def receive_baseline_correlation_products(
     # Ensure that the data is flowing, and that we throw away any data that
     # predates the start of this test (to prevent any state leaks from previous
     # tests).
-    _, chunk = await receiver.next_complete_chunk(max_delay=0)
-    receiver.stream.add_free_chunk(chunk)
+    await receiver.next_complete_chunk(max_delay=0)
     yield receiver
     receiver.stream.stop()


### PR DESCRIPTION
Instead of returning the chunk, it returns a copy of the data and
immediately returns the chunk to the stream. This simplifies a lot of
code that uses this function.

There will be some performance impact from copying the data, but
generally the tests do not contain performance-critical code immediately
after receiving the chunk.

Closes NGC-703