### PR TITLE
Fix up unit test after xarray 2022.10.0 upgrade

### DIFF
--- a/test/dsim/test_send.py
+++ b/test/dsim/test_send.py
@@ -77,6 +77,11 @@ async def test_sender(
     # The last 3 half-heapsets are from after the switch
     switch_heap = SIGNAL_HEAPS * repeats - 3 * (SIGNAL_HEAPS // 2)
     switch_task: Optional[asyncio.Future[int]] = None
+    # The copy below fails on xarray >= 2022.9.0 because it tries to deep-copy
+    # SharedArray, which doesn't support that. The attribute isn't needed for
+    # this test, so just delete it.
+    for heap_set in heap_sets:
+        del heap_set.data["payload"].attrs["shared_array"]
     orig_payload = [heap_set.data["payload"].copy() for heap_set in heap_sets]
 
     async def switch_heap_sets() -> int:


### PR DESCRIPTION
It changed so that `copy` now deep-copies attributes, which broken when one of them is a SharedArray.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
