### PR TITLE
Update all Python dependencies to latest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: no-commit-to-branch # without arguments, master/main will be protected.
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.10.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
@@ -23,7 +23,7 @@ repos:
       - id: isort
         name: isort
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies: [
@@ -36,7 +36,7 @@ repos:
       - id: pydocstyle
         exclude: 'setup.py|scratch/'  # Because complaining about docstrings here is annoying.
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.961'
+    rev: 'v0.982'
     hooks:
       - id: mypy
         # Passing filenames to mypy can do odd things. See
@@ -50,21 +50,21 @@ repos:
         types_or: [python, pyi]
         additional_dependencies: [
             'aiokatcp==1.3.1',
-            'dask==2022.6.1',
-            'katsdpsigproc==1.4.2',
+            'dask==2022.10.0',
+            'katsdpsigproc==1.4.3',
             'katsdptelstate==0.11',
-            'numpy==1.22.4',
+            'numpy==1.23.4',
             'pyparsing==3.0.9',
-            'pytest==7.1.2',
+            'pytest==7.1.3',
             'spead2==3.11.1',
             'types-decorator==5.1.1',
             'types-docutils==0.17.1',
-            'types-redis==4.3.3',
+            'types-redis==4.3.4',
             'types-setuptools==57.0.0',
             'types-six==1.16.0',
         ]
   - repo: https://github.com/jazzband/pip-tools
-    rev: 6.8.0
+    rev: 6.9.0
     hooks:
       - id: pip-compile
         name: pip-compile requirements.in

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12
     # via
     #   -r qualification/../requirements-dev.txt
     #   sphinx
-asttokens==2.0.5
+asttokens==2.0.8
     # via
     #   -r qualification/../requirements-dev.txt
     #   stack-data
@@ -16,7 +16,7 @@ async-timeout==4.0.2
     # via
     #   -r qualification/../requirements-dev.txt
     #   -r qualification/requirements.in
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   -r qualification/../requirements-dev.txt
     #   pytest
@@ -36,7 +36,7 @@ build==0.8.0
     # via
     #   -r qualification/../requirements-dev.txt
     #   pip-tools
-certifi==2022.6.15
+certifi==2022.9.24
     # via
     #   -r qualification/../requirements-dev.txt
     #   requests
@@ -44,7 +44,7 @@ cfgv==3.3.1
     # via
     #   -r qualification/../requirements-dev.txt
     #   pre-commit
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via
     #   -r qualification/../requirements-dev.txt
     #   requests
@@ -52,7 +52,9 @@ click==8.1.3
     # via
     #   -r qualification/../requirements-dev.txt
     #   pip-tools
-coverage[toml]==6.4.1
+contourpy==1.0.5
+    # via matplotlib
+coverage[toml]==6.5.0
     # via
     #   -r qualification/../requirements-dev.txt
     #   pytest-cov
@@ -64,7 +66,7 @@ decorator==5.1.1
     # via
     #   -r qualification/../requirements-dev.txt
     #   ipython
-distlib==0.3.4
+distlib==0.3.6
     # via
     #   -r qualification/../requirements-dev.txt
     #   virtualenv
@@ -80,39 +82,41 @@ execnet==1.9.0
     # via
     #   -r qualification/../requirements-dev.txt
     #   pytest-xdist
-executing==0.8.3
+executing==1.1.1
     # via
     #   -r qualification/../requirements-dev.txt
     #   stack-data
-filelock==3.7.1
+filelock==3.8.0
     # via
     #   -r qualification/../requirements-dev.txt
     #   virtualenv
-fonttools==4.33.3
+fonttools==4.37.4
     # via matplotlib
 httmock==1.4.0
     # via prometheus-api-client
-identify==2.5.1
+identify==2.5.6
     # via
     #   -r qualification/../requirements-dev.txt
     #   pre-commit
-idna==3.3
+idna==3.4
     # via
     #   -r qualification/../requirements-dev.txt
     #   requests
-imagesize==1.4.0
+imagesize==1.4.1
     # via
     #   -r qualification/../requirements-dev.txt
     #   sphinx
-importlib-metadata==4.12.0
+importlib-metadata==5.0.0
     # via
     #   -r qualification/../requirements-dev.txt
+    #   numba
     #   sphinx
+    #   sphinxcontrib-bibtex
 iniconfig==1.1.1
     # via
     #   -r qualification/../requirements-dev.txt
     #   pytest
-ipython==8.4.0
+ipython==8.5.0
     # via -r qualification/../requirements-dev.txt
 jedi==0.18.1
     # via
@@ -122,13 +126,13 @@ jinja2==3.1.2
     # via
     #   -r qualification/../requirements-dev.txt
     #   sphinx
-kiwisolver==1.4.2
+kiwisolver==1.4.4
     # via matplotlib
 latexcodec==2.0.1
     # via
     #   -r qualification/../requirements-dev.txt
     #   pybtex
-llvmlite==0.38.1
+llvmlite==0.39.1
     # via
     #   -r qualification/../requirements-dev.txt
     #   numba
@@ -136,11 +140,11 @@ markupsafe==2.1.1
     # via
     #   -r qualification/../requirements-dev.txt
     #   jinja2
-matplotlib==3.5.2
+matplotlib==3.6.1
     # via
     #   -r qualification/requirements.in
     #   prometheus-api-client
-matplotlib-inline==0.1.3
+matplotlib-inline==0.1.6
     # via
     #   -r qualification/../requirements-dev.txt
     #   ipython
@@ -148,12 +152,13 @@ nodeenv==1.7.0
     # via
     #   -r qualification/../requirements-dev.txt
     #   pre-commit
-numba==0.55.2
+numba==0.56.3
     # via -r qualification/../requirements-dev.txt
-numpy==1.22.4
+numpy==1.23.4
     # via
     #   -r qualification/../requirements-dev.txt
     #   -r qualification/requirements.in
+    #   contourpy
     #   matplotlib
     #   numba
     #   pandas
@@ -168,13 +173,13 @@ packaging==21.3
     #   matplotlib
     #   pytest
     #   sphinx
-pandas==1.4.3
+pandas==1.5.0
     # via prometheus-api-client
 parso==0.8.3
     # via
     #   -r qualification/../requirements-dev.txt
     #   jedi
-pep517==0.12.0
+pep517==0.13.0
     # via
     #   -r qualification/../requirements-dev.txt
     #   build
@@ -186,9 +191,9 @@ pickleshare==0.7.5
     # via
     #   -r qualification/../requirements-dev.txt
     #   ipython
-pillow==9.1.1
+pillow==9.2.0
     # via matplotlib
-pip-tools==6.8.0
+pip-tools==6.9.0
     # via -r qualification/../requirements-dev.txt
 platformdirs==2.5.2
     # via
@@ -198,11 +203,11 @@ pluggy==1.0.0
     # via
     #   -r qualification/../requirements-dev.txt
     #   pytest
-pre-commit==2.19.0
+pre-commit==2.20.0
     # via -r qualification/../requirements-dev.txt
 prometheus-api-client==0.5.1
     # via -r qualification/requirements.in
-prompt-toolkit==3.0.30
+prompt-toolkit==3.0.31
     # via
     #   -r qualification/../requirements-dev.txt
     #   ipython
@@ -230,7 +235,7 @@ pybtex-docutils==1.0.2
     #   sphinxcontrib-bibtex
 pycparser==2.21
     # via -r qualification/../requirements-dev.txt
-pygments==2.12.0
+pygments==2.13.0
     # via
     #   -r qualification/../requirements-dev.txt
     #   ipython
@@ -242,7 +247,7 @@ pyparsing==3.0.9
     #   -r qualification/../requirements-dev.txt
     #   matplotlib
     #   packaging
-pytest==7.1.2
+pytest==7.1.3
     # via
     #   -r qualification/../requirements-dev.txt
     #   -r qualification/requirements.in
@@ -252,17 +257,17 @@ pytest==7.1.2
     #   pytest-mock
     #   pytest-reportlog
     #   pytest-xdist
-pytest-asyncio==0.18.3
+pytest-asyncio==0.19.0
     # via -r qualification/../requirements-dev.txt
-pytest-check==1.0.9
+pytest-check==1.0.10
     # via -r qualification/requirements.in
-pytest-cov==3.0.0
+pytest-cov==4.0.0
     # via -r qualification/../requirements-dev.txt
 pytest-forked==1.4.0
     # via
     #   -r qualification/../requirements-dev.txt
     #   pytest-xdist
-pytest-mock==3.8.1
+pytest-mock==3.10.0
     # via -r qualification/../requirements-dev.txt
 pytest-reportlog==0.1.2
     # via -r qualification/requirements.in
@@ -273,7 +278,7 @@ python-dateutil==2.8.2
     #   dateparser
     #   matplotlib
     #   pandas
-pytz==2022.1
+pytz==2022.4
     # via
     #   -r qualification/../requirements-dev.txt
     #   babel
@@ -301,14 +306,13 @@ six==1.16.0
     #   latexcodec
     #   pybtex
     #   python-dateutil
-    #   virtualenv
 snowballstemmer==2.2.0
     # via
     #   -r qualification/../requirements-dev.txt
     #   sphinx
 spead2==3.11.1
     # via -r qualification/requirements.in
-sphinx==5.0.2
+sphinx==5.3.0
     # via
     #   -r qualification/../requirements-dev.txt
     #   sphinx-mathjax-offline
@@ -323,7 +327,7 @@ sphinxcontrib-applehelp==1.0.2
     # via
     #   -r qualification/../requirements-dev.txt
     #   sphinx
-sphinxcontrib-bibtex==2.4.2
+sphinxcontrib-bibtex==2.5.0
     # via -r qualification/../requirements-dev.txt
 sphinxcontrib-devhelp==1.0.2
     # via
@@ -347,7 +351,7 @@ sphinxcontrib-serializinghtml==1.1.5
     #   sphinx
 sphinxcontrib-tikz==0.4.16
     # via -r qualification/../requirements-dev.txt
-stack-data==0.3.0
+stack-data==0.5.1
     # via
     #   -r qualification/../requirements-dev.txt
     #   ipython
@@ -362,20 +366,20 @@ tomli==2.0.1
     #   coverage
     #   pep517
     #   pytest
-traitlets==5.3.0
+traitlets==5.4.0
     # via
     #   -r qualification/../requirements-dev.txt
     #   ipython
     #   matplotlib-inline
-tzdata==2022.1
+tzdata==2022.5
     # via pytz-deprecation-shim
 tzlocal==4.2
     # via dateparser
-urllib3==1.26.9
+urllib3==1.26.12
     # via
     #   -r qualification/../requirements-dev.txt
     #   requests
-virtualenv==20.15.1
+virtualenv==20.16.5
     # via
     #   -r qualification/../requirements-dev.txt
     #   pre-commit
@@ -387,7 +391,7 @@ wheel==0.37.1
     # via
     #   -r qualification/../requirements-dev.txt
     #   pip-tools
-zipp==3.8.0
+zipp==3.9.0
     # via
     #   -r qualification/../requirements-dev.txt
     #   importlib-metadata

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,13 +6,13 @@
 #
 alabaster==0.7.12
     # via sphinx
-asttokens==2.0.5
+asttokens==2.0.8
     # via stack-data
 async-timeout==4.0.2
     # via
     #   -c requirements.txt
     #   -r requirements-dev.in
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   -c requirements.txt
     #   pytest
@@ -22,17 +22,17 @@ backcall==0.2.0
     # via ipython
 build==0.8.0
     # via pip-tools
-certifi==2022.6.15
+certifi==2022.9.24
     # via requests
 cfgv==3.3.1
     # via pre-commit
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via
     #   -c requirements.txt
     #   requests
 click==8.1.3
     # via pip-tools
-coverage[toml]==6.4.1
+coverage[toml]==6.5.0
     # via
     #   -r requirements-dev.in
     #   pytest-cov
@@ -40,7 +40,7 @@ decorator==5.1.1
     # via
     #   -c requirements.txt
     #   ipython
-distlib==0.3.4
+distlib==0.3.6
     # via virtualenv
 docutils==0.17.1
     # via
@@ -50,23 +50,27 @@ docutils==0.17.1
     #   sphinxcontrib-bibtex
 execnet==1.9.0
     # via pytest-xdist
-executing==0.8.3
+executing==1.1.1
     # via stack-data
-filelock==3.7.1
+filelock==3.8.0
     # via virtualenv
-identify==2.5.1
+identify==2.5.6
     # via pre-commit
-idna==3.3
+idna==3.4
     # via
     #   -c requirements.txt
     #   requests
-imagesize==1.4.0
+imagesize==1.4.1
     # via sphinx
-importlib-metadata==4.12.0
-    # via sphinx
+importlib-metadata==5.0.0
+    # via
+    #   -c requirements.txt
+    #   numba
+    #   sphinx
+    #   sphinxcontrib-bibtex
 iniconfig==1.1.1
     # via pytest
-ipython==8.4.0
+ipython==8.5.0
     # via -r requirements-dev.in
 jedi==0.18.1
     # via ipython
@@ -76,7 +80,7 @@ jinja2==3.1.2
     #   sphinx
 latexcodec==2.0.1
     # via pybtex
-llvmlite==0.38.1
+llvmlite==0.39.1
     # via
     #   -c requirements.txt
     #   numba
@@ -84,15 +88,15 @@ markupsafe==2.1.1
     # via
     #   -c requirements.txt
     #   jinja2
-matplotlib-inline==0.1.3
+matplotlib-inline==0.1.6
     # via ipython
 nodeenv==1.7.0
     # via pre-commit
-numba==0.55.2
+numba==0.56.3
     # via
     #   -c requirements.txt
     #   -r requirements-dev.in
-numpy==1.22.4
+numpy==1.23.4
     # via
     #   -c requirements.txt
     #   numba
@@ -104,13 +108,13 @@ packaging==21.3
     #   sphinx
 parso==0.8.3
     # via jedi
-pep517==0.12.0
+pep517==0.13.0
     # via build
 pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip-tools==6.8.0
+pip-tools==6.9.0
     # via -r requirements-dev.in
 platformdirs==2.5.2
     # via
@@ -118,9 +122,9 @@ platformdirs==2.5.2
     #   virtualenv
 pluggy==1.0.0
     # via pytest
-pre-commit==2.19.0
+pre-commit==2.20.0
     # via -r requirements-dev.in
-prompt-toolkit==3.0.30
+prompt-toolkit==3.0.31
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
@@ -140,7 +144,7 @@ pycparser==2.21
     # via
     #   -c requirements.txt
     #   -r requirements-dev.in
-pygments==2.12.0
+pygments==2.13.0
     # via
     #   ipython
     #   sphinx
@@ -148,7 +152,7 @@ pyparsing==3.0.9
     # via
     #   -c requirements.txt
     #   packaging
-pytest==7.1.2
+pytest==7.1.3
     # via
     #   -r requirements-dev.in
     #   pytest-asyncio
@@ -156,17 +160,17 @@ pytest==7.1.2
     #   pytest-forked
     #   pytest-mock
     #   pytest-xdist
-pytest-asyncio==0.18.3
+pytest-asyncio==0.19.0
     # via -r requirements-dev.in
-pytest-cov==3.0.0
+pytest-cov==4.0.0
     # via -r requirements-dev.in
 pytest-forked==1.4.0
     # via pytest-xdist
-pytest-mock==3.8.1
+pytest-mock==3.10.0
     # via -r requirements-dev.in
 pytest-xdist==2.5.0
     # via -r requirements-dev.in
-pytz==2022.1
+pytz==2022.4
     # via
     #   -c requirements.txt
     #   babel
@@ -183,10 +187,9 @@ six==1.16.0
     #   asttokens
     #   latexcodec
     #   pybtex
-    #   virtualenv
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.0.2
+sphinx==5.3.0
     # via
     #   -r requirements-dev.in
     #   sphinx-mathjax-offline
@@ -199,7 +202,7 @@ sphinx-rtd-theme==1.0.0
     # via -r requirements-dev.in
 sphinxcontrib-applehelp==1.0.2
     # via sphinx
-sphinxcontrib-bibtex==2.4.2
+sphinxcontrib-bibtex==2.5.0
     # via -r requirements-dev.in
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
@@ -213,7 +216,7 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 sphinxcontrib-tikz==0.4.16
     # via -r requirements-dev.in
-stack-data==0.3.0
+stack-data==0.5.1
     # via ipython
 toml==0.10.2
     # via pre-commit
@@ -223,20 +226,22 @@ tomli==2.0.1
     #   coverage
     #   pep517
     #   pytest
-traitlets==5.3.0
+traitlets==5.4.0
     # via
     #   ipython
     #   matplotlib-inline
-urllib3==1.26.9
+urllib3==1.26.12
     # via requests
-virtualenv==20.15.1
+virtualenv==20.16.5
     # via pre-commit
 wcwidth==0.2.5
     # via prompt-toolkit
 wheel==0.37.1
     # via pip-tools
-zipp==3.8.0
-    # via importlib-metadata
+zipp==3.9.0
+    # via
+    #   -c requirements.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile requirements.in
 #
-aioconsole==0.4.1
+aioconsole==0.5.1
     # via aiomonitor
-aiohttp==3.8.1
+aiohttp==3.8.3
     # via -r requirements.in
 aiokatcp==1.3.1
     # via -r requirements.in
@@ -23,15 +23,15 @@ async-timeout==4.0.2
     #   aiohttp
     #   aiokatcp
     #   redis
-attrs==21.4.0
+attrs==22.1.0
     # via aiohttp
 cffi==1.15.1
     # via vkgdr
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via aiohttp
-cloudpickle==2.1.0
+cloudpickle==2.2.0
     # via dask
-dask==2022.6.1
+dask==2022.10.0
     # via -r requirements.in
 decorator==5.1.1
     # via
@@ -39,27 +39,29 @@ decorator==5.1.1
     #   katsdpsigproc
 deprecated==1.2.13
     # via redis
-frozenlist==1.3.0
+frozenlist==1.3.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2022.5.0
+fsspec==2022.8.2
     # via dask
 hiredis==2.0.0
     # via katsdptelstate
-idna==3.3
+idna==3.4
     # via yarl
+importlib-metadata==5.0.0
+    # via numba
 katsdpservices[aiomonitor]==1.2
     # via -r requirements.in
-katsdpsigproc[cuda]==1.4.2
+katsdpsigproc[cuda]==1.4.3
     # via -r requirements.in
 katsdptelstate==0.11
     # via -r requirements.in
-llvmlite==0.38.1
+llvmlite==0.39.1
     # via numba
 locket==1.0.0
     # via partd
-mako==1.2.2
+mako==1.2.3
     # via
     #   katsdpsigproc
     #   pycuda
@@ -75,9 +77,9 @@ netifaces==0.11.0
     # via
     #   katsdpservices
     #   katsdptelstate
-numba==0.55.2
+numba==0.56.3
     # via katsdpsigproc
-numpy==1.22.4
+numpy==1.23.4
     # via
     #   -r requirements.in
     #   katsdpsigproc
@@ -92,19 +94,19 @@ packaging==21.3
     #   dask
     #   redis
     #   xarray
-pandas==1.4.3
+pandas==1.5.0
     # via
     #   katsdpsigproc
     #   xarray
-partd==1.2.0
+partd==1.3.0
     # via dask
 platformdirs==2.5.2
     # via pytools
 prometheus-async==22.2.0
     # via -r requirements.in
-prometheus-client==0.14.1
+prometheus-client==0.15.0
     # via prometheus-async
-psutil==5.9.1
+psutil==5.9.2
     # via -r requirements.in
 pycparser==2.21
     # via cffi
@@ -122,13 +124,13 @@ python-dateutil==2.8.2
     # via pandas
 pytools==2022.1.12
     # via pycuda
-pytz==2022.1
+pytz==2022.4
     # via pandas
 pyyaml==6.0
     # via dask
 redis==4.3.4
     # via katsdptelstate
-scipy==1.8.1
+scipy==1.9.2
     # via katsdpsigproc
 six==1.16.0
     # via
@@ -138,11 +140,11 @@ spead2==3.11.1
     # via -r requirements.in
 terminaltables==3.1.10
     # via aiomonitor
-toolz==0.11.2
+toolz==0.12.0
     # via
     #   dask
     #   partd
-typing-extensions==4.2.0
+typing-extensions==4.4.0
     # via
     #   aiokatcp
     #   katsdpsigproc
@@ -154,10 +156,12 @@ wrapt==1.14.1
     # via
     #   deprecated
     #   prometheus-async
-xarray==2022.3.0
+xarray==2022.10.0
     # via -r requirements.in
-yarl==1.7.2
+yarl==1.8.1
     # via aiohttp
+zipp==3.9.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
The main motivation is to work around
https://github.com/inducer/pycuda/pull/387 when building on Python 3.10, but I figured I'd update everything. I still ran pip-compile on Python 3.8 so it shouldn't have upgraded to anything that no longer supports 3.8.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] (N/A) Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date

Relates to NGC-560.
