### PR TITLE
Bump certifi to the latest version

### DIFF
--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -40,7 +40,7 @@ build==0.8.0
     # via
     #   -r qualification/../requirements-dev.txt
     #   pip-tools
-certifi==2022.9.24
+certifi==2022.12.7
     # via
     #   -r qualification/../requirements-dev.txt
     #   requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,7 +24,7 @@ backcall==0.2.0
     # via ipython
 build==0.8.0
     # via pip-tools
-certifi==2022.9.24
+certifi==2022.12.7
     # via requests
 cfgv==3.3.1
     # via pre-commit


### PR DESCRIPTION
To shut up dependabot.

Checklist is all N/A.