### PR TITLE
Eliminate katgpucbf.fgpu.SAMPLE_BITS

### DIFF
--- a/src/katgpucbf/fgpu/__init__.py
+++ b/src/katgpucbf/fgpu/__init__.py
@@ -18,5 +18,4 @@
 
 from typing import Final
 
-SAMPLE_BITS: Final = 10
 METRIC_NAMESPACE: Final = "fgpu"

--- a/src/katgpucbf/fgpu/compute.py
+++ b/src/katgpucbf/fgpu/compute.py
@@ -25,8 +25,8 @@ import numpy as np
 from katsdpsigproc import accel, fft
 from katsdpsigproc.abc import AbstractCommandQueue, AbstractContext
 
-from .. import N_POLS
-from . import SAMPLE_BITS, pfb, postproc
+from .. import DIG_SAMPLE_BITS, N_POLS
+from . import pfb, postproc
 
 
 class ComputeTemplate:
@@ -114,7 +114,7 @@ class Compute(accel.OperationSequence):
         spectra: int,
         spectra_per_heap: int,
     ) -> None:
-        self.sample_bits = SAMPLE_BITS
+        self.sample_bits = DIG_SAMPLE_BITS
         self.template = template
         self.samples = samples
         self.spectra = spectra

--- a/src/katgpucbf/fgpu/ddc.py
+++ b/src/katgpucbf/fgpu/ddc.py
@@ -23,8 +23,7 @@ import numpy as np
 from katsdpsigproc import accel
 from katsdpsigproc.abc import AbstractCommandQueue, AbstractContext
 
-from .. import BYTE_BITS
-from . import SAMPLE_BITS
+from .. import BYTE_BITS, DIG_SAMPLE_BITS
 
 
 class _TuningDict(TypedDict):
@@ -83,8 +82,8 @@ class DDCTemplate:
             raise ValueError("decimation must be a multiple of sg_size")
         if self._group_in_size % self._segment_samples:
             raise ValueError("group_in_size must be a multiple of segment_samples (fix sg_size)")
-        if self._segment_samples * SAMPLE_BITS % 32:
-            raise ValueError("segment_samples * SAMPLE_BITS must be a multiple of 32")
+        if self._segment_samples * DIG_SAMPLE_BITS % 32:
+            raise ValueError("segment_samples * DIG_SAMPLE_BITS must be a multiple of 32")
 
         with resources.as_file(resources.files(__package__)) as resource_dir:
             program = accel.build(
@@ -96,7 +95,7 @@ class DDCTemplate:
                     "decimation": decimation,
                     "coarsen": self._coarsen,
                     "sg_size": self._sg_size,
-                    "sample_bits": SAMPLE_BITS,
+                    "sample_bits": DIG_SAMPLE_BITS,
                     "segment_samples": self._segment_samples,
                 },
                 extra_dirs=[str(resource_dir)],
@@ -141,7 +140,7 @@ class DDC(accel.Operation):
 
     .. rubric:: Slots
 
-    **in** : samples * SAMPLE_BITS // BYTE_BITS, uint8
+    **in** : samples * DIG_SAMPLE_BITS // BYTE_BITS, uint8
         Input digitiser samples in a big chunk.
     **out** : out_samples, complex64
         Filtered and decimated output data
@@ -177,7 +176,7 @@ class DDC(accel.Operation):
         self.slots["in"] = accel.IOSlot(
             (
                 accel.Dimension(
-                    samples * SAMPLE_BITS // BYTE_BITS,
+                    samples * DIG_SAMPLE_BITS // BYTE_BITS,
                     alignment=4,
                 ),
             ),

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -36,6 +36,7 @@ from .. import (
     BYTE_BITS,
     COMPLEX,
     DESCRIPTOR_TASK_NAME,
+    DIG_SAMPLE_BITS,
     GPU_PROC_TASK_NAME,
     N_POLS,
     RECV_TASK_NAME,
@@ -49,7 +50,7 @@ from ..queue_item import QueueItem
 from ..ringbuffer import ChunkRingbuffer
 from ..send import DescriptorSender
 from ..utils import DeviceStatusSensor, TimeConverter
-from . import SAMPLE_BITS, recv, send
+from . import recv, send
 from .compute import Compute, ComputeTemplate
 from .delay import AbstractDelayModel, LinearDelayModel, MultiDelayModel, wrap_angle
 
@@ -466,7 +467,7 @@ class Engine(aiokatcp.DeviceServer):
         self._src_interface = src_interface
         self._src_buffer = src_buffer
         self._src_ibv = src_ibv
-        self._src_layout = recv.Layout(SAMPLE_BITS, src_packet_samples, chunk_samples, mask_timestamp)
+        self._src_layout = recv.Layout(DIG_SAMPLE_BITS, src_packet_samples, chunk_samples, mask_timestamp)
         self._src_packet_samples = src_packet_samples
         self.adc_sample_rate = adc_sample_rate
         self.send_rate_factor = send_rate_factor
@@ -580,7 +581,7 @@ class Engine(aiokatcp.DeviceServer):
         )
         free_ringbuffers = [spead2.recv.ChunkRingbuffer(src_chunks_per_stream) for _ in range(N_POLS)]
         self._src_streams = recv.make_streams(self._src_layout, data_ringbuffer, free_ringbuffers, src_affinity)
-        chunk_bytes = self._src_layout.chunk_samples * SAMPLE_BITS // BYTE_BITS
+        chunk_bytes = self._src_layout.chunk_samples * DIG_SAMPLE_BITS // BYTE_BITS
         for pol, stream in enumerate(self._src_streams):
             for _ in range(src_chunks_per_stream):
                 if self.use_vkgdr:

--- a/src/katgpucbf/fgpu/pfb.py
+++ b/src/katgpucbf/fgpu/pfb.py
@@ -26,8 +26,7 @@ import numpy as np
 from katsdpsigproc import accel
 from katsdpsigproc.abc import AbstractCommandQueue, AbstractContext
 
-from .. import BYTE_BITS
-from . import SAMPLE_BITS
+from .. import BYTE_BITS, DIG_SAMPLE_BITS
 
 
 class PFBFIRTemplate:
@@ -95,7 +94,7 @@ class PFBFIR(accel.Operation):
 
     .. rubric:: Slots
 
-    **in** : samples * SAMPLE_BITS // BYTE_BITS, uint8
+    **in** : samples * DIG_SAMPLE_BITS // BYTE_BITS, uint8
         Input digitiser samples in a big chunk.
     **out** : spectra × 2*channels, float32
         FIR-filtered time data, ready to be processed by the FFT.
@@ -136,7 +135,7 @@ class PFBFIR(accel.Operation):
         self.samples = samples
         step = 2 * template.channels
         self.spectra = spectra  # Can be changed (TODO: documentation)
-        self.slots["in"] = accel.IOSlot((samples * SAMPLE_BITS // BYTE_BITS,), np.uint8)
+        self.slots["in"] = accel.IOSlot((samples * DIG_SAMPLE_BITS // BYTE_BITS,), np.uint8)
         self.slots["out"] = accel.IOSlot((spectra, accel.Dimension(step, exact=True)), np.float32)
         self.slots["weights"] = accel.IOSlot((step * template.taps,), np.float32)
         self.in_offset = 0  # Number of samples to skip from the start of *in

--- a/test/fgpu/test_ddc.py
+++ b/test/fgpu/test_ddc.py
@@ -20,8 +20,7 @@ import numpy as np
 import pytest
 from katsdpsigproc.abc import AbstractCommandQueue, AbstractContext
 
-from katgpucbf import BYTE_BITS
-from katgpucbf.fgpu import SAMPLE_BITS
+from katgpucbf import BYTE_BITS, DIG_SAMPLE_BITS
 from katgpucbf.fgpu.ddc import DDCTemplate, _TuningDict
 
 from .. import unpackbits
@@ -65,7 +64,7 @@ def test_ddc(
 ) -> None:
     """Test DDC kernel."""
     rng = np.random.default_rng(seed=1)
-    h_in = rng.integers(0, 256, samples * SAMPLE_BITS // BYTE_BITS, np.uint8)
+    h_in = rng.integers(0, 256, samples * DIG_SAMPLE_BITS // BYTE_BITS, np.uint8)
     weights = rng.uniform(-1.0, 1.0, (taps,)).astype(np.float32)
     mix_frequency = 0.21
     expected = ddc_host(h_in, weights, decimation, mix_frequency)

--- a/test/fgpu/test_pfb.py
+++ b/test/fgpu/test_pfb.py
@@ -20,8 +20,8 @@ import numpy as np
 import pytest
 from katsdpsigproc.abc import AbstractCommandQueue, AbstractContext
 
-from katgpucbf import BYTE_BITS
-from katgpucbf.fgpu import SAMPLE_BITS, pfb
+from katgpucbf import BYTE_BITS, DIG_SAMPLE_BITS
+from katgpucbf.fgpu import pfb
 
 from .. import unpackbits
 
@@ -54,7 +54,7 @@ def test_pfb_fir(context: AbstractContext, command_queue: AbstractCommandQueue, 
     channels = 4096
     samples = 2 * channels * (spectra + taps - 1)
     rng = np.random.default_rng(seed=1)
-    h_in = rng.integers(0, 256, samples * SAMPLE_BITS // BYTE_BITS, np.uint8)
+    h_in = rng.integers(0, 256, samples * DIG_SAMPLE_BITS // BYTE_BITS, np.uint8)
     weights = rng.uniform(-1.0, 1.0, (2 * channels * taps,)).astype(np.float32)
     expected = pfb_fir_host(h_in, channels, unzip_factor, weights)
 


### PR DESCRIPTION
I realised it was duplicating katgpucbf.DIG_SAMPLE_BITS (which I think was added later. Apart from the duplication, I like DIG_SAMPLE_BITS, since it's clear about which sort of samples are being discussed.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

No related Jira ticket.
