### PR TITLE
Update setup.cfg for doc-only installation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
     katsdpsigproc>=1.4.1
     katsdptelstate
     numba
-    numpy<1.23
+    numpy
     prometheus-async[aiohttp]
     prometheus-client>=0.4  # First version to auto-append _total to counter names
     pyparsing>=3.0.0
@@ -36,7 +36,6 @@ gpu =
     katsdpsigproc[CUDA]
 
 doc =
-    docutils<0.18
     sphinx
     sphinx-rtd-theme
     sphinxcontrib-bibtex


### PR DESCRIPTION
Some library versions needed to be limited due to Errors seen when making the initial additions, e.g.
```bash
ERROR: numba 0.56.0 has requirement numpy<1.23,>=1.18, but you will have numpy 1.23.2 which is incompatible.
ERROR: sphinx-rtd-theme 1.0.0 has requirement docutils<0.18, but you will have docutils 0.19 which is incompatible.
```

Let me know if those version limits aren't necessary and I'll remove accordingly.