### PR TITLE
Add PDF format to readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,3 +6,5 @@ python:
       path: .
       extra_requirements:
         - doc
+formats:
+  - pdf


### PR DESCRIPTION
In order to generate a PDF for download on the online hosted documentation.

I'm not an admin on katgpucbf's readthedocs, so I can't force a build of this branch.
Still, let me know if anything looks suspicious.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
