### PR TITLE
Use mathjax for equations in Sphinx

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -52,13 +52,14 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.graphviz",
-    "sphinx.ext.imgmath",
+    "sphinx.ext.mathjax",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
     "sphinxcontrib.tikz",
     "sphinxcontrib.bibtex",
+    "sphinx-mathjax-offline",
 ]
 
 
@@ -120,3 +121,7 @@ todo_include_todos = True
 # Adds \usetikzlibrary{...} to the latex preamble. We need "chains" for
 # rendering flowcharts.
 tikz_tikzlibraries = "chains"
+
+# Force MathJax to render as SVG rather than CHTML, to work around
+# https://github.com/mathjax/MathJax/issues/2701
+mathjax3_config = {"loader": {"load": ["input/tex", "output/svg"]}, "startup": {"output": "svg"}}

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -14,5 +14,6 @@ pytest-mock
 pytest-xdist  # Allows for pytest to launch multiple threads
 sphinx
 sphinx-rtd-theme
+sphinx-mathjax-offline
 sphinxcontrib-bibtex
 sphinxcontrib-tikz

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -189,9 +189,12 @@ snowballstemmer==2.2.0
 sphinx==5.0.2
     # via
     #   -r requirements-dev.in
+    #   sphinx-mathjax-offline
     #   sphinx-rtd-theme
     #   sphinxcontrib-bibtex
     #   sphinxcontrib-tikz
+sphinx-mathjax-offline==0.0.1
+    # via -r requirements-dev.in
 sphinx-rtd-theme==1.0.0
     # via -r requirements-dev.in
 sphinxcontrib-applehelp==1.0.2


### PR DESCRIPTION
It uses sphinx-mathjax-offline so that the rendered documents can be
viewed offline.
