### PR TITLE
Eliminate checks for negative delays

### DIFF
--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -226,7 +226,7 @@ async def test_delay_sensors(
     load_time = now + 2.0
     load_ts = receiver.unix_to_timestamp(load_time)
     for _ in range(receiver.n_inputs):
-        delay = rng.uniform(0.0, MAX_DELAY)
+        delay = rng.uniform(-MAX_DELAY, MAX_DELAY)
         delay_rate = rng.uniform(-MAX_DELAY_RATE, MAX_DELAY_RATE)
         phase = rng.uniform(-np.pi, np.pi)
         phase_rate = rng.uniform(-MAX_PHASE_RATE, MAX_PHASE_RATE)
@@ -465,7 +465,7 @@ async def test_delay(
     """
     receiver = receive_baseline_correlation_products
     # Minimum, maximum, resolution step, and a small coarse delay
-    delays = [0.0, MAX_DELAY, 2.5e-12, 2.75 / receiver.scale_factor_timestamp]
+    delays = [0.0, MAX_DELAY, -MAX_DELAY, 2.5e-12, 2.75 / receiver.scale_factor_timestamp]
     await _test_delay_phase_fixed(
         correlator,
         receive_baseline_correlation_products,

--- a/src/katgpucbf/fgpu/delay.py
+++ b/src/katgpucbf/fgpu/delay.py
@@ -150,8 +150,6 @@ class LinearDelayModel(AbstractDelayModel):
         rel_time = np.arange(start - self.start, stop - self.start, step, dtype=np.dtype(np.int64))
         delay = self.delay + rel_time * self.delay_rate
         coarse_delay = np.rint(delay).astype(np.int64)
-        # Prevent coarse delay from becoming negative
-        coarse_delay = np.maximum(coarse_delay, 0)
         fine_delay = delay - coarse_delay
 
         # Calculate the phase

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1323,10 +1323,6 @@ class Engine(aiokatcp.DeviceServer):
             delay_str, phase_str = coeffs.split(":")
             delay, delay_rate = comma_string_to_float(delay_str)
             phase, phase_rate = comma_string_to_float(phase_str)
-            if delay < 0:
-                raise aiokatcp.FailReply("delay cannot be negative")
-            if delay + 5 * delay_rate < 0:
-                logger.warning("delay will become negative within 5s")
 
             delay_samples = delay * self.adc_sample_rate
             # For compatibility with MeerKAT, the phase given is the net change in

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -357,7 +357,7 @@ class TestEngine:
         [
             (0.0, 0.0),
             (8192.0, 234.5),
-            (42.0, 58.0),
+            (-42.0, 58.0),
             (42.4, 24.2),
             pytest.param((42.7, 24.9), marks=[pytest.mark.cmdline_args("--dst-chunk-jones=65536")]),
             pytest.param((42.8, 24.5), marks=[pytest.mark.use_vkgdr]),

--- a/test/fgpu/test_katcp_interface.py
+++ b/test/fgpu/test_katcp_interface.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2021, National Research Foundation (SARAO)
+# Copyright (c) 2020-2022, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -202,7 +202,6 @@ class TestKatcpRequests:
             "3.76,0.12:7.322-1.91",  # Missing comma, phase half
             "3.76,0.12:apple,1.91",  # Non-float value for phase
             "3.76,pear:7.322,1.91",  # Non-float value for delay rate
-            "-1.0,0.0:0.0,0.0",  # Negative delay
         ],
     )
     async def test_delay_model_update_malformed(self, engine_client, malformed_delay_string):


### PR DESCRIPTION
Negative delays should work fine, but there were checks to prevent them being used.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date

Closes NGC-795.

[report-NGC-795-negative-delays.pdf](https://github.com/ska-sa/katgpucbf/files/9830799/report-NGC-795-negative-delays.pdf)
