### PR TITLE
Avoid artificially limiting ringbuffer capacity

### DIFF
--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -550,8 +550,8 @@ class Engine(aiokatcp.DeviceServer):
 
     def _init_recv(self, src_affinity: List[int], monitor: Monitor) -> None:
         """Initialise the receive side of the engine."""
-        ringbuffer_capacity = 2
         src_chunks_per_stream = 4
+        ringbuffer_capacity = src_chunks_per_stream * N_POLS
 
         for _ in range(self._in_free_queue.maxsize):
             self._in_free_queue.put_nowait(


### PR DESCRIPTION
For some reason fgpu limited the data ringbuffer to 2 chunks. Enlarge it
so that we don't unnecessarily block the receiving thread if downstream
tasks transiently fall behind.

Helps with but does not entirely fix NGC-749.
