### PR TITLE
Use empty string to log in to dockerhub

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -149,7 +149,7 @@ pipeline {
           branch = env.BRANCH_NAME
           tag = (branch == "main") ? "latest" : branch
           // Supply credentials to Dockerhub so that we can reliably pull the base image
-          docker.withRegistry("https://docker.io/", "dockerhub") {
+          docker.withRegistry("", "dockerhub") {
             dockerImage = docker.build(
               "harbor.sdp.kat.ac.za/cbf/katgpucbf:${tag}",
               "--pull "


### PR DESCRIPTION
The previous version didn't seem to be working for avoiding rate limits.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date