### PR TITLE
Ngc 820 save json report

### DIFF
--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -90,7 +90,7 @@ pipeline {
   post {
     always {
       emailext attachLog: true,
-      attachmentsPattern: 'report.json, report.pdf',
+      attachmentsPattern: 'report.pdf',
       body: """<b>Overall Test Results:</b> ${env.JOB_NAME} - Build#${env.BUILD_NUMBER} - ${currentBuild.result}<br>
       <b>Node:</b> ${env.NODE_NAME}<br>
       <b>Duration:</b> ${currentBuild.durationString}<br>

--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -75,7 +75,7 @@ pipeline {
            sh 'pip install --no-deps ".[qualification]" && pip check'
            sh 'spead2_net_raw pytest -v -c qualification/pytest-jenkins.ini qualification --image-override katgpucbf:harbor.sdp.kat.ac.za/cbf/katgpucbf:latest'
            sh 'qualification/report/generate_pdf.py report.json report.pdf'
-           publishHTML(target: [keepAll: true, reportName: 'Qualification Test Report', reportDir: '', reportFiles: 'report.json, report.pdf'])
+           publishHTML(target: [keepAll: true, reportName: 'Qualification Test Report', reportDir: '', reportFiles: 'report.pdf, report.json', reportTitles: 'report.pdf, report.json'])
          }
        }
     }

--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -75,7 +75,7 @@ pipeline {
            sh 'pip install --no-deps ".[qualification]" && pip check'
            sh 'spead2_net_raw pytest -v -c qualification/pytest-jenkins.ini qualification --image-override katgpucbf:harbor.sdp.kat.ac.za/cbf/katgpucbf:latest'
            sh 'qualification/report/generate_pdf.py report.json report.pdf'
-           publishHTML(target: [keepAll: true, reportName: 'Qualification Test Report', reportDir: '', reportFiles: 'report.pdf'])
+           publishHTML(target: [keepAll: true, reportName: 'Qualification Test Report', reportDir: '', reportFiles: 'report.json, report.pdf'])
          }
        }
     }
@@ -90,7 +90,7 @@ pipeline {
   post {
     always {
       emailext attachLog: true,
-      attachmentsPattern: 'report.pdf',
+      attachmentsPattern: 'report.json, report.pdf',
       body: """<b>Overall Test Results:</b> ${env.JOB_NAME} - Build#${env.BUILD_NUMBER} - ${currentBuild.result}<br>
       <b>Node:</b> ${env.NODE_NAME}<br>
       <b>Duration:</b> ${currentBuild.durationString}<br>


### PR DESCRIPTION
This PR allows the report.json file generated by the qualification tests, to be saved to the corresponding Jenkins build.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [ x ] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [ x ] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [ x ] Ensure copyright notices are present and up-to-date
- [ x ] (N/A) If qualification tests are changed: attach a sample qualification report
- [ x ] (N/A) If design has changed: ensure documentation is up to date

Closes NGC-820.
