### PR TITLE
F-engine saturation metric

### DIFF
--- a/doc/fgpu.design.rst
+++ b/doc/fgpu.design.rst
@@ -215,10 +215,6 @@ compute efficiency. It is costly to compute :math:`U_k` and :math:`V_k` so if we
 compute two elements of :math:`X`` (:math:`X_{k}` and :math:`X_{N-k}`) at once it is better than producing
 only one element of :math:`X`.
 
-**A side note:** When :math:`k = 0` or :math:`k = \frac{N}{2}` the second calculation
-is unnecessary, but it is simpler (and probably cheaper) to just do it anyway
-rather than branch to avoid it.
-
 Why is doing all this work more efficient that letting cuFFT handle the
 real-to-complex transformation? After all, cuFFT most likely does this (or
 something equivalent) internally. The answer is that instead of using a
@@ -355,6 +351,12 @@ as stated earlier from :math:`U = \frac{Z + \overline{Z'}}{2}` and
 :math:`V = \frac{Z - \overline{Z'}}{2j}` (with appropriate twiddle factor) to combine
 the various outputs from cuFFT and get the final desired output :math:`X_k`.
 
+We also wish to keep a tally of saturated (clipped) values, which requires
+that each output value is considered exactly once. This is made more
+complicated by the process that computes :math:`X_k` and :math:`X_{N-k}`
+jointly. With :math:`k = pm + s`, we consider all :math:`0 \le 0 < n` and
+:math:`0 \le s \le \frac{m}{2}`, and discard :math:`X_{N-k}` when :math:`s =
+0` or :math:`s = \frac{m}{2}` as these are duplicated cases.
 
 Postprocessing
 ^^^^^^^^^^^^^^

--- a/doc/fgpu.design.rst
+++ b/doc/fgpu.design.rst
@@ -354,7 +354,7 @@ the various outputs from cuFFT and get the final desired output :math:`X_k`.
 We also wish to keep a tally of saturated (clipped) values, which requires
 that each output value is considered exactly once. This is made more
 complicated by the process that computes :math:`X_k` and :math:`X_{N-k}`
-jointly. With :math:`k = pm + s`, we consider all :math:`0 \le 0 < n` and
+jointly. With :math:`k = pm + s`, we consider all :math:`0 \le p < n` and
 :math:`0 \le s \le \frac{m}{2}`, and discard :math:`X_{N-k}` when :math:`s =
 0` or :math:`s = \frac{m}{2}` as these are duplicated cases.
 

--- a/scratch/fgpu/benchmarks/compute_bench.py
+++ b/scratch/fgpu/benchmarks/compute_bench.py
@@ -72,7 +72,7 @@ def main():
 
         def run():
             fn.run_frontend([fn.buffer("in0"), fn.buffer("in1")], [0, 0], 0, spectra)
-            fn.run_backend(fn.buffer("out"))
+            fn.run_backend(fn.buffer("out"), fn.buffer("saturated"))
 
         run()  # Warmup pass
         start = command_queue.enqueue_marker()

--- a/src/katgpucbf/fgpu/compute.py
+++ b/src/katgpucbf/fgpu/compute.py
@@ -154,6 +154,7 @@ class Compute(accel.OperationSequence):
             # pols so they can share memory.
             "weights": [f"pfb_fir{pol}:weights" for pol in range(N_POLS)],
             "out": ["postproc:out"],
+            "saturated": ["postproc:saturated"],
             "fine_delay": ["postproc:fine_delay"],
             "phase": ["postproc:phase"],
             "gains": ["postproc:gains"],
@@ -202,7 +203,7 @@ class Compute(accel.OperationSequence):
             self.pfb_fir[pol].spectra = spectra
             self.pfb_fir[pol]()
 
-    def run_backend(self, out: accel.DeviceArray) -> None:
+    def run_backend(self, out: accel.DeviceArray, saturated: accel.DeviceArray) -> None:
         """Run the FFT and postproc on the data which has been PFB-FIRed.
 
         Postproc incorporates fine-delay, requantisation and corner-turning.
@@ -212,7 +213,7 @@ class Compute(accel.OperationSequence):
         out
             Destination for the processed data.
         """
-        self.bind(out=out)
+        self.bind(out=out, saturated=saturated)
         # TODO: only bind relevant slots for backend
         self.ensure_all_bound()
         for fft_op in self.fft:

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -611,6 +611,7 @@ class Engine(aiokatcp.DeviceServer):
                 buf = np.frombuffer(dev_buffer, dtype=item.spectra.dtype).reshape(item.spectra.shape)
                 chunk = send.Chunk(
                     buf,
+                    saturated=item.saturated.empty_like(),
                     substreams=substreams,
                     feng_id=self.feng_id,
                 )
@@ -621,11 +622,13 @@ class Engine(aiokatcp.DeviceServer):
         spectra = self._compute.spectra
         if not use_peerdirect:
             # When using PeerDirect, the chunks are created along with the items
-            send_shape = (spectra // self.spectra_per_heap, self.channels, self.spectra_per_heap, N_POLS, COMPLEX)
+            heaps = spectra // self.spectra_per_heap
+            send_shape = (heaps, self.channels, self.spectra_per_heap, N_POLS, COMPLEX)
             for _ in range(self._send_free_queue.maxsize):
                 send_chunks.append(
                     send.Chunk(
                         accel.HostArray(send_shape, send.SEND_DTYPE, context=self._compute.template.context),
+                        accel.HostArray((heaps, N_POLS), np.uint32, context=self._compute.template.context),
                         substreams=substreams,
                         feng_id=self.feng_id,
                     )
@@ -847,6 +850,7 @@ class Engine(aiokatcp.DeviceServer):
             # TODO: only need to copy the relevant region, and can limit
             # postprocessing to the relevant range (the FFT size is baked into
             # the plan, so is harder to modify on the fly).
+            # Without this, saturation counts can be wrong.
             self._compute.buffer("fine_delay").set_async(self._compute.command_queue, self._out_item.fine_delay)
             self._compute.buffer("phase").set_async(self._compute.command_queue, self._out_item.phase)
             self._compute.buffer("gains").set_async(self._compute.command_queue, self._out_item.gains)
@@ -1133,6 +1137,7 @@ class Engine(aiokatcp.DeviceServer):
                 assert isinstance(chunk.data, accel.HostArray)
                 # TODO: use get_region since it might be partial
                 out_item.spectra.get_async(self._download_queue, chunk.data)
+                out_item.saturated.get_async(self._download_queue, chunk.saturated)
                 events = [self._download_queue.enqueue_marker()]
 
             chunk.timestamp = out_item.timestamp

--- a/src/katgpucbf/fgpu/kernels/postproc.mako
+++ b/src/katgpucbf/fgpu/kernels/postproc.mako
@@ -243,7 +243,7 @@ DEVICE_FN float2 apply_delay_gain(int k, float2 gain, float phase, float2 X)
  * possible changes. The input array is guaranteed to be tightly packed and so no
  * in_stride is used.
  */
-KERNEL void postproc(
+KERNEL REQD_WORK_GROUP_SIZE(${block}, ${block}, 1) void postproc(
     GLOBAL char4 * RESTRICT out,              // Output memory
     const GLOBAL float2 * RESTRICT in0,       // Complex input voltages (pol0)
     const GLOBAL float2 * RESTRICT in1,       // Complex input voltages (pol1)

--- a/src/katgpucbf/fgpu/kernels/postproc.mako
+++ b/src/katgpucbf/fgpu/kernels/postproc.mako
@@ -267,7 +267,7 @@ DEVICE_FN float2 apply_delay_gain(int k, float2 gain, float phase, float2 X)
  */
 KERNEL REQD_WORK_GROUP_SIZE(${block}, ${block}, 1) void postproc(
     GLOBAL char4 * RESTRICT out,              // Output memory
-    GLOBAL unsigned int * RESTRICT out_saturated, // Output saturation count, per pol
+    GLOBAL unsigned int (* RESTRICT out_saturated)[2], // Output saturation count, per heap and pol
     const GLOBAL float2 * RESTRICT in0,       // Complex input voltages (pol0)
     const GLOBAL float2 * RESTRICT in1,       // Complex input voltages (pol1)
     const GLOBAL float2 * RESTRICT fine_delay, // Fine delay, in fraction of a sample (per pol)
@@ -388,5 +388,5 @@ KERNEL REQD_WORK_GROUP_SIZE(${block}, ${block}, 1) void postproc(
     // TODO: could reduce within the workgroup and do only one atomic update
     // per workgroup. It doesn't seem to have much impact though.
     for (int i = 0; i < 2; i++)
-        atomicAdd(&out_saturated[i], saturated[i]);
+        atomicAdd(&out_saturated[z][i], saturated[i]);
 }

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -711,7 +711,7 @@ class TestEngine:
         assert prom_diff.get_sample_diff("output_bytes_total") == np.sum(dst_present) * frame_size
         assert prom_diff.get_sample_diff("output_skipped_heaps_total") == np.sum(~dst_present) * n_substreams
 
-    async def test_saturation_sensors(
+    async def test_dig_clip_cnt_sensors(
         self,
         mock_recv_streams: list[spead2.InprocQueue],
         mock_send_stream: list[spead2.InprocQueue],

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -707,8 +707,10 @@ class TestEngine:
         n_substreams = len(mock_send_stream)
         output_heaps = np.sum(dst_present) * n_substreams
         assert prom_diff.get_sample_diff("output_heaps_total") == output_heaps
-        frame_size = channels * spectra_per_heap * N_POLS * COMPLEX * np.dtype(np.int8).itemsize
+        frame_samples = channels * spectra_per_heap * N_POLS
+        frame_size = frame_samples * COMPLEX * np.dtype(np.int8).itemsize
         assert prom_diff.get_sample_diff("output_bytes_total") == np.sum(dst_present) * frame_size
+        assert prom_diff.get_sample_diff("output_samples_total") == np.sum(dst_present) * frame_samples
         assert prom_diff.get_sample_diff("output_skipped_heaps_total") == np.sum(~dst_present) * n_substreams
 
     async def test_dig_clip_cnt_sensors(


### PR DESCRIPTION
Add a Prometheus metric to count F-engine output samples that are saturated. I'll add a katcp sensor in a future PR (should be straightforward with the backend code in place). I've somewhat arbitrarily defined saturation as any value that rounds downward to 127, even 127.1, while values that round up to 127 (e.g. 126.9) are not considered saturated. Saturation is measured during quantisation in the postprocessing kernel. This required some changes to avoid double-counting, as previously the postprocessing kernel was computing some values twice for simplicity. Fortunately there seems to be no measurable impact on GPU performance.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date

Partially addresses NGC-797.
