### PR TITLE
Allow dsim to send to unicast addresses

### DIFF
--- a/src/katgpucbf/dsim/descriptors.py
+++ b/src/katgpucbf/dsim/descriptors.py
@@ -16,8 +16,6 @@
 
 """Digitiser simulator descriptor sender."""
 
-from collections.abc import Iterable
-
 import spead2
 import spead2.send.asyncio
 
@@ -31,19 +29,6 @@ from ..spead import (
     MAX_PACKET_SIZE,
     TIMESTAMP_ID,
 )
-
-
-def make_descriptor_stream(
-    endpoints: Iterable[tuple[str, int]], config: spead2.send.StreamConfig, ttl: int, interface_address: str
-) -> spead2.send.asyncio.UdpStream:
-    """Create a stream for sending descriptors alongside dsim data."""
-    return spead2.send.asyncio.UdpStream(
-        spead2.ThreadPool(),
-        list(endpoints),
-        config=config,
-        ttl=ttl,
-        interface_address=interface_address,
-    )
 
 
 def create_descriptors_heap() -> spead2.send.Heap:

--- a/src/katgpucbf/dsim/main.py
+++ b/src/katgpucbf/dsim/main.py
@@ -172,8 +172,12 @@ async def async_main() -> None:
 
     config = descriptors.create_config()
     interface_address = katsdpservices.get_interface_address(args.interface)
-    descriptor_stream = descriptors.make_descriptor_stream(
-        endpoints=endpoints, config=config, ttl=args.ttl, interface_address=interface_address
+    descriptor_stream = send.make_stream_base(
+        endpoints=endpoints,
+        config=config,
+        ttl=args.ttl,
+        interface_address=interface_address,
+        ibv=args.ibv,
     )
     descriptor_stream.set_cnt_sequence(1, 2)
 

--- a/test/dsim/conftest.py
+++ b/test/dsim/conftest.py
@@ -139,7 +139,7 @@ def descriptor_send_stream(descriptor_inproc_queues: Sequence[spead2.InprocQueue
 
     config = descriptors.create_config()
     with mock.patch("spead2.send.asyncio.UdpStream", side_effect=mock_udp_stream):
-        return descriptors.make_descriptor_stream(
+        return send.make_stream_base(
             endpoints=[("invalid", -1) for _ in descriptor_inproc_queues],
             config=config,
             ttl=4,


### PR DESCRIPTION
If ibv is not enabled AND none of the endpoints is clearly a multicast address, don't try to pass TTL and interface address.

As a bonus, the descriptor sender now uses the same code for deciding how to construct the stream, and so will now use ibv when specified on the command line.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date

Closes NGC-846.
