### PR TITLE
Add sensors for average digitiser power

### DIFF
--- a/scratch/fgpu/benchmarks/compute_bench.py
+++ b/scratch/fgpu/benchmarks/compute_bench.py
@@ -51,7 +51,7 @@ def main():
         fn.ensure_all_bound()
 
         h_weights = fn.buffer("weights").empty_like()
-        h_weights[:] = generate_weights(args.channels, args.taps)
+        h_weights[:] = generate_weights(args.channels, args.taps, 1.0)
         fn.buffer("weights").set(command_queue, h_weights)
 
         h_gains = fn.buffer("gains").empty_like()
@@ -71,7 +71,13 @@ def main():
             fn.buffer(name).zero(command_queue)
 
         def run():
-            fn.run_frontend([fn.buffer("in0"), fn.buffer("in1")], [0, 0], 0, spectra)
+            fn.run_frontend(
+                [fn.buffer("in0"), fn.buffer("in1")],
+                [fn.buffer("dig_total_power0"), fn.buffer("dig_total_power1")],
+                [0, 0],
+                0,
+                spectra,
+            )
             fn.run_backend(fn.buffer("out"), fn.buffer("saturated"))
 
         run()  # Warmup pass

--- a/src/katgpucbf/fgpu/__init__.py
+++ b/src/katgpucbf/fgpu/__init__.py
@@ -20,3 +20,8 @@ from typing import Final
 
 SAMPLE_BITS: Final = 10
 METRIC_NAMESPACE: Final = "fgpu"
+
+# Range in which the dig-pwr-dbfs sensor is NOMINAL
+# TODO these thresholds are inherited from MeerKAT. Are they what we want?
+DIG_POWER_DBFS_LOW: Final = -32.0
+DIG_POWER_DBFS_HIGH: Final = -22.0

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -18,6 +18,7 @@
 
 import asyncio
 import logging
+import math
 import numbers
 from collections import deque
 from collections.abc import Iterable, Sequence
@@ -28,7 +29,7 @@ import aiokatcp
 import katsdpsigproc.accel as accel
 import numpy as np
 import spead2.recv
-from katsdpsigproc.abc import AbstractContext, AbstractEvent
+from katsdpsigproc.abc import AbstractCommandQueue, AbstractContext, AbstractEvent
 from katsdpsigproc.resource import async_wait_for_events
 from katsdptelstate.endpoint import Endpoint
 
@@ -242,6 +243,8 @@ class OutItem(QueueItem):
     spectra: accel.DeviceArray
     #: Output saturation count, per pol
     saturation: accel.DeviceArray
+    #: Output sum of squared samples, per pol
+    dig_total_power: list[accel.DeviceArray]
     #: Provides a scratch space for collecting per-spectrum fine delays while
     #: the `OutItem` is being prepared. When the `OutItem` is placed onto the
     #: queue it is copied to the `Compute`.
@@ -262,6 +265,9 @@ class OutItem(QueueItem):
         allocator = accel.DeviceAllocator(compute.template.context)
         self.spectra = compute.slots["out"].allocate(allocator, bind=False)
         self.saturated = compute.slots["saturated"].allocate(allocator, bind=False)
+        self.dig_total_power = [
+            compute.slots[f"dig_total_power{pol}"].allocate(allocator, bind=False) for pol in range(N_POLS)
+        ]
         self.fine_delay = compute.slots["fine_delay"].allocate_host(compute.template.context)
         self.phase = compute.slots["phase"].allocate_host(compute.template.context)
         self.gains = compute.slots["gains"].allocate_host(compute.template.context)
@@ -273,9 +279,24 @@ class OutItem(QueueItem):
 
         Zero the item's timestamp, empty the event list and set number of
         spectra to zero.
+
+        This does *not* zero the dig_total_power counters. Use :meth:`reset_all`
+        for that.
         """
         super().reset(timestamp)
         self.n_spectra = 0
+
+    def reset_all(self, command_queue: AbstractCommandQueue, timestamp: int = 0) -> None:
+        """Fully reset the item.
+
+        In addition to the work done by :meth:`reset`, zero out GPU
+        accumulators, using the given command queue. No events are added
+        associated with this; it is assumed that the same command queue will
+        be used to subsequently operate on the accumulators.
+        """
+        self.reset(timestamp)
+        for buf in self.dig_total_power:
+            buf.zero(command_queue)
 
     @property
     def end_timestamp(self) -> int:  # noqa: D401
@@ -313,6 +334,14 @@ def format_complex(value: numbers.Complex) -> str:
     as a Python complex may not give exactly the same value.
     """
     return f"{value.real}{value.imag:+}j"
+
+
+def dig_pwr_dbfs_status(value: float) -> aiokatcp.Sensor.Status:
+    """Compute status for dig-pwr-dbfs sensor.
+
+    TODO: the thresholds are inherited from MeerKAT. Are they what we want?
+    """
+    return aiokatcp.Sensor.Status.NOMINAL if -32.0 <= value <= -22.0 else aiokatcp.Sensor.Status.WARN
 
 
 class Engine(aiokatcp.DeviceServer):
@@ -520,6 +549,7 @@ class Engine(aiokatcp.DeviceServer):
             chunks=send_chunks,
         )
         self._out_item = self._out_free_queue.get_nowait()
+        self._out_item.reset_all(self._compute.command_queue)
 
         self.delay_models: list[MultiDelayModel] = []
         self.gains = np.zeros((self.channels, self.pols), np.complex64)
@@ -722,6 +752,15 @@ class Engine(aiokatcp.DeviceServer):
             )
             sensors.add(
                 aiokatcp.Sensor(
+                    float,
+                    f"input{pol}-dig-pwr-dbfs",
+                    "Digitiser ADC average power",
+                    units="dBFS",
+                    status_func=dig_pwr_dbfs_status,
+                )
+            )
+            sensors.add(
+                aiokatcp.Sensor(
                     int,
                     f"input{pol}-feng-clip-cnt",
                     "Number of output samples that are saturated",
@@ -843,7 +882,7 @@ class Engine(aiokatcp.DeviceServer):
 
         # Just make double-sure that all events associated with the item are past.
         item.enqueue_wait_for_events(self._compute.command_queue)
-        item.reset(new_timestamp)
+        item.reset_all(self._compute.command_queue, new_timestamp)
         return item
 
     async def _flush_out(self, new_timestamp: int) -> None:
@@ -876,6 +915,9 @@ class Engine(aiokatcp.DeviceServer):
             self._compute.buffer("phase").set_async(self._compute.command_queue, self._out_item.phase)
             self._compute.buffer("gains").set_async(self._compute.command_queue, self._out_item.gains)
             self._compute.run_backend(self._out_item.spectra, self._out_item.saturated)
+            # Note: we also need to wait for any frontend calls because they
+            # write directly to self._out_item.dig_total_power, but this
+            # marker will take care of that too.
             self._out_item.add_marker(self._compute.command_queue)
             self._out_queue.put_nowait(self._out_item)
             # TODO: could set it to None, since we only need it when we're
@@ -987,7 +1029,9 @@ class Engine(aiokatcp.DeviceServer):
                     for pol_data in self._in_items[0].pol_data:
                         assert pol_data.samples is not None
                         samples.append(pol_data.samples)
-                    self._compute.run_frontend(samples, offsets, self._out_item.n_spectra, batch_spectra)
+                    self._compute.run_frontend(
+                        samples, self._out_item.dig_total_power, offsets, self._out_item.n_spectra, batch_spectra
+                    )
                     self._out_item.n_spectra += batch_spectra
                     # Work out which output spectra contain missing data.
                     self._out_item.present[out_slice] = True
@@ -1140,16 +1184,20 @@ class Engine(aiokatcp.DeviceServer):
         """
         task: asyncio.Future | None = None
         last_end_timestamp: int | None = None
+        context = self._compute.template.context
+        # Scratch space for transferring digitiser power
+        dig_total_power = [self._compute.slots[f"dig_total_power{pol}"].allocate_host(context) for pol in range(N_POLS)]
         while True:
             with self.monitor.with_state("run_transmit", "wait out_queue"):
                 out_item = await self._out_queue.get()
             if not out_item:
                 break
+            events = []
             if out_item.chunk is not None:
                 # We're using PeerDirect
                 chunk = out_item.chunk
                 chunk.cleanup = partial(self._out_free_queue.put_nowait, out_item)
-                events = out_item.events
+                events.extend(out_item.events)
             else:
                 with self.monitor.with_state("run_transmit", "wait send_free_queue"):
                     chunk = await self._send_free_queue.get()
@@ -1158,14 +1206,28 @@ class Engine(aiokatcp.DeviceServer):
                 assert isinstance(chunk.data, accel.HostArray)
                 # TODO: use get_region since it might be partial
                 out_item.spectra.get_async(self._download_queue, chunk.data)
-                out_item.saturated.get_async(self._download_queue, chunk.saturated)
-                events = [self._download_queue.enqueue_marker()]
+            out_item.saturated.get_async(self._download_queue, chunk.saturated)
+            for pol in range(N_POLS):
+                out_item.dig_total_power[pol].get_async(self._download_queue, dig_total_power[pol])
+            events.append(self._download_queue.enqueue_marker())
 
             chunk.timestamp = out_item.timestamp
             # Each frame is valid if all spectra in it are valid
             out_item.present.reshape(-1, self.spectra_per_heap).all(axis=-1, out=chunk.present)
             with self.monitor.with_state("run_transmit", "wait transfer"):
                 await async_wait_for_events(events)
+
+            for pol in range(N_POLS):
+                total_power = float(dig_total_power[pol])
+                avg_power = total_power / (out_item.n_spectra * self.spectra_samples)
+                # Normalise relative to full scale. The factor of 2 is because we
+                # want 1.0 to correspond to a sine wave rather than a square wave.
+                avg_power /= ((1 << (SAMPLE_BITS - 1)) - 1) ** 2 / 2
+                avg_power_db = 10 * math.log10(avg_power) if avg_power else -math.inf
+                self.sensors[f"input{pol}-dig-pwr-dbfs"].set_value(
+                    avg_power_db, timestamp=self.time_converter.adc_to_unix(out_item.end_timestamp)
+                )
+
             n_frames = out_item.n_spectra // self.spectra_per_heap
             if last_end_timestamp is not None and out_item.timestamp > last_end_timestamp:
                 # Account for heaps skipped between the end of the previous out_item and the

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -50,7 +50,7 @@ from ..queue_item import QueueItem
 from ..ringbuffer import ChunkRingbuffer
 from ..send import DescriptorSender
 from ..utils import DeviceStatusSensor, TimeConverter
-from . import SAMPLE_BITS, recv, send
+from . import DIG_POWER_DBFS_HIGH, DIG_POWER_DBFS_LOW, SAMPLE_BITS, recv, send
 from .compute import Compute, ComputeTemplate
 from .delay import AbstractDelayModel, LinearDelayModel, MultiDelayModel, wrap_angle
 
@@ -337,11 +337,11 @@ def format_complex(value: numbers.Complex) -> str:
 
 
 def dig_pwr_dbfs_status(value: float) -> aiokatcp.Sensor.Status:
-    """Compute status for dig-pwr-dbfs sensor.
-
-    TODO: the thresholds are inherited from MeerKAT. Are they what we want?
-    """
-    return aiokatcp.Sensor.Status.NOMINAL if -32.0 <= value <= -22.0 else aiokatcp.Sensor.Status.WARN
+    """Compute status for dig-pwr-dbfs sensor."""
+    if DIG_POWER_DBFS_LOW <= value <= DIG_POWER_DBFS_HIGH:
+        return aiokatcp.Sensor.Status.NOMINAL
+    else:
+        return aiokatcp.Sensor.Status.WARN
 
 
 class Engine(aiokatcp.DeviceServer):

--- a/src/katgpucbf/fgpu/kernels/pfb_fir.mako
+++ b/src/katgpucbf/fgpu/kernels/pfb_fir.mako
@@ -46,6 +46,7 @@ DEVICE_FN static unsigned int shuffle_index(unsigned int idx)
  */
 KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void pfb_fir(
     GLOBAL float * RESTRICT out,          // Output memory
+    GLOBAL unsigned long long * RESTRICT out_total_power,  // Sum of squares of samples (incremented)
     const GLOBAL uchar * RESTRICT in,     // Input data (digitiser samples)
     const GLOBAL float * RESTRICT weights,// Weights for the PFB-FIR filter.
     int n,                                // Size of the `out` array, to avoid going out-of-bounds.
@@ -77,6 +78,11 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void pfb_fir(
      * We assume we are not interested in the initial transient spectra.
      * We prime all but one of the taps with samples of data. The last one will
      * be filled in later as part of the main loop.
+     *
+     * These samples are deliberately not included in total_power, because they
+     * have already been counted by a previous workgroup (except for the very
+     * first samples in the stream, or after lost data, but that's a corner
+     * case not worth worrying about).
      */
     float samples[TAPS];
     for (int i = 0; i < TAPS - 1; i++)
@@ -95,6 +101,7 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void pfb_fir(
     // output "spectra" worth of data.
     int rows = stepy / step;
 
+    unsigned long long total_power = 0;
     // Unrolling by factor of TAPS makes the sample index known at compile time.
 #pragma unroll ${taps}
     for (int i = 0; i < rows; i++)  // We'll be at our most memory-bandwidth-efficient if rows >> TAPS. Launching ~256K threads should ensure this.
@@ -109,7 +116,9 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void pfb_fir(
          * This, combined with the way they are then read out below, avoids
          * having to manually shift things along in the array each loop.
          */
-        samples[(i + TAPS - 1) % TAPS] = get_sample_10bit(in, in_offset + idx);
+        int sample = get_sample_10bit(in, in_offset + idx);
+        total_power += sample * sample;
+        samples[(i + TAPS - 1) % TAPS] = (float) sample;
 
         // Implement the actual FIR filter by multiplying samples by weights and summing.
         float sum = 0.0f;
@@ -119,4 +128,6 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void pfb_fir(
         // Sum written out to global memory.
         out[idx] = sum;
     }
+
+    atomicAdd(out_total_power, total_power);
 }

--- a/src/katgpucbf/fgpu/kernels/unpack_10bit.mako
+++ b/src/katgpucbf/fgpu/kernels/unpack_10bit.mako
@@ -24,9 +24,9 @@ DEVICE_FN int samples_to_bytes(int samples)
 }
 
 /* Get the 10-bit sample at the given index from the chunk of samples, shake off
- * the unwanted surrounding pieces, and return as a float.
+ * the unwanted surrounding pieces, and return as an integer.
  */
-DEVICE_FN float get_sample_10bit(const GLOBAL uchar * RESTRICT in, int idx)
+DEVICE_FN int get_sample_10bit(const GLOBAL uchar * RESTRICT in, int idx)
 {
     // We were given the sample number. Get the byte index.
     int byte_idx = samples_to_bytes(idx);

--- a/src/katgpucbf/fgpu/kernels/unpack_10bit.mako
+++ b/src/katgpucbf/fgpu/kernels/unpack_10bit.mako
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020-2021, National Research Foundation (SARAO)
+ * Copyright (c) 2020-2022, National Research Foundation (SARAO)
  *
  * Licensed under the BSD 3-Clause License (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy

--- a/src/katgpucbf/fgpu/pfb.py
+++ b/src/katgpucbf/fgpu/pfb.py
@@ -99,6 +99,14 @@ class PFBFIR(accel.Operation):
         FIR-filtered time data, ready to be processed by the FFT.
     **weights** : 2*channels*taps, float32
         The time-domain transfer function of the FIR filter to be applied.
+    **total_power** : uint64
+        Sum of squares of input samples. This will not include every input
+        sample. Rather, it will contain a specific tap from each PFB window
+        (currently, the last tap, but that is an implementation detail).
+
+        This is incremented rather than overwritten. It is the caller's
+        responsibility to zero it when desired, or alternatively to track
+        values before and after to measure the change.
 
     Raises
     ------
@@ -137,6 +145,7 @@ class PFBFIR(accel.Operation):
         self.slots["in"] = accel.IOSlot((samples * SAMPLE_BITS // BYTE_BITS,), np.uint8)
         self.slots["out"] = accel.IOSlot((spectra, accel.Dimension(step, exact=True)), np.float32)
         self.slots["weights"] = accel.IOSlot((step * template.taps,), np.float32)
+        self.slots["total_power"] = accel.IOSlot((), np.uint64)
         self.in_offset = 0  # Number of samples to skip from the start of *in
         self.out_offset = 0  # Number of "spectra" to skip from the start of *out.
 
@@ -166,6 +175,7 @@ class PFBFIR(accel.Operation):
             self.template.kernel,
             [
                 self.buffer("out").buffer,
+                self.buffer("total_power").buffer,
                 self.buffer("in").buffer,
                 self.buffer("weights").buffer,
                 np.int32(out_n),

--- a/test/fgpu/test_pfb.py
+++ b/test/fgpu/test_pfb.py
@@ -57,7 +57,7 @@ def test_pfb_fir(context: AbstractContext, command_queue: AbstractCommandQueue, 
     rng = np.random.default_rng(seed=1)
     h_in = rng.integers(0, 256, samples * SAMPLE_BITS // BYTE_BITS, np.uint8)
     weights = rng.uniform(-1.0, 1.0, (2 * channels * taps,)).astype(np.float32)
-    expected, expected_total_power = pfb_fir_host(h_in, channels, unzip_factor, weights)
+    expected_out, expected_total_power = pfb_fir_host(h_in, channels, unzip_factor, weights)
 
     template = pfb.PFBFIRTemplate(context, taps, channels, unzip_factor)
     fn = template.instantiate(command_queue, samples, spectra)
@@ -76,5 +76,5 @@ def test_pfb_fir(context: AbstractContext, command_queue: AbstractCommandQueue, 
     fn()
     h_out = fn.buffer("out").get(command_queue)
     h_total_power = fn.buffer("total_power").get(command_queue)[()]
-    np.testing.assert_allclose(h_out, expected, rtol=1e-5, atol=1e-3)
+    np.testing.assert_allclose(h_out, expected_out, rtol=1e-5, atol=1e-3)
     assert h_total_power == expected_total_power

--- a/test/fgpu/test_pfb.py
+++ b/test/fgpu/test_pfb.py
@@ -43,7 +43,8 @@ def pfb_fir_host(data, channels, unzip_factor, weights):
     out = out.reshape(-1, channels // unzip_factor, unzip_factor, 2)
     out = out.swapaxes(1, 2)
     out = out.reshape(-1, step)
-    return out
+    total_power = np.sum(np.square(decoded[step * (taps - 1) :].astype(np.int64)))
+    return out, total_power
 
 
 @pytest.mark.parametrize("unzip_factor", [1, 2, 4])
@@ -56,13 +57,14 @@ def test_pfb_fir(context: AbstractContext, command_queue: AbstractCommandQueue, 
     rng = np.random.default_rng(seed=1)
     h_in = rng.integers(0, 256, samples * SAMPLE_BITS // BYTE_BITS, np.uint8)
     weights = rng.uniform(-1.0, 1.0, (2 * channels * taps,)).astype(np.float32)
-    expected = pfb_fir_host(h_in, channels, unzip_factor, weights)
+    expected, expected_total_power = pfb_fir_host(h_in, channels, unzip_factor, weights)
 
     template = pfb.PFBFIRTemplate(context, taps, channels, unzip_factor)
     fn = template.instantiate(command_queue, samples, spectra)
     fn.ensure_all_bound()
     fn.buffer("in").set(command_queue, h_in)
     fn.buffer("weights").set(command_queue, weights)
+    fn.buffer("total_power").zero(command_queue)
     # Split into two parts to test the offsetting
     fn.in_offset = 0
     fn.out_offset = 0
@@ -73,4 +75,6 @@ def test_pfb_fir(context: AbstractContext, command_queue: AbstractCommandQueue, 
     fn.spectra = spectra - fn.spectra
     fn()
     h_out = fn.buffer("out").get(command_queue)
+    h_total_power = fn.buffer("total_power").get(command_queue)[()]
     np.testing.assert_allclose(h_out, expected, rtol=1e-5, atol=1e-3)
+    assert h_total_power == expected_total_power


### PR DESCRIPTION
Add dig-pwr-dbfs sensors which report the average power in the digitiser signal for the last output chunk (with some caveats described in the design doc). These correspond to the `dig.pol?-rms-dbfs` in corr2; I removed "rms" from the name because (as described in NGC 801) it's a straight average of power, not root-mean-square of power.

It doesn't make any attempt to correctly handle missing data. I'll open a ticket about that before merging. I'm not sure how best to handle that case, since trying to take the average over just the good data will add a lot of complexity.

It's currently just a sensor (to match the functionality of the MK v7 ICD) with no Prometheus metric.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [ ] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
- [ ] Open a ticket for missing data handling
- [ ] Update the ICD draft

Relates to NGC-801. A katsdpcontroller is still needed to add the fake sensors and do the sensor renaming.
