### PR TITLE
Add X-engine chan-range sensor

### DIFF
--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -279,7 +279,6 @@ class XBEngine(DeviceServer):
         context: katsdpsigproc.abc.AbstractContext,
     ):
         super().__init__(katcp_host, katcp_port)
-        self.populate_sensors(self.sensors)
 
         if sample_bits != 8:
             raise ValueError("sample_bits must equal 8 - no other values supported at the moment.")
@@ -298,6 +297,9 @@ class XBEngine(DeviceServer):
         self.n_spectra_per_heap = n_spectra_per_heap
         self.sample_bits = sample_bits
         self.n_samples_between_spectra = n_samples_between_spectra
+        self.channel_offset_value = channel_offset_value
+
+        self.populate_sensors(self.sensors)
 
         self._src = src
         self._src_interface = src_interface
@@ -336,7 +338,6 @@ class XBEngine(DeviceServer):
             math.ceil(rx_reorder_tol / self.rx_heap_timestamp_step / self.heaps_per_fengine_per_chunk) + 1
         )
         n_free_chunks: int = self.max_active_chunks + 8  # TODO: Abstract this 'naked' constant
-        self.channel_offset_value = channel_offset_value
 
         self.monitor = monitor
 
@@ -443,9 +444,19 @@ class XBEngine(DeviceServer):
             tx_enabled=self._init_tx_enabled,
         )
 
-    @staticmethod
-    def populate_sensors(sensors: aiokatcp.SensorSet) -> None:
+    def populate_sensors(self, sensors: aiokatcp.SensorSet) -> None:
         """Define the sensors for an XBEngine."""
+        # Static sensors
+        sensors.add(
+            aiokatcp.Sensor(
+                str,
+                "chan-range",
+                "The range of channels processed by this XB-engine",
+                default=f"({self.channel_offset_value},{self.channel_offset_value + self.n_channels_per_stream - 1})",
+                initial_status=aiokatcp.Sensor.Status.NOMINAL,
+            )
+        )
+        # Dynamic sensors
         sensors.add(
             aiokatcp.Sensor(
                 bool,

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -458,6 +458,11 @@ class TestEngine:
         timestamp_step = n_samples_between_spectra * n_spectra_per_heap
         missing_antennas = set() if missing_antenna is None else {missing_antenna}
 
+        assert (
+            xbengine.sensors["chan-range"].value
+            == f"({n_channels_per_stream*CHANNEL_OFFSET},{n_channels_per_stream*CHANNEL_OFFSET + n_channels_per_stream - 1})"  # noqa: E501
+        )
+
         # Need a method of capturing synchronised aiokatcp.Sensor updates
         # as they happen in the XBEngine
         actual_sensor_updates: list[tuple[bool, aiokatcp.Sensor.Status]] = []

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -458,10 +458,9 @@ class TestEngine:
         timestamp_step = n_samples_between_spectra * n_spectra_per_heap
         missing_antennas = set() if missing_antenna is None else {missing_antenna}
 
-        assert (
-            xbengine.sensors["chan-range"].value
-            == f"({n_channels_per_stream*CHANNEL_OFFSET},{n_channels_per_stream*CHANNEL_OFFSET + n_channels_per_stream - 1})"  # noqa: E501
-        )
+        range_start = n_channels_per_stream * CHANNEL_OFFSET
+        range_end = range_start + n_channels_per_stream - 1
+        assert xbengine.sensors["chan-range"].value == f"({range_start},{range_end})"
 
         # Need a method of capturing synchronised aiokatcp.Sensor updates
         # as they happen in the XBEngine


### PR DESCRIPTION
I had to re-arrange a few of the initialisation things in the top of XBEngine.__init__(), and make populate_sensors no longer a static function, because it needed to access class members. But it seems to work.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [X] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [X] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [X] Ensure copyright notices are present and up-to-date
- [X] (N/A) If qualification tests are changed: attach a sample qualification report
- [X] (N/A) If design has changed: ensure documentation is up to date
- [ ] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Addresses NGC-837
