### PR TITLE
Increase --src-buffer for fgpu

### DIFF
--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -121,9 +121,9 @@ def parse_args(arglist: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--src-buffer",
         type=int,
-        default=32 * 1024 * 1024,
+        default=64 * 1024 * 1024,
         metavar="BYTES",
-        help="Size of network receive buffer (per pol) [32MiB]",
+        help="Size of network receive buffer (per pol) [64MiB]",
     )
     parser.add_argument(
         "--dst-interface", type=get_interface_address, required=True, help="Name of output network device"


### PR DESCRIPTION
Combined with #391 this makes things stable at 1.75 GHz sampling rate on
our lab hardware.

Closes NGC-749.
