### PR TITLE
Bump pillow to 9.3.0

### DIFF
--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -230,7 +230,7 @@ pickleshare==0.7.5
     # via
     #   -r qualification/../requirements-dev.txt
     #   ipython
-pillow==9.2.0
+pillow==9.3.0
     # via matplotlib
 pip-tools==6.9.0
     # via -r qualification/../requirements-dev.txt


### PR DESCRIPTION
Dependabot is complaining that 9.2.0 has a security vulnerability, although since we're not processing arbitrary images from the internet, it's unlikely to matter.

Checklist is N/A.