### PR TITLE
Use enp4s0 for run-fgpu-4 on boston2 system

### DIFF
--- a/scratch/config/ska2.sh
+++ b/scratch/config/ska2.sh
@@ -1,7 +1,7 @@
-iface1=enp193s0f0np0
-iface2=enp193s0f1np1
-iface3=enp4s0f0np0
-iface4=enp4s0f1np1
+iface1=enp4s0f0np0
+iface2=enp4s0f1np1
+iface3=enp193s0f0np0
+iface4=enp193s0f1np1
 
 cuda1=0
 cuda2=0


### PR DESCRIPTION
This scales to significantly higher performance than enp193s0 when used
with GPU 0. It also makes it consistent with the other Boston system.
