### PR TITLE
Bump PyCUDA to 2022.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         additional_dependencies: [
             'aiokatcp==1.5.1',
             'dask==2022.10.0',
-            'katsdpsigproc==1.6.0',
+            'katsdpsigproc==1.6.1',
             'katsdptelstate==0.11',
             'numpy==1.23.4',
             'pyparsing==3.0.9',

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -138,7 +138,7 @@ jinja2==3.1.2
     #   sphinx
 katsdpservices==1.2
     # via -r qualification/requirements.in
-katsdpsigproc==1.6.0
+katsdpsigproc==1.6.1
     # via -r qualification/requirements.in
 katsdptelstate==0.11
     # via -r qualification/requirements.in

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@ aiohttp
 aiokatcp>=1.5.0
 dask
 katsdpservices[aiomonitor]>=1.2
-katsdpsigproc[CUDA]>=1.6.0
+katsdpsigproc[CUDA]>=1.6.1
 katsdptelstate
 numpy
 prometheus-async

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ idna==3.4
     # via yarl
 katsdpservices[aiomonitor]==1.2
     # via -r requirements.in
-katsdpsigproc[cuda]==1.6.0
+katsdpsigproc[cuda]==1.6.1
     # via -r requirements.in
 katsdptelstate==0.11
     # via -r requirements.in
@@ -108,7 +108,7 @@ psutil==5.9.2
     # via -r requirements.in
 pycparser==2.21
     # via cffi
-pycuda==2022.1
+pycuda==2022.2
     # via
     #   -r requirements.in
     #   katsdpsigproc

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ install_requires =
     aiokatcp>=1.5.1
     dask
     katsdpservices[aiomonitor]
-    katsdpsigproc>=1.6.0
+    katsdpsigproc>=1.6.1
     katsdptelstate
     numba
     numpy


### PR DESCRIPTION
This allows the workaround for the build-time dependency on numpy to be dropped, as 2022.2 uses oldest-supported-numpy instead.

Also update katsdpsigproc to 1.6.1 which contains a fix for a bug that was only exposed when using the newer pycuda. I don't know whether the newer pycuda is only showing a new warning (and the old one silently leaked) or if the old version didn't provoke the leak at all.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] (N/A) Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

No related Jira ticket.
