### PR TITLE
Place tick labels at power-of-two intervals

### DIFF
--- a/qualification/antenna_channelised_voltage/test_channel.py
+++ b/qualification/antenna_channelised_voltage/test_channel.py
@@ -23,7 +23,7 @@ import pytest
 from matplotlib.figure import Figure
 
 from .. import BaselineCorrelationProductsReceiver, CorrelatorRemoteControl
-from ..reporter import Reporter
+from ..reporter import POTLocator, Reporter
 from . import sample_tone_response_hdr
 
 
@@ -134,7 +134,6 @@ async def test_channelisation_and_sfdr(
     plot_channel = rel_freqs[selected_plot_idx]
     pdf_report.step(f"SFDR plot for base channel {plot_channel}.")
 
-    xticks = np.linspace(0, receiver.n_chans, 9)
     ymin = -100
     title = f"SFDR for channel {plot_channel}"
     x = np.linspace(0, receiver.n_chans - 1, len(hdr_data_db[selected_plot_idx, :]))
@@ -146,13 +145,13 @@ async def test_channelisation_and_sfdr(
     ax.set_title(title)
     ax.set_xlabel("Channel")
     ax.set_ylabel("dB")
-    ax.set_xticks(xticks)
+    ax.xaxis.set_major_locator(POTLocator())
     ax.set_ylim(ymin, -0.05 * ymin)
     if ymin < -required_sfdr_db:
         ax.axhline(-required_sfdr_db, dashes=(1, 1), color="black")
         ax.annotate(
             f"{-required_sfdr_db} dB",
-            (xticks[-1], -required_sfdr_db),
+            (0, -required_sfdr_db),
             xytext=(-3, -3),
             textcoords="offset points",
             horizontalalignment="right",

--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -29,7 +29,7 @@ from katgpucbf import BYTE_BITS, N_POLS
 from katgpucbf.fgpu.delay import wrap_angle
 
 from .. import BaselineCorrelationProductsReceiver, CorrelatorRemoteControl, get_sensor_val
-from ..reporter import Reporter
+from ..reporter import POTLocator, Reporter
 from . import compute_tone_gain
 
 MAX_DELAY = 79.53e-6  # seconds
@@ -279,6 +279,7 @@ def check_phases(
     ax.set_title(f"Phase with {caption}")
     ax.set_xlabel("Channel")
     ax.set_ylabel("Phase (degrees)")
+    ax.xaxis.set_major_locator(POTLocator())
     # It's very noisy, and a thinner linewidth allows more detail to be seen
     ax.plot(x, np.rad2deg(wrap_angle(actual)), linewidth=0.3, label="Actual")
     ax.plot(x, np.rad2deg(wrap_angle(expected)), linewidth=0.3, label="Expected")
@@ -287,6 +288,7 @@ def check_phases(
     ax_err.set_title(f"Phase error with {caption}")
     ax_err.set_xlabel("Channel")
     ax_err.set_ylabel("Error (degrees)")
+    ax_err.xaxis.set_major_locator(POTLocator())
     ax_err.plot(x, np.rad2deg(delta), linewidth=0.3)
 
     pdf_report.figure(fig)

--- a/qualification/baseline_correlation_products/test_consistency.py
+++ b/qualification/baseline_correlation_products/test_consistency.py
@@ -20,7 +20,7 @@ import matplotlib.figure
 import numpy as np
 
 from .. import BaselineCorrelationProductsReceiver, CorrelatorRemoteControl, get_sensor_val
-from ..reporter import Reporter
+from ..reporter import POTLocator, Reporter
 
 
 async def test_consistency(
@@ -73,4 +73,5 @@ async def test_consistency(
     ax.set_title("Power")
     ax.set_xlabel("Channel")
     ax.set_ylabel("dBfs")
+    ax.xaxis.set_major_locator(POTLocator())
     pdf_report.figure(fig)

--- a/qualification/demo.py
+++ b/qualification/demo.py
@@ -17,9 +17,10 @@
 """Example tests helpful in developing the reporting framework."""
 
 import matplotlib.figure
+import numpy as np
 import pytest
 
-from .reporter import Reporter
+from .reporter import POTLocator, Reporter
 
 
 @pytest.mark.requirements("DEMO-000")
@@ -51,7 +52,8 @@ def test_figure(pdf_report: Reporter) -> None:
     ax.set_xlabel("X axis")
     ax.set_ylabel("Y axis")
     ax.set_title("Caption")
-    ax.plot([1, 3, 4], [2, 6, 3], label="A line")
+    ax.xaxis.set_major_locator(POTLocator())
+    ax.plot(np.sin(np.arange(1024) * 2 * np.pi / 1024), label="sine wave")
     ax.legend()
 
     pdf_report.step("Show a figure")


### PR DESCRIPTION
For plots showing the whole spectrum. This makes it easy to see features
like the centre channel.

Closes NGC-745.
