### PR TITLE
Compact some three-line one-element lists

### DIFF
--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -130,9 +130,7 @@ def n_dsims():  # noqa: D401
 
 @pytest.fixture(
     scope="package",
-    params=[
-        8192,
-    ],
+    params=[8192],
 )
 def n_channels(request):  # noqa: D401
     """Number of channels for the channeliser."""
@@ -141,9 +139,7 @@ def n_channels(request):  # noqa: D401
 
 @pytest.fixture(
     scope="package",
-    params=[
-        "l",
-    ],
+    params=["l"],
 )
 def band(request) -> str:  # noqa: D104
     """Band ID."""

--- a/test/xbgpu/test_recv.py
+++ b/test/xbgpu/test_recv.py
@@ -93,9 +93,7 @@ def send_stream(queue) -> "spead2.send.asyncio.AsyncStream":
     config = spead2.send.StreamConfig(max_packet_size=9000)
     return spead2.send.asyncio.InprocStream(
         spead2.ThreadPool(),
-        [
-            queue,
-        ],
+        [queue],
         config,
     )
 


### PR DESCRIPTION
Change
```
[
    "foo",
]
```
to
```
["foo"]
```

Closes NGC-738.
