### PR TITLE
Remove ability for device-status to return fail

### DIFF
--- a/src/katgpucbf/utils.py
+++ b/src/katgpucbf/utils.py
@@ -106,7 +106,6 @@ class DeviceStatusSensor(aiokatcp.SimpleAggregateSensor[DeviceStatus]):
         )
         if worst_status <= aiokatcp.Sensor.Status.NOMINAL:  # NOMINAL or UNKNOWN
             return (aiokatcp.Sensor.Status.NOMINAL, DeviceStatus.OK)
-        elif worst_status == aiokatcp.Sensor.Status.WARN:
-            return (aiokatcp.Sensor.Status.WARN, DeviceStatus.DEGRADED)
-        else:
-            return (aiokatcp.Sensor.Status.ERROR, DeviceStatus.FAIL)
+        # We won't return FAIL because if the device is unusable, we probably
+        # won't be able to.
+        return (aiokatcp.Sensor.Status.WARN, DeviceStatus.DEGRADED)


### PR DESCRIPTION
I haven't thought of a good way to log things yet, though maybe the things that trigger warnings / errors in the sensors themselves should do the logging?

Checklist:

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date

Closes NGC-843.
