### PR TITLE
Add a template file for pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Checklist:
 
 - [ ] If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
 - [ ] If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
-- [ ] If new files are added: ensure they have a copyright notice
+- [ ] Ensure copyright notices are present and up-to-date
 - [ ] If qualification tests are changed: attach a sample qualification report
 - [ ] If design has changed: ensure documentation is up to date
 


### PR DESCRIPTION
This will (in theory, can't test until it's merged) be pre-filled
whenever someone opens a PR, to remind them of some things that are easy
to forget.

Closes NGC-645.
