### PR TITLE
Add scratch config to run 8 instances of fgpu

### DIFF
--- a/scratch/fgpu/config/ska2.sh
+++ b/scratch/fgpu/config/ska2.sh
@@ -1,0 +1,9 @@
+iface1=enp193s0f0np0
+iface2=enp193s0f1np1
+iface3=enp4s0f0np0
+iface4=enp4s0f1np1
+
+cuda1=0
+cuda2=0
+cuda3=1
+cuda4=1

--- a/scratch/fgpu/run-fgpu-4.yaml
+++ b/scratch/fgpu/run-fgpu-4.yaml
@@ -1,4 +1,4 @@
-session_name: stress
+session_name: fgpu-4
 windows:
     - window_name: window
       layout: tiled

--- a/scratch/fgpu/run-fgpu-8.yaml
+++ b/scratch/fgpu/run-fgpu-8.yaml
@@ -1,0 +1,18 @@
+# Uses two windows because tmux gives an error about insufficient space
+# if one tries to do it in a single pane.
+session_name: fgpu-8
+windows:
+    - window_name: window1
+      layout: tiled
+      panes:
+          - ./run-fgpu.sh 0 --use-vkgdr --use-peerdirect
+          - ./run-fgpu.sh 1 --use-vkgdr --use-peerdirect
+          - ./run-fgpu.sh 2 --use-vkgdr --use-peerdirect
+          - ./run-fgpu.sh 3 --use-vkgdr --use-peerdirect
+    - window_name: window2
+      layout: tiled
+      panes:
+          - ./run-fgpu.sh 4 --use-vkgdr --use-peerdirect
+          - ./run-fgpu.sh 5 --use-vkgdr --use-peerdirect
+          - ./run-fgpu.sh 6 --use-vkgdr --use-peerdirect
+          - ./run-fgpu.sh 7 --use-vkgdr --use-peerdirect

--- a/scratch/fgpu/run-fgpu.sh
+++ b/scratch/fgpu/run-fgpu.sh
@@ -5,8 +5,9 @@ set -e -u
 # Load variables for machine-specific config
 . config/$(hostname -s).sh
 
+nodes=$(lscpu | grep 'NUMA node.*CPU' | wc -l)
 nproc=$(nproc)
-step=$(($nproc / 4))
+step=$(($nproc / $nodes))
 hstep=$(($step / 2))
 
 src_affinity="$(($step*$1)),$(($step*$1+1))"
@@ -29,8 +30,16 @@ case "$1" in
         iface="$iface2"
         export CUDA_VISIBLE_DEVICES="$cuda2"
         ;;
+    4|5)
+        iface="$iface3"
+        export CUDA_VISIBLE_DEVICES="$cuda3"
+        ;;
+    6|7)
+        iface="$iface4"
+        export CUDA_VISIBLE_DEVICES="$cuda4"
+        ;;
     *)
-        echo "Pass 0-3" 1>&2
+        echo "Pass 0-7" 1>&2
         exit 2
         ;;
 esac
@@ -48,6 +57,6 @@ exec spead2_net_raw taskset -c $other_affinity fgpu \
     --katcp-port $katcp_port \
     --prometheus-port $prom_port \
     --sync-epoch 0 \
-    --array-size 4 \
+    --array-size ${array_size:-8} \
     --feng-id "$feng_id" \
     $srcs $dst "$@"


### PR DESCRIPTION
It bakes in --use-vkgdr --use-peerdirect, since that's the only
situation in which it makes sense to run 8 instances.
