### PR TITLE
Updates to 8×fgpu config

### DIFF
--- a/scratch/fgpu/run-fgpu-8.yaml
+++ b/scratch/fgpu/run-fgpu-8.yaml
@@ -5,14 +5,14 @@ windows:
     - window_name: window1
       layout: tiled
       panes:
-          - ./run-fgpu.sh 0 --use-vkgdr --use-peerdirect
-          - ./run-fgpu.sh 1 --use-vkgdr --use-peerdirect
-          - ./run-fgpu.sh 2 --use-vkgdr --use-peerdirect
-          - ./run-fgpu.sh 3 --use-vkgdr --use-peerdirect
+          - ./run-fgpu.sh 0 --use-vkgdr
+          - ./run-fgpu.sh 1 --use-vkgdr
+          - ./run-fgpu.sh 2 --use-vkgdr
+          - ./run-fgpu.sh 3 --use-vkgdr
     - window_name: window2
       layout: tiled
       panes:
-          - ./run-fgpu.sh 4 --use-vkgdr --use-peerdirect
-          - ./run-fgpu.sh 5 --use-vkgdr --use-peerdirect
-          - ./run-fgpu.sh 6 --use-vkgdr --use-peerdirect
-          - ./run-fgpu.sh 7 --use-vkgdr --use-peerdirect
+          - ./run-fgpu.sh 4 --use-vkgdr
+          - ./run-fgpu.sh 5 --use-vkgdr
+          - ./run-fgpu.sh 6 --use-vkgdr
+          - ./run-fgpu.sh 7 --use-vkgdr

--- a/scratch/fgpu/run-fgpu.sh
+++ b/scratch/fgpu/run-fgpu.sh
@@ -9,13 +9,14 @@ nodes=$(lscpu | grep 'NUMA node.*CPU' | wc -l)
 nproc=$(nproc)
 step=$(($nproc / $nodes))
 hstep=$(($step / 2))
+src_idx=$(($1 % 4))
 
 src_affinity="$(($step*$1)),$(($step*$1+1))"
 src_comp=$src_affinity
 dst_affinity="$(($step*$1+$hstep))"
 dst_comp=$dst_affinity
 other_affinity="$(($step*$1+$hstep+1))"
-srcs="239.102.$1.64+7:7148 239.102.$1.72+7:7148"
+srcs="239.102.$src_idx.64+7:7148 239.102.$src_idx.72+7:7148"
 dst="239.102.$((200+$1)).0+15:7148"
 katcp_port="$(($1+7140))"
 prom_port="$(($1+7150))"


### PR DESCRIPTION
- Remove `--use-peerdirect`, as it runs into bandwidth limitations.
- Subscribe engines 4-7 to the same sources as 0-3, so that it's not
  necessary to run 8 dsims.
