### PR TITLE
X-engine saturation metric

### DIFF
--- a/doc/katgpucbf.accel_utils.rst
+++ b/doc/katgpucbf.accel_utils.rst
@@ -1,0 +1,7 @@
+katgpucbf.accel\_utils module
+=============================
+
+.. automodule:: katgpucbf.accel_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/katgpucbf.rst
+++ b/doc/katgpucbf.rst
@@ -17,6 +17,7 @@ Submodules
 .. toctree::
    :maxdepth: 4
 
+   katgpucbf.accel_utils
    katgpucbf.meerkat
    katgpucbf.monitor
    katgpucbf.queue_item

--- a/doc/xbgpu.design.rst
+++ b/doc/xbgpu.design.rst
@@ -284,7 +284,7 @@ from that accumulation is normally called a :dfn:`dump` — the terms are used
 interchangeably. Once all the data for a dump has been correlated, the separate
 accumulators are added together ("reduced") to produce a final result.  This
 reduction process also converts from 64-bit to 32-bit integers, saturating if
-necessary.
+necessary, and counts the number of saturated visibilities.
 
 The number of batches to accumulate in an accumulation
 is equal to the :option:`!--heap-accumulation-threshold` flag. The timestamp difference

--- a/src/katgpucbf/accel_utils.py
+++ b/src/katgpucbf/accel_utils.py
@@ -1,0 +1,42 @@
+################################################################################
+# Copyright (c) 2022, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""A collection of utility functions for working with katsdpsigproc."""
+
+from katsdpsigproc import accel
+from katsdpsigproc.abc import AbstractContext
+
+
+def device_allocate_slot(context: AbstractContext, slot: accel.IOSlotBase) -> accel.DeviceArray:
+    """Allocate a :class:`~katsdpsigproc.accel.DeviceArray` to match a given slot.
+
+    The `slot` argument is annotated as :class:`.IOSlotBase` to reduce the
+    boilerplate needed to call this helper, but it must be a real
+    :class:`.IOSlot`.
+    """
+    assert isinstance(slot, accel.IOSlot)
+    return accel.DeviceArray(context, slot.shape, slot.dtype, slot.required_padded_shape())
+
+
+def host_allocate_slot(context: AbstractContext, slot: accel.IOSlotBase) -> accel.HostArray:
+    """Allocate a :class:`~katsdpsigproc.accel.HostArray` to match a given slot.
+
+    The `slot` argument is annotated as :class:`.IOSlotBase` to reduce the
+    boilerplate needed to call this helper, but it must be a real
+    :class:`.IOSlot`.
+    """
+    assert isinstance(slot, accel.IOSlot)
+    return accel.HostArray(slot.shape, slot.dtype, slot.required_padded_shape(), context=context)

--- a/src/katgpucbf/xbgpu/correlation.py
+++ b/src/katgpucbf/xbgpu/correlation.py
@@ -199,7 +199,7 @@ class Correlation(accel.Operation):
         self.slots["in_samples"] = accel.IOSlot(dimensions=input_data_dimensions, dtype=np.int8)
         self.slots["mid_visibilities"] = accel.IOSlot(dimensions=mid_data_dimensions, dtype=np.int64)
         self.slots["out_visibilities"] = accel.IOSlot(dimensions=mid_data_dimensions[1:], dtype=np.int32)
-        self.slots["out_saturated"] = accel.IOSlot(dimensions=(1,), dtype=np.uint32)
+        self.slots["out_saturated"] = accel.IOSlot(dimensions=(), dtype=np.uint32)
         if n_batches * self.template.n_channels * self.template.n_baselines * N_POLS * N_POLS >= 2**31:
             # Can probably go higher, but rather keep it low to reduce the risk
             # of indexing bugs.

--- a/src/katgpucbf/xbgpu/xsend.py
+++ b/src/katgpucbf/xbgpu/xsend.py
@@ -36,8 +36,11 @@ output_heaps_counter = Counter("output_x_heaps", "number of X-engine heaps trans
 output_bytes_counter = Counter(
     "output_x_bytes", "number of X-engine payload bytes transmitted", namespace=METRIC_NAMESPACE
 )
+output_visibilities_counter = Counter(
+    "output_x_visibilities", "number of scalar visibilities that saturated", namespace=METRIC_NAMESPACE
+)
 output_clipped_visibilities_counter = Counter(
-    "output_clipped_visibilities", "number of visibilities that saturated", namespace=METRIC_NAMESPACE
+    "output_x_clipped_visibilities", "number of scalar visibilities that saturated", namespace=METRIC_NAMESPACE
 )
 incomplete_accum_counter = Counter(
     "output_x_incomplete_accs",
@@ -298,6 +301,7 @@ class XSend:
             # typically done.
             output_heaps_counter.inc(1)
             output_bytes_counter.inc(heap.buffer.nbytes)
+            output_visibilities_counter.inc(heap.buffer.shape[0] * heap.buffer.shape[1])
             output_clipped_visibilities_counter.inc(saturated)
         else:
             # :meth:`get_free_heap` still needs to await some Future before

--- a/src/katgpucbf/xbgpu/xsend.py
+++ b/src/katgpucbf/xbgpu/xsend.py
@@ -37,7 +37,7 @@ output_bytes_counter = Counter(
     "output_x_bytes", "number of X-engine payload bytes transmitted", namespace=METRIC_NAMESPACE
 )
 output_visibilities_counter = Counter(
-    "output_x_visibilities", "number of scalar visibilities that saturated", namespace=METRIC_NAMESPACE
+    "output_x_visibilities", "number of scalar visibilities", namespace=METRIC_NAMESPACE
 )
 output_clipped_visibilities_counter = Counter(
     "output_x_clipped_visibilities", "number of scalar visibilities that saturated", namespace=METRIC_NAMESPACE

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -17,7 +17,7 @@
 """Unit tests for XBEngine module."""
 
 from collections.abc import Iterable
-from typing import AbstractSet, Final
+from typing import AbstractSet, Callable, Final
 
 import aiokatcp
 import numpy as np
@@ -96,7 +96,7 @@ def generate_expected_output(
 
     This doesn't do a full correlator. It calculates the results according to
     what is expected from the specific input generated in
-    :func:`create_heaps`.
+    :meth:`TestEngine._create_heaps`.
     """
     baselines = antennas * (antennas + 1) * 2
     output_array = np.zeros((channels, baselines, COMPLEX), dtype=np.int32)
@@ -287,13 +287,13 @@ class TestEngine:
         mock_recv_streams: list[spead2.InprocQueue],
         recv_stream: spead2.recv.asyncio.Stream,
         *,
+        heap_factory: Callable[[int], list[spead2.send.HeapReference]],
         heap_accumulation_threshold: int,
         batch_indices: Iterable[int],
         timestamp_step: int,
         n_ants: int,
         n_channels_per_stream: int,
         n_spectra_per_heap: int,
-        missing_antennas: AbstractSet[int] = frozenset(),
     ) -> np.ndarray:
         """Send a contiguous stream of data to the engine and retrieve the results.
 
@@ -307,6 +307,8 @@ class TestEngine:
             Fixture
         recv_stream
             InprocStream to receive data output by XBEngine.
+        heap_factory
+            Callback that takes a batch index and returns the heaps for that index.
         heap_accumulation_threshold
             Number of consecutive heaps to process in a single accumulation.
         batch_indices
@@ -314,7 +316,7 @@ class TestEngine:
             but need not be contiguous.
         timestamp_step
             Timestamp step between each received heap processed.
-        n_ants, n_channels_per_stream, n_spectra_per_heap, missing_antennas
+        n_ants, n_channels_per_stream, n_spectra_per_heap
             See :meth:`_create_heaps` for more info.
 
         Returns
@@ -329,15 +331,7 @@ class TestEngine:
 
         accumulation_indices_set = set()
         for batch_index in batch_indices:
-            timestamp = batch_index * timestamp_step
-            heaps = self._create_heaps(
-                timestamp,
-                batch_index,
-                n_ants,
-                n_channels_per_stream,
-                n_spectra_per_heap,
-                missing_antennas=missing_antennas,
-            )
+            heaps = heap_factory(batch_index)
             accumulation_indices_set.add(batch_index // heap_accumulation_threshold)
             await feng_stream.async_send_heaps(heaps, spead2.send.GroupMode.ROUND_ROBIN)
 
@@ -427,11 +421,13 @@ class TestEngine:
         while n_engines < n_ants:
             n_engines *= 2
         n_channels_per_stream = n_channels_total // n_engines
+        n_baselines = n_ants * (n_ants + 1) * 2
         heap_accumulation_threshold = 4
         first_accumulation_index = 123
         n_full_accumulations = 3
         n_total_accumulations = n_full_accumulations + 1
         timestamp_step = n_samples_between_spectra * n_spectra_per_heap
+        missing_antennas = set() if missing_antenna is None else {missing_antenna}
 
         queue = mock_send_stream
         recv_stream = spead2.recv.asyncio.Stream(spead2.ThreadPool(), spead2.recv.StreamConfig(max_heaps=100))
@@ -471,6 +467,17 @@ class TestEngine:
 
         await xbengine.start()
 
+        def heap_factory(batch_index: int) -> list[spead2.send.HeapReference]:
+            timestamp = batch_index * timestamp_step
+            return self._create_heaps(
+                timestamp,
+                batch_index,
+                n_ants,
+                n_channels_per_stream,
+                n_spectra_per_heap,
+                missing_antennas=missing_antennas,
+            )
+
         with PromDiff(namespace=METRIC_NAMESPACE) as prom_diff:
             # Generate one extra chunk to simulate an incomplete accumulation
             # to check that dumps are aligned correctly - even if the first
@@ -484,11 +491,11 @@ class TestEngine:
                 recv_stream,
                 heap_accumulation_threshold=heap_accumulation_threshold,
                 batch_indices=range(batch_start_index, batch_end_index),
+                heap_factory=heap_factory,
                 timestamp_step=timestamp_step,
                 n_ants=n_ants,
                 n_channels_per_stream=n_channels_per_stream,
                 n_spectra_per_heap=n_spectra_per_heap,
-                missing_antennas=set() if missing_antenna is None else {missing_antenna},
             )
 
         incomplete_accums_counter = 0
@@ -526,9 +533,13 @@ class TestEngine:
         assert prom_diff.get_sample_diff("output_x_incomplete_accs_total") == incomplete_accums_counter
         assert prom_diff.get_sample_diff("output_x_heaps_total") == n_total_accumulations
         # Could manually calculate it here, but it's available inside the send_stream
-        assert prom_diff.get_sample_diff("output_x_bytes_total") == xbengine.send_stream.heap_payload_size_bytes * (
-            n_total_accumulations
+        assert prom_diff.get_sample_diff("output_x_bytes_total") == (
+            xbengine.send_stream.heap_payload_size_bytes * n_total_accumulations
         )
+        assert prom_diff.get_sample_diff("output_x_visibilities_total") == (
+            n_channels_per_stream * n_baselines * n_total_accumulations
+        )
+        assert prom_diff.get_sample_diff("output_x_clipped_visibilities_total") == 0
 
         expected_sensor_updates: list[tuple[bool, aiokatcp.Sensor.Status]] = []
         # As per the explanation in :func:`~send_data`, the first accumulation
@@ -544,3 +555,78 @@ class TestEngine:
         np.testing.assert_equal(actual_sensor_updates, expected_sensor_updates)
 
         await xbengine.stop()
+
+    async def test_saturation(
+        self,
+        context: AbstractContext,
+        mock_recv_streams: list[spead2.InprocQueue],
+        mock_send_stream: spead2.InprocQueue,
+    ):
+        """Test saturation statistics.
+
+        .. todo::
+
+           After the implementation is updated to avoid counting missing data
+           as saturated, extend the test to check that.
+        """
+        n_channels_total = 1024
+        n_samples_between_spectra = 2 * n_channels_total
+        n_ants = 4
+        n_engines = 16
+        n_spectra_per_heap = 256
+        heap_accumulation_threshold = 300
+        n_channels_per_stream = n_channels_total // n_engines
+        timestamp_step = n_samples_between_spectra * n_spectra_per_heap
+        n_baselines = n_ants * (n_ants + 1) * 2
+
+        arglist = [
+            "--katcp-host=127.0.0.1",
+            "--katcp-port=0",
+            f"--adc-sample-rate={ADC_SAMPLE_RATE}",
+            f"--array-size={n_ants}",
+            f"--channels={n_channels_total}",
+            f"--channels-per-substream={n_channels_per_stream}",
+            f"--samples-between-spectra={n_samples_between_spectra}",
+            f"--channel-offset-value={n_channels_per_stream * CHANNEL_OFFSET}",
+            f"--spectra-per-heap={n_spectra_per_heap}",
+            f"--heaps-per-fengine-per-chunk={HEAPS_PER_FENGINE_PER_CHUNK}",
+            f"--heap-accumulation-threshold={heap_accumulation_threshold}",
+            "--src-interface=lo",
+            "--dst-interface=lo",
+            "--tx-enabled",
+            "239.10.11.4:7149",  # src
+            "239.21.11.4:7149",  # dst
+        ]
+        args = parse_args(arglist)
+        xbengine, _ = make_engine(context, args)
+
+        queue = mock_send_stream
+        recv_stream = spead2.recv.asyncio.Stream(spead2.ThreadPool(), spead2.recv.StreamConfig(max_heaps=100))
+        recv_stream.add_inproc_reader(queue)
+
+        await xbengine.start()
+
+        def heap_factory(batch_index: int) -> list[spead2.send.HeapReference]:
+            timestamp = timestamp_step * batch_index
+            data = np.full((n_channels_per_stream, n_spectra_per_heap, N_POLS, COMPLEX), 127, np.int8)
+            return [
+                spead2.send.HeapReference(gen_heap(timestamp, ant_index, n_channels_per_stream * CHANNEL_OFFSET, data))
+                for ant_index in range(n_ants)
+            ]
+
+        with PromDiff(namespace=METRIC_NAMESPACE) as prom_diff:
+            await self._send_data(
+                mock_recv_streams,
+                recv_stream,
+                heap_accumulation_threshold=heap_accumulation_threshold,
+                batch_indices=range(0, heap_accumulation_threshold),
+                heap_factory=heap_factory,
+                timestamp_step=timestamp_step,
+                n_ants=n_ants,
+                n_channels_per_stream=n_channels_per_stream,
+                n_spectra_per_heap=n_spectra_per_heap,
+            )
+            await xbengine.stop()
+
+        assert prom_diff.get_sample_diff("output_x_visibilities_total") == n_channels_per_stream * n_baselines
+        assert prom_diff.get_sample_diff("output_x_clipped_visibilities_total") == n_channels_per_stream * n_baselines

--- a/test/xbgpu/test_xsend.py
+++ b/test/xbgpu/test_xsend.py
@@ -45,19 +45,19 @@ class TestXSend:
         await send_stream.source_stream.async_send_heap(send_stream.descriptor_heap)
 
         for i in range(TOTAL_HEAPS):
-            # Get a free buffer to store the next heap - there is not
-            # always a free buffer available. This function yields until one it
-            # available.
-            buffer = await send_stream.get_free_heap()
+            # Get a free heap - there is not always a free one available. This
+            # function yields until one it available.
+            heap = await send_stream.get_free_heap()
 
             # Populate the buffer with dummy data.
-            buffer.fill(i)
+            heap.buffer.fill(i)
 
-            # Give the buffer back to the send_stream to transmit out
+            # Give the heap back to the send_stream to transmit out
             # onto the network. The timestamp is multiplied by TIMESTAMP_SCALE
             # so that its value is different from the values in the
             # buffer array.
-            send_stream.send_heap(i * TIMESTAMP_SCALE, buffer)
+            heap.timestamp = i * TIMESTAMP_SCALE
+            send_stream.send_heap(heap)
         # send_heap just queues data for sending but is non-blocking.
         # Flush to ensure that the data all gets sent before we return.
         await send_stream.source_stream.async_flush()


### PR DESCRIPTION
Add a Prometheus metric (output_x_clipped_visibilities) for saturated visibilities, along with a total visibilities metric (output_x_visibilities). Where data goes missing it might still be counted as saturated: fixing that is going to require moving the missing data handling to the GPU and I'll make a separate ticket for it. Connecting the information to a katcp sensor will come in a later PR.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date

Partly addresses NGC-797.
