### PR TITLE
Add labels to Docker image indicating the Git revision

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -148,7 +148,12 @@ pipeline {
           tag = (branch == "main") ? "latest" : branch
           // Supply credentials to Dockerhub so that we can reliably pull the base image
           docker.withRegistry("https://docker.io/", "dockerhub") {
-            dockerImage = docker.build "harbor.sdp.kat.ac.za/cbf/katgpucbf:${tag}", "--pull ."
+            dockerImage = docker.build(
+              "harbor.sdp.kat.ac.za/cbf/katgpucbf:${tag}",
+              "--pull "
+              + "--label=org.opencontainers.image.revision=${env.GIT_COMMIT} "
+              + "--label=org.opencontainers.image.source=${env.GIT_URL} ."
+            )
           }
           docker.withRegistry("https://harbor.sdp.kat.ac.za/", "harbor-cbf") {
             dockerImage.push()


### PR DESCRIPTION
I wanted to check what image had been running in a test and realised that had never been added. The labels used come from https://github.com/opencontainers/image-spec/blob/main/annotations.md

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
