### PR TITLE
qual report: use DCGM_FI_DEV_FB_TOTAL for GPU info

### DIFF
--- a/qualification/host_config.py
+++ b/qualification/host_config.py
@@ -21,7 +21,7 @@ from typing import Optional, Set
 from prometheus_api_client.prometheus_connect import PrometheusConnect
 
 QUERIES = [
-    'dcgm_exporter_info{instance="%h"}',
+    'DCGM_FI_DEV_FB_TOTAL{instance="%h"}',
     'node_cpu_info{instance="%h", cpu="0"}',
     'node_dmi_info{instance="%h"}',
     'node_ethtool_info{instance="%h"}',

--- a/qualification/report/generate_pdf.py
+++ b/qualification/report/generate_pdf.py
@@ -175,6 +175,7 @@ class GPU:
     driver: str
     vbios: str
     bus_id: str
+    ram: int
 
 
 @dataclass(frozen=True)
@@ -269,14 +270,16 @@ def _parse_interface(labels: dict) -> Interface:
     )
 
 
-def _parse_gpu(labels: dict) -> GPU:
-    """Parse a single GPU from ``dcgm_exporter_info`` labels."""
+def _parse_gpu(labels: dict, fb_total: float) -> GPU:
+    """Parse a single GPU from the DCGM_FI_DEV_FB_TOTAL metric."""
     return GPU(
         number=int(labels["gpu"]),
         model_name=labels["modelName"],
         driver=labels.get("DCGM_FI_DRIVER_VERSION", UNKNOWN),
         vbios=labels.get("DCGM_FI_DEV_VBIOS_VERSION", UNKNOWN),
         bus_id=labels.get("DCGM_FI_DEV_PCI_BUSID", UNKNOWN),
+        # Documentation says "MB", but using 10**6 leads to a "12GB" GPU only having 11.2 GiB
+        ram=round(fb_total * 1024**2),
     )
 
 
@@ -305,8 +308,8 @@ def _parse_host(msg: dict) -> Tuple[str, Host]:
             ram = int(value)
         elif metric_name == "node_ethtool_info":
             interfaces.append(_parse_interface(labels))
-        elif metric_name == "dcgm_exporter_info":
-            gpus.append(_parse_gpu(labels))
+        elif metric_name == "DCGM_FI_DEV_FB_TOTAL":
+            gpus.append(_parse_gpu(labels, value))
         elif metric_name == "node_uname_info":
             kernel = " ".join([labels["sysname"], labels["release"], labels["version"]])
     interfaces.sort(key=lambda interface: interface.name)
@@ -506,6 +509,7 @@ def _doc_hosts(section: Container, hosts: Mapping[Host, Sequence[str]]) -> None:
                 host_table.add_row("Driver", gpu.driver)
                 host_table.add_row("VBIOS", gpu.vbios)
                 host_table.add_row("Bus ID", gpu.bus_id)
+                host_table.add_row("RAM", f"{gpu.ram / 2**30:.0f} GiB")
                 host_table.add_hline()
 
 


### PR DESCRIPTION
The dcgm-exporter image used has been updated to follow the final
resolution of https://github.com/NVIDIA/dcgm-exporter/issues/72, in
which labels are attached to existing metrics rather than a new
`dcgm_exporter_info` metric. This updates the qualification report to
use the DCGM_FI_DEV_FB_TOTAL metric, and as a side benefit, report the
amount of the RAM on the GPU.