### PR TITLE
Improvements to saturation count calculation

### DIFF
--- a/doc/dsim.rst
+++ b/doc/dsim.rst
@@ -154,11 +154,12 @@ in parallel. The chunk size is determined by the constant
 :data:`katgpucbf.dsim.signal.CHUNK_SIZE`.
 
 The simulator also populates the saturation count and flag in the
-``digitiser_status`` SPEAD item. A per-sample saturation flag is computed with
-dask (prior to bit-packing), and then accumulated to heap granularity with
-serial code. This accumulation could be done more directly for better
-efficiency, but the current approach is reasonably performant and does not
-require the sampling code to take the heap size into account.
+``digitiser_status`` SPEAD item. A per-heap saturation count is computed with
+dask (prior to bit-packing), and then packed into the ``digitiser_status``
+bit-field with serial code. This accumulation could be done in parallel for
+better efficiency, but the current approach is reasonably performant and does
+not require the sampling code to have any knowledge of the format of the
+``digitiser_status`` item.
 
 Generating reproducible random signals needs to be done carefully when
 parallelising. The given random seed is first used to produce a


### PR DESCRIPTION
- Move summation over a heap into `sample`. This should reduce the load on the main thread and avoid stalling transmission (NGC-815).
- Avoid using np.abs in the check, because abs(INT_MIN) is INT_MIN (where INT_MIN is the minimum value of whatever the dtype is).
- Add a unit test for saturation_counts.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date

Closes NGC-815.
