### PR TITLE
Bump mako to the latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ llvmlite==0.38.1
     # via numba
 locket==1.0.0
     # via partd
-mako==1.2.1
+mako==1.2.2
     # via
     #   katsdpsigproc
     #   pycuda


### PR DESCRIPTION
This is to keep Dependabot happy about a security issue, although it is extremely unlikely to affect katgpucbf since mako is not used with any user input.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] (N/A) Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date

No corresponding Jira ticket.
