### PR TITLE
Add F-engine `rx.device-status` sensor.

### DIFF
--- a/src/katgpucbf/fgpu/recv.py
+++ b/src/katgpucbf/fgpu/recv.py
@@ -256,9 +256,7 @@ def make_sensors(sensor_timeout: float) -> aiokatcp.SensorSet:
             TimeoutSensorStatusObserver(sensor, sensor_timeout, aiokatcp.Sensor.Status.NOMINAL)
             sensors.add(sensor)
 
-        sensors.add(
-            DeviceStatusSensor(sensors, "rx.device-status", "F-engine is receiving a good, clean digitiser stream")
-        )
+    sensors.add(DeviceStatusSensor(sensors, "rx.device-status", "F-engine is receiving a good, clean digitiser stream"))
 
     return sensors
 

--- a/src/katgpucbf/fgpu/recv.py
+++ b/src/katgpucbf/fgpu/recv.py
@@ -38,7 +38,7 @@ from ..recv import BaseLayout, Chunk, StatsCollector
 from ..recv import make_stream as make_base_stream
 from ..recv import user_data_type
 from ..spead import DIGITISER_STATUS_ID, DIGITISER_STATUS_SATURATION_COUNT_SHIFT, TIMESTAMP_ID
-from ..utils import TimeConverter, TimeoutSensorStatusObserver
+from ..utils import DeviceStatusSensor, TimeConverter, TimeoutSensorStatusObserver
 from . import METRIC_NAMESPACE
 
 #: Number of partial chunks to allow at a time. Using 1 would reject any out-of-order
@@ -255,6 +255,11 @@ def make_sensors(sensor_timeout: float) -> aiokatcp.SensorSet:
         for sensor in missing_sensors:
             TimeoutSensorStatusObserver(sensor, sensor_timeout, aiokatcp.Sensor.Status.NOMINAL)
             sensors.add(sensor)
+
+        sensors.add(
+            DeviceStatusSensor(sensors, "rx.device-status", "F-engine is receiving a good, clean digitiser stream")
+        )
+
     return sensors
 
 

--- a/src/katgpucbf/utils.py
+++ b/src/katgpucbf/utils.py
@@ -76,11 +76,16 @@ class DeviceStatusSensor(aiokatcp.SimpleAggregateSensor[DeviceStatus]):
     it's quick to identify if there's something wrong, or if everything is good.
     """
 
-    def __init__(self, target: aiokatcp.SensorSet) -> None:
+    def __init__(
+        self, target: aiokatcp.SensorSet, name: str = "device-status", description: str = "Overall engine health"
+    ) -> None:
         # We count the number of sensors with each possible status
         self._counts: Counter[aiokatcp.Sensor.Status] = Counter()
         super().__init__(
-            target=target, sensor_type=DeviceStatus, name="device-status", description="Overall engine health"
+            target=target,
+            sensor_type=DeviceStatus,
+            name=name,
+            description=description,
         )
 
     def update_aggregate(

--- a/src/katgpucbf/utils.py
+++ b/src/katgpucbf/utils.py
@@ -116,6 +116,11 @@ class DeviceStatusSensor(aiokatcp.SimpleAggregateSensor[DeviceStatus]):
         # won't be able to.
         return (aiokatcp.Sensor.Status.WARN, DeviceStatus.DEGRADED)
 
+    def filter_aggregate(self, sensor: aiokatcp.Sensor) -> bool:  # noqa: D102
+        # Filter other aggregate sensors out. We don't need them because the
+        # underlying (normal) sensors are incorporated.
+        return not isinstance(sensor, aiokatcp.AggregateSensor)
+
 
 class TimeoutSensorStatusObserver:
     """Change the status of a sensor if it doesn't receive an update for a given time.

--- a/test/fgpu/test_recv.py
+++ b/test/fgpu/test_recv.py
@@ -41,7 +41,7 @@ from katgpucbf.spead import (
     FLAVOUR,
     TIMESTAMP_ID,
 )
-from katgpucbf.utils import TimeConverter
+from katgpucbf.utils import DeviceStatus, TimeConverter
 
 from .. import PromDiff
 
@@ -426,3 +426,6 @@ class TestChunkSets:
             assert sensor.value == time_converter.adc_to_unix(20 * layout.chunk_samples)
             assert sensor.status == aiokatcp.Sensor.Status.ERROR
             assert sensor.timestamp == sensor.value
+        ds_sensor = sensors["rx.device-status"]
+        assert ds_sensor.value == DeviceStatus.DEGRADED
+        assert ds_sensor.status == aiokatcp.Sensor.Status.WARN


### PR DESCRIPTION
Turned out to be relatively simple.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
(See https://github.com/ska-sa/katsdpcontroller/pull/630)
Closes NGC-847.
