### PR TITLE
Remove specialised config for cbfgpu06 in scratch

### DIFF
--- a/scratch/config/cbfgpu06.sh
+++ b/scratch/config/cbfgpu06.sh
@@ -1,4 +1,1 @@
-iface1=enp193s0f0
-iface2=enp193s0f1
-cuda1=0
-cuda2=0
+cbfgpu01.sh


### PR DESCRIPTION
The machine has been reinstalled and now has the same interface name as the others.

Checklist is all N/A.

Closes NGC-519.
