### PR TITLE
Introduce device status sensors for the F- and X-engines

### DIFF
--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -452,7 +452,6 @@ class Engine(aiokatcp.DeviceServer):
     ) -> None:
         super().__init__(katcp_host, katcp_port)
         self._populate_sensors(self.sensors)
-        self.sensors.add(DeviceStatusSensor(self.sensors))
 
         # Attributes copied or initialised from arguments
         self._srcs = list(srcs)
@@ -719,6 +718,7 @@ class Engine(aiokatcp.DeviceServer):
                 initial_status=aiokatcp.Sensor.Status.NOMINAL,
             )
         )
+        sensors.add(DeviceStatusSensor(sensors))
 
     async def _next_in(self) -> InItem | None:
         """Load next InItem for processing.

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -49,6 +49,7 @@ from ..monitor import Monitor
 from ..queue_item import QueueItem
 from ..ringbuffer import ChunkRingbuffer
 from ..send import DescriptorSender
+from ..utils import DeviceStatusSensor
 from . import SAMPLE_BITS, recv, send
 from .compute import Compute, ComputeTemplate
 from .delay import AbstractDelayModel, LinearDelayModel, MultiDelayModel, wrap_angle
@@ -451,6 +452,7 @@ class Engine(aiokatcp.DeviceServer):
     ) -> None:
         super().__init__(katcp_host, katcp_port)
         self._populate_sensors(self.sensors)
+        self.sensors.add(DeviceStatusSensor(self.sensors))
 
         # Attributes copied or initialised from arguments
         self._srcs = list(srcs)

--- a/src/katgpucbf/utils.py
+++ b/src/katgpucbf/utils.py
@@ -100,11 +100,11 @@ class DeviceStatusSensor(aiokatcp.AggregateSensor[DeviceStatus]):
                 worst_status = max(worst_status, sensor.status)
 
         if reading is not None and old_reading is not None:  # i.e. an update
-            # max in order to prevent time from appearing to move backwards
-            # if sensors' timestamps come from different places
             timestamp = sensor.timestamp
-        else:
+        else:  # i.e. an addition or removal
             timestamp = time.time()
+        # max in order to prevent time from appearing to move backwards
+        # if sensors' timestamps come from different places
         timestamp = max(timestamp, self.timestamp)
 
         if worst_status == aiokatcp.Sensor.Status.NOMINAL:

--- a/src/katgpucbf/utils.py
+++ b/src/katgpucbf/utils.py
@@ -90,7 +90,6 @@ class DeviceStatusSensor(aiokatcp.AggregateSensor[DeviceStatus]):
         reading: aiokatcp.Reading[_T] | None,
         old_reading: aiokatcp.Reading[_T] | None,
     ) -> aiokatcp.Reading[DeviceStatus] | None:  # noqa: D102
-
         if reading is not None and old_reading is not None and reading.status == old_reading.status:
             return None  # Sensor didn't change state, so no change in overall device status
         # Otherwise, we have to recalculate.
@@ -100,7 +99,8 @@ class DeviceStatusSensor(aiokatcp.AggregateSensor[DeviceStatus]):
                 worst_status = max(worst_status, sensor.status)
 
         if reading is not None and old_reading is not None:  # i.e. an update
-            timestamp = sensor.timestamp
+            assert updated_sensor is not None
+            timestamp = updated_sensor.timestamp
         else:  # i.e. an addition or removal
             timestamp = time.time()
         # max in order to prevent time from appearing to move backwards

--- a/src/katgpucbf/utils.py
+++ b/src/katgpucbf/utils.py
@@ -108,7 +108,10 @@ class DeviceStatusSensor(aiokatcp.AggregateSensor[DeviceStatus]):
         timestamp = max(timestamp, self.timestamp)
 
         if worst_status == aiokatcp.Sensor.Status.NOMINAL:
-            return aiokatcp.Reading(timestamp, aiokatcp.Sensor.Status.NOMINAL, DeviceStatus.OK)
-        if worst_status == aiokatcp.Sensor.Status.WARN:
-            return aiokatcp.Reading(timestamp, aiokatcp.Sensor.Status.WARN, DeviceStatus.DEGRADED)
-        return aiokatcp.Reading(timestamp, aiokatcp.Sensor.Status.ERROR, DeviceStatus.FAIL)
+            agg_value = DeviceStatus.OK
+        elif worst_status == aiokatcp.Sensor.Status.WARN:
+            agg_value = DeviceStatus.DEGRADED
+        else:
+            agg_value = DeviceStatus.FAIL
+
+        return aiokatcp.Reading(timestamp, worst_status, agg_value)

--- a/src/katgpucbf/utils.py
+++ b/src/katgpucbf/utils.py
@@ -61,11 +61,7 @@ def parse_source(value: str) -> list[tuple[str, int]] | str:
 
 
 class DeviceStatus(Enum):
-    """Discrete `device-status` readings.
-
-    Doesn't follow the convention of :class:`aiokatcp.Sensor.Status` because
-    it's useful for `UNKNOWN` to have the highest (or worst) value.
-    """
+    """Discrete `device-status` readings."""
 
     OK = 1
     DEGRADED = 2
@@ -93,7 +89,7 @@ class DeviceStatusSensor(aiokatcp.AggregateSensor[DeviceStatus]):
         if reading is not None and old_reading is not None and reading.status == old_reading.status:
             return None  # Sensor didn't change state, so no change in overall device status
         # Otherwise, we have to recalculate.
-        worst_status: aiokatcp.Sensor.Status = aiokatcp.Sensor.Status.NOMINAL
+        worst_status = aiokatcp.Sensor.Status.NOMINAL
         for sensor in self.target.values():
             if self.filter_aggregate(sensor):
                 worst_status = max(worst_status, sensor.status)

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -278,7 +278,6 @@ class XBEngine(DeviceServer):
     ):
         super().__init__(katcp_host, katcp_port)
         self.populate_sensors(self.sensors)
-        self.sensors.add(DeviceStatusSensor(self.sensors))
 
         if sample_bits != 8:
             raise ValueError("sample_bits must equal 8 - no other values supported at the moment.")
@@ -463,6 +462,7 @@ class XBEngine(DeviceServer):
                 status_func=lambda value: aiokatcp.Sensor.Status.NOMINAL if value else aiokatcp.Sensor.Status.ERROR,
             )
         )
+        sensors.add(DeviceStatusSensor(sensors))
 
     async def _receiver_loop(self) -> None:
         """

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -63,6 +63,7 @@ from ..monitor import Monitor
 from ..queue_item import QueueItem
 from ..ringbuffer import ChunkRingbuffer
 from ..send import DescriptorSender
+from ..utils import DeviceStatusSensor
 from . import recv
 from .correlation import Correlation, CorrelationTemplate
 from .xsend import XSend, incomplete_accum_counter, make_stream
@@ -277,6 +278,7 @@ class XBEngine(DeviceServer):
     ):
         super().__init__(katcp_host, katcp_port)
         self.populate_sensors(self.sensors)
+        self.sensors.add(DeviceStatusSensor(self.sensors))
 
         if sample_bits != 8:
             raise ValueError("sample_bits must equal 8 - no other values supported at the moment.")


### PR DESCRIPTION
This is fairly straightforward. Most of the complexity lives in `aiokatcp` so I'm hoping to keep this PR simple.

Main possible point of contention that I can see is the `update_aggregate()` mechanism - which could potentially be more efficient. I also couldn't really think of a good way to unit-test things.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date

Closes NGC-442.