### PR TITLE
Fix readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,9 @@
 version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
 python:
-  version: 3.10
   install:
     - method: pip
       path: .


### PR DESCRIPTION
Closes NGC-828.

<!-- Add a description of your change here -->

Checklist (all N/A):

- [x] If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
