### PR TITLE
Correct comment about dumps missing data from all ants

### DIFF
--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -699,7 +699,7 @@ class XBEngine(DeviceServer):
             await katsdpsigproc.resource.async_wait_for_events([event])
 
             if not np.any(item.present_ants):
-                # All Antennas have missed data at some point, zero the entire dump
+                # All Antennas have missed data at some point, mark the entire dump missing
                 logger.warning("All Antennas had a break in data during this accumulation")
                 buffer_wrapper.buffer[...] = MISSING
                 incomplete_accum_counter.inc(1)


### PR DESCRIPTION
Previously they were zeroed, now Bruce's `MISSING` is used, so the comment was just a bit out-of-date.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] (N/A) Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date

No associated ticket, just came across this while I was handling NGC-746.
