### PR TITLE
Force pre-commit to run with Python 3.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3
+  python: python3.8
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
This is particularly needed for the pip-compile hook, since the output is different depending on the Python version.

<!-- Add a description of your change here -->

Checklist is N/A.

Relates to NGC-560.