### PR TITLE
Collect and report digitiser saturation counts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
             'numpy==1.22.4',
             'pyparsing==3.0.9',
             'pytest==7.1.2',
-            'spead2==3.9.1',
+            'spead2==3.11.0',
             'types-decorator==5.1.1',
             'types-docutils==0.17.1',
             'types-redis==4.3.3',

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
             'numpy==1.22.4',
             'pyparsing==3.0.9',
             'pytest==7.1.2',
-            'spead2==3.11.0',
+            'spead2==3.11.1',
             'types-decorator==5.1.1',
             'types-docutils==0.17.1',
             'types-redis==4.3.3',

--- a/qualification/requirements.in
+++ b/qualification/requirements.in
@@ -8,4 +8,4 @@ pylatex
 pytest
 pytest-check
 pytest-reportlog
-spead2>=3.9.1
+spead2>=3.11.0

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -306,7 +306,7 @@ snowballstemmer==2.2.0
     # via
     #   -r qualification/../requirements-dev.txt
     #   sphinx
-spead2==3.11.0
+spead2==3.11.1
     # via -r qualification/requirements.in
 sphinx==5.0.2
     # via

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -306,7 +306,7 @@ snowballstemmer==2.2.0
     # via
     #   -r qualification/../requirements-dev.txt
     #   sphinx
-spead2==3.9.1
+spead2==3.11.0
     # via -r qualification/requirements.in
 sphinx==5.0.2
     # via

--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,6 @@ prometheus-async
 psutil  # Gives more accurate dask.system.CPU_COUNT
 pycuda
 pyparsing>=3.0.0
-spead2>=3.9.1
+spead2>=3.11.0
 vkgdr @ git+ssh://git@github.com/ska-sa/vkgdr
 xarray

--- a/requirements.txt
+++ b/requirements.txt
@@ -134,7 +134,7 @@ six==1.16.0
     # via
     #   katsdptelstate
     #   python-dateutil
-spead2==3.11.0
+spead2==3.11.1
     # via -r requirements.in
 terminaltables==3.1.10
     # via aiomonitor

--- a/requirements.txt
+++ b/requirements.txt
@@ -134,7 +134,7 @@ six==1.16.0
     # via
     #   katsdptelstate
     #   python-dateutil
-spead2==3.9.1
+spead2==3.11.0
     # via -r requirements.in
 terminaltables==3.1.10
     # via aiomonitor

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     prometheus-async[aiohttp]
     prometheus-client>=0.4  # First version to auto-append _total to counter names
     pyparsing>=3.0.0
-    spead2>=3.9.1
+    spead2>=3.11.0
     xarray
 python_requires = >=3.8
 

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -584,11 +584,16 @@ class Engine(aiokatcp.DeviceServer):
                     # mapping.
                     buf = buf[:chunk_bytes]
                     device_array = accel.DeviceArray(context, (device_bytes,), np.uint8, raw=mem)
-                    chunk = recv.Chunk(data=buf, device=device_array, stream=stream)
                 else:
                     buf = accel.HostArray((chunk_bytes,), np.uint8, context=context)
-                    chunk = recv.Chunk(data=buf, stream=stream)
-                chunk.present = np.zeros(self._src_layout.chunk_samples // self._src_packet_samples, np.uint8)
+                    device_array = None
+                chunk = recv.Chunk(
+                    data=buf,
+                    device=device_array,
+                    present=np.zeros(self._src_layout.chunk_samples // self._src_packet_samples, np.uint8),
+                    extra=np.zeros(self._src_layout.chunk_samples // self._src_packet_samples, np.uint16),
+                    stream=stream,
+                )
                 chunk.recycle()  # Make available to the stream
 
     def _init_send(self, substreams: int, use_peerdirect: bool) -> List[send.Chunk]:
@@ -697,13 +702,22 @@ class Engine(aiokatcp.DeviceServer):
             sensors.add(
                 aiokatcp.Sensor(
                     int,
-                    "steady-state-timestamp",
-                    "Heaps with this timestamp or greater are guaranteed to "
-                    "reflect the effects of previous katcp requests.",
+                    f"dig.pol{pol}-dig-clip-cnt",
+                    "Number of digitiser samples that are saturated",
                     default=0,
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,
                 )
             )
+        sensors.add(
+            aiokatcp.Sensor(
+                int,
+                "steady-state-timestamp",
+                "Heaps with this timestamp or greater are guaranteed to "
+                "reflect the effects of previous katcp requests.",
+                default=0,
+                initial_status=aiokatcp.Sensor.Status.NOMINAL,
+            )
+        )
 
     async def _next_in(self) -> Optional[InItem]:
         """Load next InItem for processing.
@@ -1018,9 +1032,12 @@ class Engine(aiokatcp.DeviceServer):
             in_item.n_samples = chunks[0].data.nbytes * BYTE_BITS // self.sample_bits
 
             transfer_events = []
-            for pol_data, chunk in zip(in_item.pol_data, chunks):
+            for pol, (pol_data, chunk) in enumerate(zip(in_item.pol_data, chunks)):
                 # Copy the present flags (synchronously).
                 pol_data.present[: len(chunk.present)] = chunk.present
+                # Update the digitiser saturation count (the "extra" fields holds
+                # per-heap values).
+                self.sensors[f"dig.pol{pol}-dig-clip-cnt"].value += int(np.sum(chunk.extra, dtype=np.uint64))
             if self.use_vkgdr:
                 for pol_data, chunk in zip(in_item.pol_data, chunks):
                     assert pol_data.samples is None

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1037,7 +1037,12 @@ class Engine(aiokatcp.DeviceServer):
                 pol_data.present[: len(chunk.present)] = chunk.present
                 # Update the digitiser saturation count (the "extra" fields holds
                 # per-heap values).
-                self.sensors[f"dig.pol{pol}-dig-clip-cnt"].value += int(np.sum(chunk.extra, dtype=np.uint64))
+                assert chunk.extra is not None
+                sensor = self.sensors[f"dig.pol{pol}-dig-clip-cnt"]
+                sensor.set_value(
+                    sensor.value + int(np.sum(chunk.extra, dtype=np.uint64)),
+                    timestamp=chunk.timestamp + layout.chunk_samples,
+                )
             if self.use_vkgdr:
                 for pol_data, chunk in zip(in_item.pol_data, chunks):
                     assert pol_data.samples is None

--- a/src/katgpucbf/fgpu/recv.py
+++ b/src/katgpucbf/fgpu/recv.py
@@ -295,6 +295,7 @@ async def chunk_sets(
                     bytes_counter.labels(pol).inc(buf_good * layout.heap_bytes)
                     # Zero out saturation count for heaps that were never received
                     # (otherwise the value is undefined memory).
+                    assert c.extra is not None
                     c.extra[c.present == 0] = 0
                     dig_clip_counter.labels(pol).inc(int(np.sum(c.extra, dtype=np.uint64)))
                     # Determine how many heaps we expected to have seen by

--- a/src/katgpucbf/recv.py
+++ b/src/katgpucbf/recv.py
@@ -241,6 +241,7 @@ class BaseLayout(ABC):
 
 
 def make_stream(
+    *,
     layout: BaseLayout,
     spead_items: List[int],
     max_active_chunks: int,
@@ -248,6 +249,7 @@ def make_stream(
     free_ringbuffer: spead2.recv.ChunkRingbuffer,
     affinity: int,
     stream_stats: List[str],
+    max_heap_extra: int = 0,
     **kwargs: Any,
 ) -> spead2.recv.ChunkRingStream:
     """Create a SPEAD receiver stream.
@@ -260,6 +262,8 @@ def make_stream(
         List of SPEAD item IDs to be expected in the heap headers.
     max_active_chunks
         Maximum number of chunks under construction.
+    max_heap_extra
+        Maximum non-payload data written by the place callback
     data_ringbuffer
         Output ringbuffer to which chunks will be sent.
     free_ringbuffer
@@ -279,6 +283,7 @@ def make_stream(
     chunk_stream_config = spead2.recv.ChunkStreamConfig(
         items=spead_items,
         max_chunks=max_active_chunks,
+        max_heap_extra=max_heap_extra,
         place=layout.chunk_place(stats_base),
     )
 

--- a/src/katgpucbf/recv.py
+++ b/src/katgpucbf/recv.py
@@ -53,6 +53,7 @@ class Chunk(spead2.recv.Chunk):
     # Refine the types used in the base class
     present: np.ndarray
     data: np.ndarray
+    extra: Optional[np.ndarray]
     # New fields
     device: object
     timestamp: int


### PR DESCRIPTION
The `digitiser_status ` SPEAD item is extracted and used to compute an accumulated saturation count, which is reported by katcp sensor (to make it available to SDP) and Prometheus metric (so that we can add it to the dashboard later). The sensor timestamp is computed from the data so that it is not affected by clock drift on the host (or latency in the networking pipeline).

The sensor name does not exactly match MeerKAT (since we do not have the concept of an f-host) but is chosen to be similar.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date

Addresses NGC-796 (but it should not be closed yet).
