### PR TITLE
Add qualification test stage to Jenkins pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,10 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
     pdf2svg \
     tex-gyre \
     texlive-latex-recommended \
-    texlive-latex-extra
+    texlive-latex-extra \
+    texlive-base \
+    texlive-science \
+    lmodern
 
 #######################################################################
 

--- a/qualification/pytest.ini
+++ b/qualification/pytest.ini
@@ -1,0 +1,12 @@
+[pytest]
+tester = Tester one
+asyncio_mode = auto
+master_controller_host = lab5.sdp.kat.ac.za
+master_controller_port = 5001
+prometheus_url = http://lab5.sdp.kat.ac.za:9090
+product_name = jenkins_qualification_correlator
+interface = enp129s0np0
+use_ibv = true
+log_cli = true
+log_cli_level = info
+addopts = --report-log=report.json


### PR DESCRIPTION
This PR is for adding a qualification stage to the Jenkins CI/CD pipeline. Th following changes were made:

Add Jenkins pipeline stage for running qualification tests.
Add network device parameters to allow Docker container to access Correlator network for ingesting data.
Add pytest config file for Jenkins qualification test environment.
Add dependencies for latex pdf document generation.
Generate QTR and send with Jenkins email notifications.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] N/A If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] N/A If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] N/A If qualification tests are changed: attach a sample qualification report
- [x] N/A If design has changed: ensure documentation is up to date

Contributes to NGC-766.
