### PR TITLE
Add sensor for F-engine saturation

### DIFF
--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -74,7 +74,7 @@ async def test_delay_application_time(
         pdf_report.detail("Set delays.")
         await correlator.product_controller_client.request("delays", "antenna_channelised_voltage", target, *delays)
         pdf_report.step("Receive data for the corresponding dump.")
-        target_ts = receiver.unix_to_timestamp(target)
+        target_ts = round(receiver.time_converter.unix_to_adc(target))
         target_acc_ts = target_ts // receiver.timestamp_step * receiver.timestamp_step
         acc = None
         async for timestamp, chunk in receiver.complete_chunks(max_delay=0):
@@ -100,7 +100,7 @@ async def test_delay_application_time(
     # Estimate time at which delay was applied based on real:imaginary
     total = np.sum(np.abs(acc))
     load_frac = abs(acc[0]) / total  # Load time as fraction of the accumulation
-    load_time = receiver.timestamp_to_unix(target_acc_ts) + load_frac * receiver.int_time
+    load_time = receiver.time_converter.adc_to_unix(target_acc_ts) + load_frac * receiver.int_time
     delta = load_time - target
     pdf_report.detail(f"Estimated load time error: {delta * 1e6:.3f}µs.")
     with check:
@@ -224,7 +224,7 @@ async def test_delay_sensors(
     rng = np.random.default_rng(seed=31)
     now = await correlator.dsim_time()
     load_time = now + 2.0
-    load_ts = receiver.unix_to_timestamp(load_time)
+    load_ts = round(receiver.time_converter.unix_to_adc(load_time))
     for _ in range(receiver.n_inputs):
         delay = rng.uniform(-MAX_DELAY, MAX_DELAY)
         delay_rate = rng.uniform(-MAX_DELAY_RATE, MAX_DELAY_RATE)

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1050,7 +1050,7 @@ class Engine(aiokatcp.DeviceServer):
                 sensor = self.sensors[f"input{pol}-dig-clip-cnt"]
                 sensor.set_value(
                     sensor.value + int(np.sum(chunk.extra, dtype=np.uint64)),
-                    timestamp=chunk.timestamp + layout.chunk_samples,
+                    timestamp=self.time_converter.adc_to_unix(chunk.timestamp + layout.chunk_samples),
                 )
             if self.use_vkgdr:
                 for pol_data, chunk in zip(in_item.pol_data, chunks):

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -49,7 +49,7 @@ from ..monitor import Monitor
 from ..queue_item import QueueItem
 from ..ringbuffer import ChunkRingbuffer
 from ..send import DescriptorSender
-from ..utils import DeviceStatusSensor
+from ..utils import DeviceStatusSensor, TimeConverter
 from . import SAMPLE_BITS, recv, send
 from .compute import Compute, ComputeTemplate
 from .delay import AbstractDelayModel, LinearDelayModel, MultiDelayModel, wrap_angle
@@ -461,7 +461,7 @@ class Engine(aiokatcp.DeviceServer):
         self.feng_id = feng_id
         self.n_ants = num_ants
         self.default_gain = gain
-        self.sync_epoch = sync_epoch
+        self.time_converter = TimeConverter(sync_epoch, adc_sample_rate)
         self.monitor = monitor
         self.use_vkgdr = use_vkgdr
 
@@ -1314,7 +1314,7 @@ class Engine(aiokatcp.DeviceServer):
         # of this delta and the delay_rate (same for phase).
         # This may be too small to be a concern, but if it is a concern,
         # then we'd need to compensate for that here.
-        start_sample_count = round((start_time - self.sync_epoch) * self.adc_sample_rate)
+        start_sample_count = round(self.time_converter.unix_to_adc(start_time))
         if start_sample_count < 0:
             raise aiokatcp.FailReply("Start time cannot be prior to the sync epoch")
 

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -706,6 +706,15 @@ class Engine(aiokatcp.DeviceServer):
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,
                 )
             )
+            sensors.add(
+                aiokatcp.Sensor(
+                    int,
+                    f"input{pol}-feng-clip-cnt",
+                    "Number of output samples that are saturated",
+                    default=0,
+                    initial_status=aiokatcp.Sensor.Status.NOMINAL,
+                )
+            )
         sensors.add(
             aiokatcp.Sensor(
                 int,
@@ -1152,7 +1161,7 @@ class Engine(aiokatcp.DeviceServer):
                 # We're not in PeerDirect mode
                 # (when we are the cleanup callback returns the item)
                 self._out_free_queue.put_nowait(out_item)
-            task = asyncio.create_task(chunk.send(stream, n_frames))
+            task = asyncio.create_task(chunk.send(stream, n_frames, self.time_converter, self.sensors))
             task.add_done_callback(partial(self._chunk_finished, chunk))
 
         if task:

--- a/test/dsim/conftest.py
+++ b/test/dsim/conftest.py
@@ -106,7 +106,7 @@ def sender(
     send_stream: "spead2.send.asyncio.AsyncStream", heap_sets: Sequence[send.HeapSet]
 ) -> send.Sender:  # noqa: D401
     """A :class:`~katgpucbf.dsim.Sender` using the first of :func:`heaps_sets`."""
-    return send.Sender(send_stream, heap_sets[0], DIG_HEAP_SAMPLES, ADC_SAMPLE_RATE)
+    return send.Sender(send_stream, heap_sets[0], DIG_HEAP_SAMPLES)
 
 
 @pytest.fixture

--- a/test/dsim/test_send.py
+++ b/test/dsim/test_send.py
@@ -29,9 +29,10 @@ from spead2 import ItemGroup
 from katgpucbf import DIG_HEAP_SAMPLES
 from katgpucbf.dsim import send
 from katgpucbf.send import DescriptorSender
+from katgpucbf.utils import TimeConverter
 
 from .. import PromDiff, unpackbits
-from .conftest import N_ENDPOINTS_PER_POL, N_POLS, SIGNAL_HEAPS
+from .conftest import ADC_SAMPLE_RATE, N_ENDPOINTS_PER_POL, N_POLS, SIGNAL_HEAPS
 
 
 async def descriptor_recv(
@@ -123,7 +124,7 @@ async def test_sender(
 
     # Now proceed with DSim data using received descriptors (in ItemGroup)(ig)
     with PromDiff(namespace=send.METRIC_NAMESPACE) as prom_diff:
-        await sender.run(0, time.time())
+        await sender.run(0, TimeConverter(time.time(), ADC_SAMPLE_RATE))
     for queue in inproc_queues:
         queue.stop()
 

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -132,7 +132,7 @@ class TestEngine:
         assert engine_server._src_interface == "127.0.0.1"
         # TODO: `dst_interface` goes to the _sender member, which doesn't have anything we can query.
         assert engine_server.channels == CHANNELS
-        assert engine_server.sync_epoch == SYNC_EPOCH
+        assert engine_server.time_converter.sync_epoch == SYNC_EPOCH
         assert engine_server._srcs == [
             [
                 ("239.10.10.0", 7149),

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -31,6 +31,7 @@ from katgpucbf import COMPLEX, N_POLS
 from katgpucbf.fgpu import METRIC_NAMESPACE, SAMPLE_BITS
 from katgpucbf.fgpu.delay import wrap_angle
 from katgpucbf.fgpu.engine import Engine, InItem
+from katgpucbf.utils import TimeConverter
 
 from .. import PromDiff
 from .test_recv import gen_heaps
@@ -736,10 +737,12 @@ class TestEngine:
         )
         # TODO: turn aiokatcp.Reading into a dataclass (or at least implement
         # __eq__ and __repr__) so that it can be used in comparisons.
+        time_converter = TimeConverter(SYNC_EPOCH, ADC_SAMPLE_RATE)
+        expected_timestamps = [time_converter.adc_to_unix(t) for t in [524288, 1048576, 1572864]]
         assert [r.value for r in sensor_update_dict[sensors[0].name]] == [5000, 5000, 5000]
-        assert [r.timestamp for r in sensor_update_dict[sensors[0].name]] == [524288, 1048576, 1572864]
+        assert [r.timestamp for r in sensor_update_dict[sensors[0].name]] == expected_timestamps
         assert [r.value for r in sensor_update_dict[sensors[1].name]] == [0, 0, 10000]
-        assert [r.timestamp for r in sensor_update_dict[sensors[1].name]] == [524288, 1048576, 1572864]
+        assert [r.timestamp for r in sensor_update_dict[sensors[1].name]] == expected_timestamps
 
     @pytest.mark.parametrize("tone_pol", [0, 1])
     async def test_output_clip_count(

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,44 @@
+################################################################################
+# Copyright (c) 2020-2022, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Tests for :mod:`katcbfgpu.utils`."""
+
+import pytest
+
+from katgpucbf.utils import TimeConverter
+
+
+class TestTimeConverter:
+    """Tests for :class:`katgpucbf.utils.TimeConverter`."""
+
+    @pytest.fixture
+    def time_converter(self) -> TimeConverter:  # noqa: D401
+        """A time converter.
+
+        It has power-of-two ADC sample count so that tests do not need to worry
+        about rounding effects.
+        """
+        return TimeConverter(1234567890.0, 1048576.0)
+
+    def test_unix_to_adc(self, time_converter: TimeConverter) -> None:
+        """Test :meth:`.TimeConverter.unix_to_adc`."""
+        assert time_converter.unix_to_adc(1234567890.0) == 0.0
+        assert time_converter.unix_to_adc(1234567890.0 + 10.0) == 10485760.0
+
+    def test_adc_to_unix(self, time_converter: TimeConverter) -> None:
+        """Test :meth:`.TimeConverter.adc_to_unix`."""
+        assert time_converter.adc_to_unix(0.0) == 1234567890.0
+        assert time_converter.adc_to_unix(10485760.0) == 1234567890.0 + 10.0


### PR DESCRIPTION
A couple of additional changes:

- Introduce a TimeConverter class to unify all the code for converting between UNIX time and ADC samples
- Fix a bug where dig-clip-cnt's timestamp was in the wrong timescale

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date

Addresses NGC-797.

Qualification report (just to show I ran it - it should look the same as usual): [report.pdf](https://github.com/ska-sa/katgpucbf/files/10029944/report.pdf)
