### PR TITLE
Fix qualification report errors from siunitx v3

### DIFF
--- a/qualification/report/requirements_text/CBF-REQ-0112.tex
+++ b/qualification/report/requirements_text/CBF-REQ-0112.tex
@@ -1,8 +1,8 @@
 The CBF shall apply the phase polynomial, as provided via the
 CAM interface, with the following criteria:
 \begin{enumerate}
-\item range of fringe phase: $\SI{-\pi}{\radian}$ to $\SI{\pi}{\radian}$
-($\ang{-180}$ to $\ang{+180}$)
+\item range of fringe phase: $\SI[parse-numbers=false]{-\pi}{\radian}$ to
+$\SI[parse-numbers=false]{\pi}{\radian}$ ($\ang{-180}$ to $\ang{+180}$)
 \item resolution of fringe phase: less than or equal to $\SI{0.01}{\radian}$
 ($\ang{0.57}$)
 \item range of rate of change of fringe phase: $\le


### PR DESCRIPTION
siunitx now tries harder to parse the number, and `-\pi` isn't a number it understands.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] (N/A) Ensure copyright notices are present and up-to-date
- [ ] If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date

Closes NGC-821.
