### PR TITLE
Make dsim generate saturation counts

### DIFF
--- a/doc/dsim.rst
+++ b/doc/dsim.rst
@@ -153,6 +153,13 @@ internally splits arrays into chunks and performs computations for each chunk
 in parallel. The chunk size is determined by the constant
 :data:`katgpucbf.dsim.signal.CHUNK_SIZE`.
 
+The simulator also populates the saturation count and flag in the
+``digitiser_status`` SPEAD item. A per-sample saturation flag is computed with
+dask (prior to bit-packing), and then accumulated to heap granularity with
+serial code. This accumulation could be done more directly for better
+efficiency, but the current approach is reasonably performant and does not
+require the sampling code to take the heap size into account.
+
 Generating reproducible random signals needs to be done carefully when
 parallelising. The given random seed is first used to produce a
 :class:`~numpy.random.SeedSequence` for each chunk, and each chunk then uses

--- a/src/katgpucbf/dsim/__init__.py
+++ b/src/katgpucbf/dsim/__init__.py
@@ -1,7 +1,7 @@
 # noqa: D104
 
 ################################################################################
-# Copyright (c) 2021, National Research Foundation (SARAO)
+# Copyright (c) 2021-2022, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katgpucbf/dsim/__init__.py
+++ b/src/katgpucbf/dsim/__init__.py
@@ -19,3 +19,7 @@
 from typing import Final
 
 METRIC_NAMESPACE: Final = "dsim"
+#: Bit position in digitiser_status SPEAD item for ADC saturation flag
+STATUS_SATURATION_FLAG_BIT: Final = 1
+#: First bit position in digitiser status SPEAD item for ADC saturation count
+STATUS_SATURATION_COUNT_SHIFT: Final = 32

--- a/src/katgpucbf/dsim/__init__.py
+++ b/src/katgpucbf/dsim/__init__.py
@@ -1,7 +1,7 @@
 # noqa: D104
 
 ################################################################################
-# Copyright (c) 2021-2022, National Research Foundation (SARAO)
+# Copyright (c) 2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -19,7 +19,3 @@
 from typing import Final
 
 METRIC_NAMESPACE: Final = "dsim"
-#: Bit position in digitiser_status SPEAD item for ADC saturation flag
-STATUS_SATURATION_FLAG_BIT: Final = 1
-#: First bit position in digitiser status SPEAD item for ADC saturation count
-STATUS_SATURATION_COUNT_SHIFT: Final = 32

--- a/src/katgpucbf/dsim/server.py
+++ b/src/katgpucbf/dsim/server.py
@@ -19,10 +19,11 @@
 import asyncio
 import logging
 import time
-from typing import Sequence
+from typing import Optional, Sequence
 
 import aiokatcp
 import pyparsing as pp
+import xarray as xr
 
 from .. import BYTE_BITS, __version__
 from ..send import DescriptorSender
@@ -45,22 +46,8 @@ class DeviceServer(aiokatcp.DeviceServer):
         Sampling rate in Hz
     sample_bits
         Number of bits per output sample
-    first_timestamp
-        The timestamp associated with the first output sample
     dither_seed
         Dither seed (used only to populate a sensor).
-    signals_str
-        String that was parsed to produce `signals`.
-    signals
-        User-requested signals. Note that these must have already been loaded
-        into the sender; it is provided here purely to populate sensors.
-    period
-        Initial period used to generate the signal loaded into the sender.
-    signal_service
-        Helper process for generating new signals. It must be constructed
-        consistent with the other arguments (in particular,
-        ``sender.heap_set.data["payload"]`` and ``spare.data["payload"]`` must
-        be passed to the constructor).
     *args, **kwargs
         Passed to base class
     """
@@ -77,12 +64,7 @@ class DeviceServer(aiokatcp.DeviceServer):
         spare: HeapSet,
         adc_sample_rate: float,
         sample_bits: int,
-        first_timestamp: int,
         dither_seed: int,
-        signals_str: str,
-        signals: Sequence[Signal],
-        period: int,
-        signal_service: SignalService,
         *args,
         **kwargs,
     ) -> None:
@@ -92,37 +74,35 @@ class DeviceServer(aiokatcp.DeviceServer):
         self.spare = spare
         self.adc_sample_rate = adc_sample_rate
         self.sample_bits = sample_bits
-        self.first_timestamp = first_timestamp
+        # Scratch space for computing saturation counts
+        self._saturated = xr.zeros_like(sender.heap_set.data["payload"], dtype=bool)
         self._signals_lock = asyncio.Lock()  # Serialises request_signals
-        self._signal_service = signal_service
+        heap_sets = [sender.heap_set, spare]
+        self._signal_service = SignalService(
+            [heap_set.data["payload"] for heap_set in heap_sets] + [self._saturated],
+            sample_bits,
+            dither_seed,
+        )
 
         self._signals_orig_sensor = aiokatcp.Sensor(
             str,
             "signals-orig",
             "User-provided string used to define the signals",
-            initial_status=aiokatcp.Sensor.Status.NOMINAL,
-            default=signals_str,
         )
         self._signals_sensor = aiokatcp.Sensor(
             str,
             "signals",
             "String reproducibly describing how the signals are generated",
-            initial_status=aiokatcp.Sensor.Status.NOMINAL,
-            default=format_signals(signals),
         )
         self._period_sensor = aiokatcp.Sensor(
             int,
             "period",
             "Number of samples after which the signals will be repeated",
-            initial_status=aiokatcp.Sensor.Status.NOMINAL,
-            default=period,
         )
         self._steady_state_sensor = aiokatcp.Sensor(
             int,
             "steady-state-timestamp",
             "Heaps with this timestamp or greater are guaranteed to reflect the effects of previous katcp requests.",
-            default=0,
-            initial_status=aiokatcp.Sensor.Status.NOMINAL,
         )
         self.sensors.add(self._signals_orig_sensor)
         self.sensors.add(self._signals_sensor)
@@ -171,6 +151,28 @@ class DeviceServer(aiokatcp.DeviceServer):
         self.descriptor_sender.halt()
         await self._signal_service.stop()
 
+    async def set_signals(self, signals: Sequence[Signal], signals_str: str, period: Optional[int] = None) -> int:
+        """Change the signals :meth:`request_signals`.
+
+        This is the implementation of :meth:`request_signals`. See that method for
+        description of the parameters and return value (`signals` is the parsed
+        version of `signals_str`).
+        """
+        if period is None:
+            period = self.sensors["max-period"].value
+        async with self._signals_lock:
+            await self._signal_service.sample(
+                signals, 0, period, self.adc_sample_rate, self.spare.data["payload"], self._saturated
+            )
+            spare = self.sender.heap_set
+            timestamp = await self.sender.set_heaps(self.spare)
+            self.spare = spare
+            self._signals_orig_sensor.value = signals_str
+            self._signals_sensor.value = format_signals(signals)
+            self._period_sensor.value = period
+            self._steady_state_sensor.value = max(self._steady_state_sensor.value, timestamp)
+            return timestamp
+
     async def request_signals(self, ctx, signals_str: str, period: int = None) -> int:
         """Update the signals that are generated.
 
@@ -198,25 +200,7 @@ class DeviceServer(aiokatcp.DeviceServer):
         n_pol = self.spare.data.dims["pol"]
         if len(signals) != n_pol:
             raise aiokatcp.FailReply(f"expected {n_pol} signals, received {len(signals)}")
-        if period is None:
-            period = self.sensors["max-period"].value
-
-        async with self._signals_lock:
-            await self._signal_service.sample(
-                signals,
-                self.first_timestamp,
-                period,
-                self.adc_sample_rate,
-                self.spare.data["payload"],
-            )
-            spare = self.sender.heap_set
-            timestamp = await self.sender.set_heaps(self.spare)
-            self.spare = spare
-            self._signals_orig_sensor.value = signals_str
-            self._signals_sensor.value = format_signals(signals)
-            self._period_sensor.value = period
-            self._steady_state_sensor.value = max(self._steady_state_sensor.value, timestamp)
-            return timestamp
+        return await self.set_signals(signals, signals_str, period)
 
     async def request_time(self, ctx) -> float:
         """Return the current UNIX timestamp."""

--- a/src/katgpucbf/dsim/server.py
+++ b/src/katgpucbf/dsim/server.py
@@ -28,7 +28,7 @@ import xarray as xr
 
 from .. import BYTE_BITS, __version__
 from ..send import DescriptorSender
-from . import STATUS_SATURATION_COUNT_SHIFT, STATUS_SATURATION_FLAG_BIT
+from ..spead import DIGITISER_STATUS_SATURATION_COUNT_SHIFT, DIGITISER_STATUS_SATURATION_FLAG_BIT
 from .send import HeapSet, Sender
 from .shared_array import SharedArray
 from .signal import Signal, SignalService, TerminalError, format_signals, parse_signals
@@ -178,8 +178,10 @@ class DeviceServer(aiokatcp.DeviceServer):
             # bit 1 holds a boolean flag.
             # np.left_shift is << but xarray doesn't seem to implement the
             # operator overload.
-            digitiser_status = np.left_shift(saturation_count, STATUS_SATURATION_COUNT_SHIFT)
-            digitiser_status |= xr.where(digitiser_status, np.int64(1 << STATUS_SATURATION_FLAG_BIT), np.int64(0))
+            digitiser_status = np.left_shift(saturation_count, DIGITISER_STATUS_SATURATION_COUNT_SHIFT)
+            digitiser_status |= xr.where(
+                digitiser_status, np.int64(1 << DIGITISER_STATUS_SATURATION_FLAG_BIT), np.int64(0)
+            )
             self.spare.data["digitiser_status"][:] = digitiser_status
             spare = self.sender.heap_set
             timestamp = await self.sender.set_heaps(self.spare)

--- a/src/katgpucbf/dsim/server.py
+++ b/src/katgpucbf/dsim/server.py
@@ -28,6 +28,7 @@ import xarray as xr
 
 from .. import BYTE_BITS, __version__
 from ..send import DescriptorSender
+from . import STATUS_SATURATION_COUNT_SHIFT, STATUS_SATURATION_FLAG_BIT
 from .send import HeapSet, Sender
 from .shared_array import SharedArray
 from .signal import Signal, SignalService, TerminalError, format_signals, parse_signals
@@ -177,8 +178,8 @@ class DeviceServer(aiokatcp.DeviceServer):
             # bit 1 holds a boolean flag.
             # np.left_shift is << but xarray doesn't seem to implement the
             # operator overload.
-            digitiser_status = np.left_shift(saturation_count, 32)
-            digitiser_status |= xr.where(digitiser_status, np.int64(2), np.int64(0))
+            digitiser_status = np.left_shift(saturation_count, STATUS_SATURATION_COUNT_SHIFT)
+            digitiser_status |= xr.where(digitiser_status, np.int64(1 << STATUS_SATURATION_FLAG_BIT), np.int64(0))
             self.spare.data["digitiser_status"][:] = digitiser_status
             spare = self.sender.heap_set
             timestamp = await self.sender.set_heaps(self.spare)

--- a/src/katgpucbf/dsim/signal.py
+++ b/src/katgpucbf/dsim/signal.py
@@ -534,6 +534,26 @@ def quantise(
 
 
 @numba.njit(nogil=True)
+def _saturation_flags(data: np.ndarray, saturation_value: np.generic) -> np.ndarray:
+    out = np.empty(data.shape, np.bool_)
+    for i in range(len(data)):
+        out[i] = np.abs(out[i]) >= saturation_value
+    return out
+
+
+def saturation_flags(data: da.Array, saturation_value) -> da.Array:
+    """Return a flag array indicating saturated elements of ``data``.
+
+    Elements are considered saturated if they exceed `saturation_value` in
+    absolute value.
+    """
+    assert data.ndim == 1
+    # Ensure the saturation value is already a numpy scalar
+    saturation_value = data.dtype.type(saturation_value)
+    return da.map_blocks(_saturation_flags, data, meta=np.array((), bool), saturation_value=saturation_value)
+
+
+@numba.njit(nogil=True)
 def _packbits(data: np.ndarray, bits: int) -> np.ndarray:
     # Note: needs lots of explicit casting to np.uint64, as otherwise
     # numba seems to want to infer double precision.
@@ -579,6 +599,7 @@ def sample(
     sample_rate: float,
     sample_bits: int,
     out: xr.DataArray,
+    out_saturated: Optional[xr.DataArray] = None,
     *,
     dither: Union[bool, xr.DataArray] = True,
     dither_seed: Optional[int] = None,
@@ -605,6 +626,9 @@ def sample(
     out
         Output array, with a dimension called ``pol`` (which must match the
         number of signals). The other dimensions are flattened.
+    out_saturated
+        Output array, with the same shape as ``out``, into which saturation
+        flags are written.
     dither
         If true (default), add uniform random values in the range [-0.5, 0.5)
         after scaling to reduce artefacts. It may also be a :class:`xr.DataArray`
@@ -631,7 +655,8 @@ def sample(
             raise ValueError(f"Expected at least {period} dither samples, only found {dither.sizes['data']}")
         dither = dither.isel(data=np.s_[:period])
 
-    sampled = []
+    in_arrays = []
+    out_arrays = []
     for i, sig in enumerate(signals):
         data = sig.sample(period, sample_rate)
         if sig.terminal:
@@ -640,13 +665,21 @@ def sample(
             sig_dither = dither.isel(pol=i).data
         data = quantise(data, sample_bits, sig_dither)
         data = da.roll(data, -timestamp)
+        if out_saturated is not None:
+            saturated = saturation_flags(data, 2 ** (sample_bits - 1) - 1)
         data = packbits(data, sample_bits)
         if period < n:
             data = da.tile(data, n // period)
-        sampled.append(data)
+            if out_saturated is not None:
+                saturated = da.tile(saturated, n // period)
+        in_arrays.append(data)
+        out_arrays.append(out.isel(pol=i).data.ravel())
+        if out_saturated is not None:
+            in_arrays.append(saturated)
+            out_arrays.append(out_saturated.isel(pol=i).data.ravel())
     # Compute all the pols together, so that common signals are only computed
     # once.
-    da.store(sampled, [out.isel(pol=i).data.ravel() for i in range(len(signals))], lock=False)
+    da.store(in_arrays, out_arrays, lock=False)
 
 
 class SignalService:
@@ -674,7 +707,8 @@ class SignalService:
         timestamp: int
         period: Optional[int]
         sample_rate: float
-        out_idx: int  #: Index of the array in the list of valid arrays
+        out_idx: int  #: Index of the out array in the list of valid arrays
+        out_saturation_idx: Optional[int]  #: Index of the out saturation array in the list of valid arrays
 
     @staticmethod
     def _run(
@@ -718,6 +752,7 @@ class SignalService:
                     req.sample_rate,
                     sample_bits,
                     arrays[req.out_idx],
+                    out_saturated=arrays[req.out_saturation_idx] if req.out_saturation_idx is not None else None,
                     dither=dither,
                 )
             except Exception as exc:
@@ -764,6 +799,16 @@ class SignalService:
         if reply is not None:
             raise reply
 
+    def _array_index(self, out: xr.DataArray) -> int:
+        for i, array in enumerate(self.arrays):
+            # Object identity doesn't work well, I think because fetching one
+            # xr.DataArray from a xr.DataSet creates a new object on the fly.
+            # So we check if they're referencing the same memory in the same
+            # way.
+            if array.data.__array_interface__ == out.data.__array_interface__:
+                return i
+        raise ValueError("output was not registered with the constructor")
+
     async def sample(
         self,
         signals: Sequence[Signal],
@@ -771,25 +816,18 @@ class SignalService:
         period: Optional[int],
         sample_rate: float,
         out: xr.DataArray,
+        out_saturation: Optional[xr.DataArray] = None,
     ) -> None:
         """Perform signal sampling in the remote process.
 
-        `out` must be one of the arrays passed to the constructor. Only the
-        first `n` samples will be populated (and this will be taken as the
-        period).
+        `out` and `out_saturation` must each be one of the arrays passed to the
+        constructor. Only the first `n` samples will be populated (and this
+        will be taken as the period).
         """
-        for i, array in enumerate(self.arrays):
-            # Object identity doesn't work well, I think because fetching one
-            # xr.DataArray from a xr.DataSet creates a new object on the fly.
-            # So we check if they're referencing the same memory in the same
-            # way.
-            if array.data.__array_interface__ == out.data.__array_interface__:
-                out_idx = i
-                break
-        else:
-            raise ValueError("output was not registered with the constructor")
+        out_idx = self._array_index(out)
+        out_saturation_idx = self._array_index(out_saturation) if out_saturation is not None else None
         loop = asyncio.get_running_loop()
-        req = SignalService._Request(signals, timestamp, period, sample_rate, out_idx)
+        req = SignalService._Request(signals, timestamp, period, sample_rate, out_idx, out_saturation_idx)
         await loop.run_in_executor(None, self._make_request, req)
 
     async def __aenter__(self) -> "SignalService":

--- a/src/katgpucbf/spead.py
+++ b/src/katgpucbf/spead.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2021, National Research Foundation (SARAO)
+# Copyright (c) 2020-2022, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -29,6 +29,11 @@ ADC_SAMPLES_ID = 0x3300  # Digitiser data
 XENG_RAW_ID = 0x1800
 TIMESTAMP_ID = 0x1600
 MAX_PACKET_SIZE = 8872
+
+#: Bit position in digitiser_status SPEAD item for ADC saturation flag
+DIGITISER_STATUS_SATURATION_FLAG_BIT = 1
+#: First bit position in digitiser status SPEAD item for ADC saturation count
+DIGITISER_STATUS_SATURATION_COUNT_SHIFT = 32
 
 #: SPEAD flavour used for all send streams
 FLAVOUR = spead2.Flavour(4, 64, 48, 0)

--- a/test/dsim/conftest.py
+++ b/test/dsim/conftest.py
@@ -16,7 +16,6 @@
 
 """Common fixtures for dsim tests."""
 
-import time
 from typing import Generator, Sequence
 from unittest import mock
 
@@ -107,7 +106,7 @@ def sender(
     send_stream: "spead2.send.asyncio.AsyncStream", heap_sets: Sequence[send.HeapSet]
 ) -> send.Sender:  # noqa: D401
     """A :class:`~katgpucbf.dsim.Sender` using the first of :func:`heaps_sets`."""
-    return send.Sender(send_stream, heap_sets[0], 0, DIG_HEAP_SAMPLES, time.time(), ADC_SAMPLE_RATE)
+    return send.Sender(send_stream, heap_sets[0], DIG_HEAP_SAMPLES, ADC_SAMPLE_RATE)
 
 
 @pytest.fixture

--- a/test/dsim/test_send.py
+++ b/test/dsim/test_send.py
@@ -18,6 +18,7 @@
 
 import asyncio
 import itertools
+import time
 from typing import Optional, Sequence
 
 import numpy as np
@@ -117,7 +118,7 @@ async def test_sender(
 
     # Now proceed with DSim data using received descriptors (in ItemGroup)(ig)
     with PromDiff(namespace=send.METRIC_NAMESPACE) as prom_diff:
-        await sender.run()
+        await sender.run(0, time.time())
     for queue in inproc_queues:
         queue.stop()
 

--- a/test/dsim/test_server.py
+++ b/test/dsim/test_server.py
@@ -25,11 +25,11 @@ import numpy as np
 import pytest
 
 from katgpucbf import DIG_HEAP_SAMPLES, DIG_SAMPLE_BITS
-from katgpucbf.dsim import STATUS_SATURATION_COUNT_SHIFT, STATUS_SATURATION_FLAG_BIT
 from katgpucbf.dsim.send import HeapSet, Sender
 from katgpucbf.dsim.server import DeviceServer
 from katgpucbf.dsim.signal import parse_signals
 from katgpucbf.send import DescriptorSender
+from katgpucbf.spead import DIGITISER_STATUS_SATURATION_COUNT_SHIFT, DIGITISER_STATUS_SATURATION_FLAG_BIT
 
 from .. import get_sensor
 from .conftest import ADC_SAMPLE_RATE, SIGNAL_HEAPS
@@ -108,15 +108,15 @@ async def test_signals(
     assert not np.all(payload.isel(pol=1).data == 0)
     # Check that the saturation flag is consistent with the saturation count
     np.testing.assert_equal(
-        (status.data & (1 << STATUS_SATURATION_FLAG_BIT)) > 0,
-        (status.data >> STATUS_SATURATION_COUNT_SHIFT) > 0,
+        (status.data & (1 << DIGITISER_STATUS_SATURATION_FLAG_BIT)) > 0,
+        (status.data >> DIGITISER_STATUS_SATURATION_COUNT_SHIFT) > 0,
     )
     if period is None:  # The tests below depend on having enough unique data
         # Check that pol 1 is saturated about as much as expected
         assert np.mean(status.isel(pol=1).data >> 32) / DIG_HEAP_SAMPLES == pytest.approx(2 / 3, abs=0.01)
         # Check that some heaps are entirely unsaturated, so that the
         # saturation flag consistency test is not vacuous.
-        assert not np.all(status.isel(pol=1).data & (1 << STATUS_SATURATION_FLAG_BIT))
+        assert not np.all(status.isel(pol=1).data & (1 << DIGITISER_STATUS_SATURATION_FLAG_BIT))
     # Check that sensors were updated
     assert await get_sensor(katcp_client, "signals-orig") == signals_str
     assert await get_sensor(katcp_client, "period") == (period or DIG_HEAP_SAMPLES * SIGNAL_HEAPS)

--- a/test/dsim/test_server.py
+++ b/test/dsim/test_server.py
@@ -25,6 +25,7 @@ import numpy as np
 import pytest
 
 from katgpucbf import DIG_HEAP_SAMPLES, DIG_SAMPLE_BITS
+from katgpucbf.dsim import STATUS_SATURATION_COUNT_SHIFT, STATUS_SATURATION_FLAG_BIT
 from katgpucbf.dsim.send import HeapSet, Sender
 from katgpucbf.dsim.server import DeviceServer
 from katgpucbf.dsim.signal import parse_signals
@@ -106,13 +107,16 @@ async def test_signals(
     np.testing.assert_equal(payload.isel(pol=0).data, 0)
     assert not np.all(payload.isel(pol=1).data == 0)
     # Check that the saturation flag is consistent with the saturation count
-    np.testing.assert_equal((status.data & 2) > 0, (status.data >> 32) > 0)
+    np.testing.assert_equal(
+        (status.data & (1 << STATUS_SATURATION_FLAG_BIT)) > 0,
+        (status.data >> STATUS_SATURATION_COUNT_SHIFT) > 0,
+    )
     if period is None:  # The tests below depend on having enough unique data
         # Check that pol 1 is saturated about as much as expected
         assert np.mean(status.isel(pol=1).data >> 32) / DIG_HEAP_SAMPLES == pytest.approx(2 / 3, abs=0.01)
         # Check that some heaps are entirely unsaturated, so that the
         # saturation flag consistency test is not vacuous.
-        assert not np.all(status.isel(pol=1).data & 2)
+        assert not np.all(status.isel(pol=1).data & (1 << STATUS_SATURATION_FLAG_BIT))
     # Check that sensors were updated
     assert await get_sensor(katcp_client, "signals-orig") == signals_str
     assert await get_sensor(katcp_client, "period") == (period or DIG_HEAP_SAMPLES * SIGNAL_HEAPS)


### PR DESCRIPTION
Emit saturation count and saturation flag in the `digitiser_status` SPEAD item.

A major part of this is some not-really-related refactoring: previously the initial signal was set up by `main`, bypassing the mechanisms used by `request_signal`. That was done to avoid a cyclic dependency, where the DeviceServer needs a Sender which required the start time which could only sanely be computed after the initial signal was sampled (because sampling is slow). I instead broke that dependency by making Sender only need the start time when run instead of when constructed.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date

Relates to NGC-796.
