### PR TITLE
Add --w-cutoff argument to fgpu

### DIFF
--- a/doc/maths.rst
+++ b/doc/maths.rst
@@ -40,7 +40,7 @@ frequency bin). Specifically, if there are :math:`n` output channels and
 .. math::
 
    x_i = A\sin^2\left(\frac{\pi i}{w - 1}\right)
-         \operatorname{sinc}\left(\frac{i + \tfrac 12 - nt}{2n}\right),
+         \operatorname{sinc}\left(w_c\cdot \frac{i + \tfrac 12 - nt}{2n}\right),
 
 where :math:`i` runs from 0 to :math:`w - 1`. Here :math:`A` is a
 normalisation factor which is chosen such that :math:`\sum_i x_i^2 = 1`. This
@@ -48,6 +48,11 @@ ensures that given white Gaussian noise as input, the expected output power
 in a channel is the same as the expected input power in a digitised sample.
 Note that the input and output are treated as integers rather than as
 fixed-point values.
+
+The tuning parameter :math:`w_c` (specified by the :option:`!--w-cutoff`
+command-line option) scales the width of the response in the frequency domain.
+The default value is 1, which makes the width of the response (at -6dB)
+approximately equal the channel spacing.
 
 Correlation products
 --------------------

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -199,6 +199,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         "2*channels*spectra-per-heap, it will be rounded up to the next multiple. [%(default)s]",
     )
     parser.add_argument("--taps", type=int, default=16, help="Number of taps in polyphase filter bank [%(default)s]")
+    parser.add_argument("--w-cutoff", type=float, default=1.0, help="Scaling factor for channel width [%(default)s]")
     parser.add_argument(
         "--max-delay-diff",
         type=int,
@@ -281,6 +282,7 @@ def make_engine(ctx: AbstractContext, args: argparse.Namespace) -> tuple[Engine,
         spectra_per_heap=args.spectra_per_heap,
         channels=args.channels,
         taps=args.taps,
+        w_cutoff=args.w_cutoff,
         max_delay_diff=args.max_delay_diff,
         gain=args.gain,
         sync_epoch=float(args.sync_epoch),  # CLI arg is an int, but SDP can handle a float downstream.


### PR DESCRIPTION
There are no specific tests for it because the requirements haven't been clarified. Once they have been there will no doubt be some updates to the channel shape qualification tests.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date

Closes NGC-540.

Qualification report after hacking the qualification tests to pass `--w-cutoff=0.91` (the recommended value for pulsar timing): 
[report-w-cutoff-0.91.pdf](https://github.com/ska-sa/katgpucbf/files/10032253/report-w-cutoff-0.91.pdf)

It looks pretty similar but the channel shape is definitely narrower.