### PR TITLE
Increase fgpu receive buffer to 96MiB

### DIFF
--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -121,9 +121,9 @@ def parse_args(arglist: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--src-buffer",
         type=int,
-        default=64 * 1024 * 1024,
+        default=96 * 1024 * 1024,
         metavar="BYTES",
-        help="Size of network receive buffer (per pol) [64MiB]",
+        help="Size of network receive buffer (per pol) [96MiB]",
     )
     parser.add_argument(
         "--dst-interface", type=get_interface_address, required=True, help="Name of output network device"


### PR DESCRIPTION
This worked well at preventing RDMA out-of-buffer events when running at
S-band rates. I would have made it 128MiB but that was exceeding the
memory given to fgpu by katsdpcontroller, and 96MiB seems like enough.

There were still a handful of packet drops, but these were at the
hardware level, rather than running out of buffer.
