### PR TITLE
Bump aiokatcp and mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
       - id: pydocstyle
         exclude: 'setup.py|scratch/'  # Because complaining about docstrings here is annoying.
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.982'
+    rev: 'v0.991'
     hooks:
       - id: mypy
         # Passing filenames to mypy can do odd things. See
@@ -49,7 +49,7 @@ repos:
         types: []
         types_or: [python, pyi]
         additional_dependencies: [
-            'aiokatcp==1.5.0',
+            'aiokatcp==1.5.1',
             'dask==2022.10.0',
             'katsdpsigproc==1.4.3',
             'katsdptelstate==0.11',

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile qualification/requirements.in
 #
-aiokatcp==1.5.0
+aiokatcp==1.5.1
     # via -r qualification/requirements.in
 alabaster==0.7.12
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ aioconsole==0.5.1
     # via aiomonitor
 aiohttp==3.8.3
     # via -r requirements.in
-aiokatcp==1.5.0
+aiokatcp==1.5.1
     # via -r requirements.in
 aiomonitor==0.4.5
     # via katsdpservices

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ package_dir =
     = src
 packages = find:
 install_requires =
-    aiokatcp>=1.5.0
+    aiokatcp>=1.5.1
     dask
     katsdpservices[aiomonitor]
     katsdpsigproc>=1.4.1

--- a/src/katgpucbf/dsim/server.py
+++ b/src/katgpucbf/dsim/server.py
@@ -197,7 +197,7 @@ class DeviceServer(aiokatcp.DeviceServer):
             self._steady_state_sensor.value = max(self._steady_state_sensor.value, timestamp)
             return timestamp
 
-    async def request_signals(self, ctx, signals_str: str, period: int = None) -> int:
+    async def request_signals(self, ctx, signals_str: str, period: int | None = None) -> int:
         """Update the signals that are generated.
 
         Parameters


### PR DESCRIPTION
Bumping aiokatcp to 1.5.1 made it possible to make the code compliant with the newer mypy's strictness by explicitly annotating an optional argument with `| None`.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
