### PR TITLE
Make sending descriptors to all substreams optional

### DIFF
--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1351,7 +1351,7 @@ class Engine(aiokatcp.DeviceServer):
             self._descriptor_heap,
             self.n_ants * descriptor_interval_s,
             (self.feng_id + 1) * descriptor_interval_s,
-            send_all_descriptors=True,
+            all_substreams=True,
         )
         self._descriptor_task = asyncio.create_task(descriptor_sender.run(), name=DESCRIPTOR_TASK_NAME)
         self.add_service_task(self._descriptor_task)

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1351,6 +1351,7 @@ class Engine(aiokatcp.DeviceServer):
             self._descriptor_heap,
             self.n_ants * descriptor_interval_s,
             (self.feng_id + 1) * descriptor_interval_s,
+            send_all_descriptors=True,
         )
         self._descriptor_task = asyncio.create_task(descriptor_sender.run(), name=DESCRIPTOR_TASK_NAME)
         self.add_service_task(self._descriptor_task)

--- a/src/katgpucbf/send.py
+++ b/src/katgpucbf/send.py
@@ -57,7 +57,7 @@ class DescriptorSender:
         interval: float,
         first_interval: Optional[float] = None,
         *,
-        all_substreams: Optional[bool] = False,
+        all_substreams: bool = False,
     ) -> None:
         self._stream = stream
         self._heap_reference_list = spead2.send.HeapReferenceList(

--- a/src/katgpucbf/send.py
+++ b/src/katgpucbf/send.py
@@ -45,6 +45,9 @@ class DescriptorSender:
     first_interval
         Delay (in seconds) immediately after starting. If not specified, it
         defaults to `interval`.
+    send_all_descriptors
+        Send descriptors to all substreams if true, otherwise default behaviour
+        is to send only to the first substream.
     """
 
     def __init__(
@@ -53,10 +56,13 @@ class DescriptorSender:
         descriptors: spead2.send.Heap,
         interval: float,
         first_interval: Optional[float] = None,
+        send_all_descriptors: Optional[bool] = False,
     ) -> None:
         self._stream = stream
         self._heap_reference_list = spead2.send.HeapReferenceList(
             [spead2.send.HeapReference(descriptors, substream_index=i) for i in range(stream.num_substreams)]
+            if send_all_descriptors
+            else [spead2.send.HeapReference(descriptors, substream_index=0)]
         )
         self._interval = interval
         self._first_interval = interval if first_interval is None else first_interval

--- a/src/katgpucbf/send.py
+++ b/src/katgpucbf/send.py
@@ -45,7 +45,7 @@ class DescriptorSender:
     first_interval
         Delay (in seconds) immediately after starting. If not specified, it
         defaults to `interval`.
-    send_all_descriptors
+    all_substreams
         Send descriptors to all substreams if true, otherwise default behaviour
         is to send only to the first substream.
     """
@@ -56,12 +56,13 @@ class DescriptorSender:
         descriptors: spead2.send.Heap,
         interval: float,
         first_interval: Optional[float] = None,
-        send_all_descriptors: Optional[bool] = False,
+        *,
+        all_substreams: Optional[bool] = False,
     ) -> None:
         self._stream = stream
         self._heap_reference_list = spead2.send.HeapReferenceList(
             [spead2.send.HeapReference(descriptors, substream_index=i) for i in range(stream.num_substreams)]
-            if send_all_descriptors
+            if all_substreams
             else [spead2.send.HeapReference(descriptors, substream_index=0)]
         )
         self._interval = interval


### PR DESCRIPTION
This was breaking the dsim which initially tried to send descriptors to all its substreams, instead of just the first one. This fix allows the dsim to actually start, which will hopefully give us the ability to run a correlator again.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date

Closes NGC-809.
