### PR TITLE
qual: update existing tests with new delay requirements

### DIFF
--- a/qualification/report/requirements_text/CBF-REQ-0185.tex
+++ b/qualification/report/requirements_text/CBF-REQ-0185.tex
@@ -1,11 +1,11 @@
 The CBF shall apply the delay polynomial, as provided via the CAM
 interface, with the following criteria:
 \begin{enumerate}
-\item range of delay: 0 to $\ge \SI{75}{\micro\second}$.
+\item range of delay: 0 to $\ge \SI{79.53}{\micro\second}$.
 \item resolution of delay: $\le \SI{2.5}{\pico\second}$.
 \item range of rate of change of delay:
-$\le \SI{500}{\pico\second\per\second}$ to
-$\ge \SI{1.9}{\nano\second\per\second}$.
+$\le \SI{-2.56}{\nano\second\per\second}$ to
+$\ge \SI{2.56}{\nano\second\per\second}$.
 \item resolution of rate of change of delay:
 $\le \SI{2.5}{\pico\second\per\second}$.
 \end{enumerate}

--- a/qualification/report/requirements_text/CBF-REQ-0187.tex
+++ b/qualification/report/requirements_text/CBF-REQ-0187.tex
@@ -1,0 +1,4 @@
+The CBF shall compute and add delay compensation per antenna at a rate of $\ge
+\SI{2500}{\hertz}$ using a first order phase tracking polynomial with
+coefficients as received via the CAM interface, with polynomial coefficients
+updated at a rate of $\ge \SI{0.167}{\hertz}.$

--- a/qualification/report/requirements_text/CBF-REQ-0188.tex
+++ b/qualification/report/requirements_text/CBF-REQ-0188.tex
@@ -1,0 +1,4 @@
+The CBF shall compute and add phase compensation per antenna, per frequency
+channel, at a rate of $\ge \SI{2500}{\hertz}$ using a first order phase
+tracking polynomial with coefficients as received via the CAM interface, with
+polynomial coefficients updated at a rate of $\ge \SI{0.167}{\hertz}.$


### PR DESCRIPTION
Update the requirements to match MeerKAT Extension Delay Compensation
Requirements revision E. Also
- Fix a mis-linked requirement to CBF-REQ-0200 which should have been
  to 0187/0188.
- Add a test for the update rate part of 0187/0188, just so that the
  requirement is fully tested.

Relates to NGC-626.