### PR TITLE
Rework DeviceStatusSensor with SimpleAggregateSensor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
         types: []
         types_or: [python, pyi]
         additional_dependencies: [
-            'aiokatcp==1.4.0',
+            'aiokatcp==1.5.0',
             'dask==2022.10.0',
             'katsdpsigproc==1.4.3',
             'katsdptelstate==0.11',

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile qualification/requirements.in
 #
-aiokatcp==1.4.0
+aiokatcp==1.5.0
     # via -r qualification/requirements.in
 alabaster==0.7.12
     # via

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 aiohttp
-aiokatcp>=1.4.0
+aiokatcp>=1.5.0
 dask
 katsdpservices[aiomonitor]>=1.2
 katsdpsigproc[CUDA]>=1.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ aioconsole==0.5.1
     # via aiomonitor
 aiohttp==3.8.3
     # via -r requirements.in
-aiokatcp==1.4.0
+aiokatcp==1.5.0
     # via -r requirements.in
 aiomonitor==0.4.5
     # via katsdpservices

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ package_dir =
     = src
 packages = find:
 install_requires =
-    aiokatcp>=1.4.0
+    aiokatcp>=1.5.0
     dask
     katsdpservices[aiomonitor]
     katsdpsigproc>=1.4.1


### PR DESCRIPTION
This simplifies the logic somewhat, and makes the timestamp logic the responsibility of aiokatcp. A functional change is that now if the worst status is beyond ERROR (e.g. UNREACHABLE), the aggregate status will be ERROR. That shouldn't have any effect since katgpucbf does not provide any such sensors.

This will fail to run right now because it needs a new release of aiokatcp that implements SimpleAggregateSensor.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date

Relates to NGC-442.
