### PR TITLE
Manually update annotations for Py 3.10

### DIFF
--- a/scratch/fgpu/showf/backend.py
+++ b/scratch/fgpu/showf/backend.py
@@ -3,7 +3,6 @@ import asyncio
 import copy
 import functools
 from collections import deque
-from typing import Deque
 
 import bokeh.server.contexts
 import numpy as np
@@ -70,7 +69,7 @@ class Backend:
             spead2.recv.RingStreamConfig(heaps=32 * substreams),
         )
         self.stream.add_udp_ibv_reader(endpoint_tuples, get_interface_address(interface), buffer_size=64 * 1024 * 1024)
-        self.frames: Deque[Frame] = deque()
+        self.frames: deque[Frame] = deque()
         self.last_full_timestamp = -1
         self.server_context = server_context
 

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -23,7 +23,7 @@ from collections import deque
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from functools import partial
-from typing import Deque, Optional, cast
+from typing import cast
 
 import aiokatcp
 import katsdpsigproc.accel as accel
@@ -474,13 +474,11 @@ class Engine(aiokatcp.DeviceServer):
         n_send = 4
         n_out = n_send if use_peerdirect else 2
 
-        # The type annotations have to be in comments because Python 3.8
-        # doesn't support the syntax at runtime (Python 3.9 fixes that).
-        self._in_queue = monitor.make_queue("in_queue", n_in)  # type: asyncio.Queue[Optional[InItem]]
-        self._in_free_queue = monitor.make_queue("in_free_queue", n_in)  # type: asyncio.Queue[InItem]
-        self._out_queue = monitor.make_queue("out_queue", n_out)  # type: asyncio.Queue[Optional[OutItem]]
-        self._out_free_queue = monitor.make_queue("out_free_queue", n_out)  # type: asyncio.Queue[OutItem]
-        self._send_free_queue = monitor.make_queue("send_free_queue", n_send)  # type: asyncio.Queue[send.Chunk]
+        self._in_queue: asyncio.Queue[InItem | None] = monitor.make_queue("in_queue", n_in)
+        self._in_free_queue: asyncio.Queue[InItem] = monitor.make_queue("in_free_queue", n_in)
+        self._out_queue: asyncio.Queue[OutItem | None] = monitor.make_queue("out_queue", n_out)
+        self._out_free_queue: asyncio.Queue[OutItem] = monitor.make_queue("out_free_queue", n_out)
+        self._send_free_queue: asyncio.Queue[send.Chunk] = monitor.make_queue("send_free_queue", n_send)
 
         self._init_compute(
             context=context,
@@ -491,7 +489,7 @@ class Engine(aiokatcp.DeviceServer):
             max_delay_diff=max_delay_diff,
         )
 
-        self._in_items: Deque[InItem] = deque()
+        self._in_items: deque[InItem] = deque()
         self._init_recv(src_affinity, monitor)
 
         send_chunks = self._init_send(len(dst), use_peerdirect)

--- a/src/katgpucbf/fgpu/recv.py
+++ b/src/katgpucbf/fgpu/recv.py
@@ -22,7 +22,7 @@ from collections import deque
 from collections.abc import AsyncGenerator, Sequence
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Deque, cast
+from typing import cast
 
 import numba
 import numpy as np
@@ -235,7 +235,7 @@ async def chunk_sets(
     n_pol = len(streams)
     # Working buffer to match up pairs of chunks from both pols. There is
     # a deque for each pol, ordered by time
-    buf: list[Deque[Chunk]] = [deque() for _ in streams]
+    buf: list[deque[Chunk]] = [deque() for _ in streams]
     ring = cast(spead2.recv.asyncio.ChunkRingbuffer, streams[0].data_ringbuffer)
     lost = 0
 

--- a/src/katgpucbf/recv.py
+++ b/src/katgpucbf/recv.py
@@ -88,7 +88,7 @@ class StatsCollector(Collector):
     class _StreamInfo:
         """Information about a single registered stream."""
 
-        stream: "weakref.ReferenceType[spead2.recv.ChunkRingStream]"
+        stream: weakref.ReferenceType[spead2.recv.ChunkRingStream]
         indices: list[int]  # Indices of counters, in the order given by counter_map
         prev: list[int]  # Amounts already counted
 

--- a/test/dsim/test_shared_array.py
+++ b/test/dsim/test_shared_array.py
@@ -18,7 +18,6 @@
 
 import multiprocessing
 from collections.abc import Generator
-from typing import Union
 
 import numpy as np
 import pytest
@@ -26,9 +25,11 @@ import pytest
 from katgpucbf.dsim.shared_array import SharedArray
 
 # Process isn't an attribute of BaseContext but of each subclass
-_MPContext = Union[
-    multiprocessing.context.ForkContext, multiprocessing.context.ForkServerContext, multiprocessing.context.SpawnContext
-]
+_MPContext = (
+    multiprocessing.context.ForkContext
+    | multiprocessing.context.ForkServerContext
+    | multiprocessing.context.SpawnContext
+)
 
 
 @pytest.fixture


### PR DESCRIPTION
- Convert a Union -> | that pyupgrade missed (split over lines)
- Replace typing.Deque with collections.deque
- Move typing comments for asyncio.Queue into proper annotations (Python 3.8 didn't support `Queue.__class_getitem__`).
- Remove quotes around weakref.ReferenceType annotation

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date

Closes NGC-560.
