### PR TITLE
Use annotations to match requirements to qual tests

### DIFF
--- a/qualification/antenna_channelised_voltage/test_channel_shape.py
+++ b/qualification/antenna_channelised_voltage/test_channel_shape.py
@@ -17,6 +17,7 @@
 """Channel shape tests."""
 
 import numpy as np
+import pytest
 from matplotlib.figure import Figure
 from numpy.typing import ArrayLike
 
@@ -54,20 +55,14 @@ def cutoff_bandwidth(data: np.ndarray, cutoff: float, step: float) -> float:
     return (right - left) * step  # Scale from indices to channels
 
 
+@pytest.mark.requirements("CBF-REQ-0126")
 async def test_channel_shape(
     correlator: CorrelatorRemoteControl,
     receive_baseline_correlation_products: BaselineCorrelationProductsReceiver,
     pdf_report: Reporter,
     expect,
 ) -> None:
-    r"""Test the shape of the response to a single channel.
-
-    Requirements verified:
-
-    CBF-REQ-0126
-        The CBF shall perform channelisation such that the 53 dB attenuation bandwidth
-        is :math:`\le 2\times` (twice) the pass band width.
-    """
+    """Test the shape of the response to a single channel."""
     receiver = receive_baseline_correlation_products
     # Arbitrary channel, not too near the edges
     base_channel = receiver.n_chans // 3

--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -39,6 +39,7 @@ MAX_DELAY_RATE = 1.9e-9
 MAX_PHASE_RATE = 186.13  # rad/second
 
 
+@pytest.mark.requirements("CBF-REQ-0077")
 async def test_delay_application_time(
     correlator: CorrelatorRemoteControl,
     receive_baseline_correlation_products: BaselineCorrelationProductsReceiver,
@@ -47,17 +48,8 @@ async def test_delay_application_time(
 ) -> None:
     """Test that delay/phase changes are applied at the correct time.
 
-    Requirements verified:
-
-    CBF-REQ-0077
-        The CBF shall delay execution of Continuous Parameter Control commands until
-        a UTC time, as received on the CAM interface, with an execution time
-        accuracy of <= 10 ms, provided the command is received at least 200ms
-        before the execution time, and the execution time delay is no more than
-        2 seconds.
-
-    Verification method:
-
+    Verification method
+    -------------------
     Verification by means of test. A 90 degree phase change is loaded for one
     polarisation at a chosen time. The actual application time is estimated by
     checking the ratio of real to imaginary components in the corresponding
@@ -116,6 +108,7 @@ async def test_delay_application_time(
     expect(delta < 0.01)
 
 
+@pytest.mark.requirements("CBF-REQ-0066,CBF-REQ-0110,CBF-REQ-0200")
 async def test_delay_enable_disable(
     correlator: CorrelatorRemoteControl,
     receive_baseline_correlation_products: BaselineCorrelationProductsReceiver,
@@ -124,22 +117,8 @@ async def test_delay_enable_disable(
 ) -> None:
     """Test that delay and phase compensation can be enabled and disabled.
 
-    Requirements verified:
-
-    CBF-REQ-0066
-        The CBF shall, on request via the CAM interface, enable or disable
-        delay compensation.
-
-    CBF-REQ-0110
-        The CBF shall, on request via the CAM interface, enable or disable
-        phase compensation.
-
-    CBF-REQ-0200
-        The CBF shall receive and apply a complete set of phase-up coefficients
-        from SP at a rate of up to once a second.
-
-    Verification method:
-
+    Verification method
+    -------------------
     Verified by means of test. Insert a signal with a tone. Enable delay/phase
     compensation and check that it is applied, then disable and check again.
     Check that all requests complete within 1s.
@@ -210,10 +189,8 @@ async def test_delay_sensors(
 ) -> None:
     r"""Test that delay sensors work correctly.
 
-    Requirements verified: none
-
-    Verification method:
-
+    Verification method
+    -------------------
     Verified by test. Load a set of random delays with a load time in the
     future. Once that time arrives, check that the sensors report the correct
     values.
@@ -253,6 +230,7 @@ async def test_delay_sensors(
         expect(value == pytest.approx(expected, rel=1e-9), f"Delay sensor for {label} has incorrect value")
 
 
+@pytest.mark.requirements("CBF-REQ-0128,CBF-REQ-0185")
 async def test_delay(
     correlator: CorrelatorRemoteControl,
     receive_baseline_correlation_products: BaselineCorrelationProductsReceiver,
@@ -261,27 +239,8 @@ async def test_delay(
 ) -> None:
     r"""Test performance of delay compensation.
 
-    Requirements verified:
-
-    CBF-REQ-0128
-        The CBF shall have an overall per-antenna phase error of
-        :math:`\le \ang{1}` RMS for correlation products, including
-        quantisation effects and imperfect phase tracking.
-
-    CBF-REQ-0185
-        The CBF shall apply the delay polynomial, as provided via the CAM
-        interface, with the following criteria:
-
-        1. range of delay: 0 to :math:`\ge \SI{75}{\micro\second}`.
-        2. resolution of delay: :math:`\le \SI{2.5}{\pico\second}`.
-        3. range of rate of change of delay:
-           :math:`\le \SI{500}{\pico\second\per\second}` to
-           :math:`\ge \SI{1.9}{\nano\second\per\second}`.
-        4. resolution of rate of change of delay:
-           :math:`\le \SI{2.5}{\pico\second\per\second}`.
-
-    Verification method:
-
+    Verification method
+    -------------------
     Verified by test. Set a variety of delays on different inputs. Delay the
     corresponding dsim signal by the same amount, rounded to the nearest 8
     samples. Check that the resulting phases are within :math:`\ang{1}` degree

--- a/qualification/antenna_channelised_voltage/test_gain.py
+++ b/qualification/antenna_channelised_voltage/test_gain.py
@@ -19,12 +19,14 @@
 import asyncio
 
 import numpy as np
+import pytest
 from numpy.typing import NDArray
 
 from .. import BaselineCorrelationProductsReceiver, CorrelatorRemoteControl, get_sensor_val
 from ..reporter import Reporter
 
 
+@pytest.mark.requirements("CBF-REQ-0119")
 async def test_gains(
     correlator: CorrelatorRemoteControl,
     receive_baseline_correlation_products: BaselineCorrelationProductsReceiver,
@@ -33,15 +35,8 @@ async def test_gains(
 ) -> None:
     r"""Test that gains can be applied.
 
-    Requirements verified:
-
-    CBF-REQ-0119
-        The CBF shall apply gain correction per antenna, per polarisation, per
-        frequency channel with a range of at least :math:`\pm 6` dB and
-        a resolution of :math:`\le 1` dB.
-
-    Verification method:
-
+    Verification method
+    -------------------
     Verified by test. A repeating white noise signal is injected and the
     response measured with the default gains. The gain is then changed to a
     random set of gains, and the response is compared to this.

--- a/qualification/antenna_channelised_voltage/test_linearity.py
+++ b/qualification/antenna_channelised_voltage/test_linearity.py
@@ -30,11 +30,8 @@ async def test_linearity(
 ) -> None:
     """Test that baseline Correlation Products are linear when input CW is scaled.
 
-    Requirements verified:
-        CBF.V.A.IF: CBF Linearity
-
-    Verification method:
-
+    Verification method
+    -------------------
     Verify linearity by checking the channelised output scales linearly with a
     linear change to the CW input amplitude.
     """

--- a/qualification/baseline_correlation_products/test_accum_length.py
+++ b/qualification/baseline_correlation_products/test_accum_length.py
@@ -26,6 +26,7 @@ from .. import BaselineCorrelationProductsReceiver, CorrelatorRemoteControl
 from ..reporter import Reporter
 
 
+@pytest.mark.requirements("CBF-REQ-0096")
 async def test_accum_length(
     correlator: CorrelatorRemoteControl,
     receive_baseline_correlation_products: BaselineCorrelationProductsReceiver,
@@ -34,15 +35,8 @@ async def test_accum_length(
 ) -> None:
     """Test that accumulations are set to the correct length.
 
-    Requirements verified:
-
-    CBF-REQ-0096
-        The CBF shall set the Baseline Correlation Products accumulation
-        interval to 500ms. The minimum permissible accumulation interval is
-        480ms.
-
-    Verification method:
-
+    Verification method
+    -------------------
     Verify by testing that the accumulation interval is within specification
     when set to 500ms. Inject a noise signal and check that the measured
     signal has the expected power.

--- a/qualification/baseline_correlation_products/test_baselines.py
+++ b/qualification/baseline_correlation_products/test_baselines.py
@@ -19,11 +19,13 @@
 from typing import Tuple
 
 import numpy as np
+import pytest
 
 from .. import BaselineCorrelationProductsReceiver, CorrelatorRemoteControl
 from ..reporter import Reporter
 
 
+@pytest.mark.requirements("CBF-REQ-0087,CBF-REQ-0104")
 async def test_baseline_correlation_products(
     correlator: CorrelatorRemoteControl,
     receive_baseline_correlation_products: BaselineCorrelationProductsReceiver,
@@ -32,22 +34,8 @@ async def test_baseline_correlation_products(
 ) -> None:
     """Test that the baseline ordering indicated in the sensor matches the output data.
 
-    Requirements verified:
-
-    CBF-REQ-0087
-        The CBF shall, on request via the CAM interface, compute all cross-
-        correlation and auto-correlation products for all configured baselines
-        in each defined sub-array.
-
-    CBF-REQ-0104
-        The CBF, when requested to produce the Baseline Correlation Products
-        data product, shall transfer the appropriate data continuously to the
-        subscribed user(s) via the interface as specified in the appropriate
-        ICD.
-
-
-    Verification method:
-
+    Verification method
+    -------------------
     Verification by means of test. Verify by testing all correlation product
     combinations. Use gain correction after channelisation to turn the input
     signal on or off. Iterate through all combinations and verify that the

--- a/qualification/baseline_correlation_products/test_consistency.py
+++ b/qualification/baseline_correlation_products/test_consistency.py
@@ -30,8 +30,8 @@ async def test_consistency(
 ) -> None:
     """Test that repeated calculations give consistent results.
 
-    Verification method:
-
+    Verification method
+    -------------------
     Provide the same simulated digitiser data to every antenna, with a
     period that divides into the accumulation length. Verify that every
     baseline produces the same bit-wise output, and that two successive

--- a/qualification/demo.py
+++ b/qualification/demo.py
@@ -17,14 +17,20 @@
 """Example tests helpful in developing the reporting framework."""
 
 import matplotlib.figure
+import pytest
 
 from .reporter import Reporter
 
 
+@pytest.mark.requirements("DEMO-000")
 def test_passes(pdf_report: Reporter) -> None:
     r"""Pass the test.
 
     Here is some maths: :math:`e^{\pi j} + 1 = 0`.
+
+    Verification method
+    -------------------
+    Don't actually test anything.
     """
     pdf_report.step("Do things")
     pdf_report.detail("Thing implementation detail 1")

--- a/qualification/report/requirements_text/CBF-REQ-0066.tex
+++ b/qualification/report/requirements_text/CBF-REQ-0066.tex
@@ -1,0 +1,2 @@
+The CBF shall, on request via the CAM interface, enable or disable delay
+compensation.

--- a/qualification/report/requirements_text/CBF-REQ-0077.tex
+++ b/qualification/report/requirements_text/CBF-REQ-0077.tex
@@ -1,0 +1,5 @@
+The CBF shall delay execution of Continuous Parameter Control commands until
+a UTC time, as received on the CAM interface, with an execution time
+accuracy of $\le$ 10 ms, provided the command is received at least 200ms
+before the execution time, and the execution time delay is no more than
+2 seconds.

--- a/qualification/report/requirements_text/CBF-REQ-0087.tex
+++ b/qualification/report/requirements_text/CBF-REQ-0087.tex
@@ -1,0 +1,3 @@
+The CBF shall, on request via the CAM interface, compute all cross-correlation
+and auto-correlation products for all configured baselines in each defined
+sub-array.

--- a/qualification/report/requirements_text/CBF-REQ-0096.tex
+++ b/qualification/report/requirements_text/CBF-REQ-0096.tex
@@ -1,0 +1,2 @@
+The CBF shall set the Baseline Correlation Products accumulation interval to
+500ms. The minimum permissible accumulation interval is 480ms.

--- a/qualification/report/requirements_text/CBF-REQ-0104.tex
+++ b/qualification/report/requirements_text/CBF-REQ-0104.tex
@@ -1,0 +1,4 @@
+The CBF, when requested to produce the Baseline Correlation Products
+data product, shall transfer the appropriate data continuously to the
+subscribed user(s) via the interface as specified in the appropriate
+ICD.

--- a/qualification/report/requirements_text/CBF-REQ-0110.tex
+++ b/qualification/report/requirements_text/CBF-REQ-0110.tex
@@ -1,0 +1,2 @@
+The CBF shall, on request via the CAM interface, enable or disable phase
+compensation.

--- a/qualification/report/requirements_text/CBF-REQ-0119.tex
+++ b/qualification/report/requirements_text/CBF-REQ-0119.tex
@@ -1,0 +1,3 @@
+The CBF shall apply gain correction per antenna, per polarisation, per
+frequency channel with a range of at least $\pm 6$ dB and a resolution of $\le
+1$ dB.

--- a/qualification/report/requirements_text/CBF-REQ-0126.tex
+++ b/qualification/report/requirements_text/CBF-REQ-0126.tex
@@ -1,0 +1,2 @@
+The CBF shall perform channelisation such that the 53 dB attenuation
+bandwidth is $\le 2\times$ (twice) the pass band width.

--- a/qualification/report/requirements_text/CBF-REQ-0128.tex
+++ b/qualification/report/requirements_text/CBF-REQ-0128.tex
@@ -1,0 +1,3 @@
+The CBF shall have an overall per-antenna phase error of $\le \ang{1}$ RMS for
+correlation products, including quantisation effects and imperfect phase
+tracking.

--- a/qualification/report/requirements_text/CBF-REQ-0185.tex
+++ b/qualification/report/requirements_text/CBF-REQ-0185.tex
@@ -1,0 +1,11 @@
+The CBF shall apply the delay polynomial, as provided via the CAM
+interface, with the following criteria:
+\begin{enumerate}
+\item range of delay: 0 to $\ge \SI{75}{\micro\second}$.
+\item resolution of delay: $\le \SI{2.5}{\pico\second}$.
+\item range of rate of change of delay:
+$\le \SI{500}{\pico\second\per\second}$ to
+$\ge \SI{1.9}{\nano\second\per\second}$.
+\item resolution of rate of change of delay:
+$\le \SI{2.5}{\pico\second\per\second}$.
+\end{enumerate}

--- a/qualification/report/requirements_text/CBF-REQ-0200.tex
+++ b/qualification/report/requirements_text/CBF-REQ-0200.tex
@@ -1,0 +1,2 @@
+The CBF shall receive and apply a complete set of phase-up coefficients from
+SP at a rate of up to once a second.

--- a/qualification/report/requirements_text/DEMO-000.tex
+++ b/qualification/report/requirements_text/DEMO-000.tex
@@ -1,0 +1,1 @@
+Example of some requirement text.


### PR DESCRIPTION
Instead of putting requirements as text in the docstring of each test,
use `pytest.mark.requirements` with a list of requirements. The report
generator pulls requirements for requirements_text/{requirement}.tex to
populate the report. In future this will allow us to programmatically
determine which requirements have tests.

The report generation now also maps top-level sections in the test
docstrings to subsubsectios in LaTeX, making them usable. The
"verification method" of each test is now made into a section.

Closes NGC-702.