### PR TITLE
Check that gains can be set within 30s

### DIFF
--- a/qualification/antenna_channelised_voltage/test_gain.py
+++ b/qualification/antenna_channelised_voltage/test_gain.py
@@ -83,10 +83,10 @@ async def test_gains(
     end_time = loop.time()
     elapsed = end_time - start_time
     pdf_report.detail(f"Gains set in {elapsed:.3f}s")
-    # Disabled until we determine whether CBF-REQ-0200 is applicable - it
-    # currently fails.
-    # with check:
-    #     assert elapsed < 1, "Took too long to set gains"
+    # MKAT-ECP-277 specifies 300s between gain updates, but we'd like to be
+    # able to set gains faster than that. This is an arbitrary number.
+    with check:
+        assert elapsed < 30.0, "Took too long to set gains"
 
     pdf_report.step("Collect and compare results.")
     data = await next_chunk_data()


### PR DESCRIPTION
This is an arbitrary time (ECP only requires 300s), but we don't want it to take forever.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [ ] If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date

Closes NGC-617 (at least until final requirements emerge).
