### PR TITLE
Introduce rudimentary pytest.ini validation

### DIFF
--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
 
 
-# Storeing ini options this way makes pytest.ini easier to validate up-front.
+# Storing ini options this way makes pytest.ini easier to validate up-front.
 IniOption = namedtuple("IniOption", ["name", "help", "type", "default"], defaults=[None])
 ini_options = [
     IniOption(


### PR DESCRIPTION
I previously just `assert`ed just-in-time on the output of
`config.getini()`, but the problem with that was you could start up a
big correlator and only then discover oops, I don't know what my
`interface` name is, which wastes a whole lot of time.

This way, if something isn't there that should be, it fails immediately.
A weakness (which I don't think can be solved without getting more
complex than it's worth) is that if the configuration options are all
there, this doesn't check whether they're actually any good, so you
could have something like `interface=foo` and it'll happily get going
until it reaches the point where it can't read from the `foo` interface
because it doesn't exist.

But this seems low-risk to me.

Further nails in the coffin of NGC-701.