### PR TITLE
Install pdf2svg in Jenkins Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,9 +78,12 @@ RUN SPEAD2_VERSION=$(grep ^spead2== katgpucbf/requirements.txt | cut -d= -f3) &&
 # Image used by Jenkins
 FROM build-base as jenkins
 
+# docker so that Jenkins can build a Docker image
+# All the TeX stuff for building the documentation
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     docker.io \
     latexmk \
+    pdf2svg \
     tex-gyre \
     texlive-latex-recommended \
     texlive-latex-extra


### PR DESCRIPTION
It's needed for sphinxcontrib-tikz to produce HTML output.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [ ] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date

Closes NGC-798.
