### PR TITLE
Set an auto strategy on some fast-updating sensors

### DIFF
--- a/src/katgpucbf/__init__.py
+++ b/src/katgpucbf/__init__.py
@@ -43,9 +43,9 @@ DEFAULT_KATCP_HOST: Final = ""  # All interfaces
 DEFAULT_KATCP_PORT: Final = 7147
 DIG_HEAP_SAMPLES: Final = 4096
 DIG_SAMPLE_BITS: Final = 10
-# Update rate (expressed in seconds) for katcp sensors where the underlying value
-# may update extremely rapidly.
-SENSOR_UPDATE_TIME: Final = 1.0
+# Minimum update period (in seconds) for katcp sensors where the underlying
+# value may update extremely rapidly.
+MIN_SENSOR_UPDATE_PERIOD: Final = 1.0
 
 GPU_PROC_TASK_NAME: Final[str] = "GPU Processing Loop"
 RECV_TASK_NAME: Final[str] = "Receiver Loop"

--- a/src/katgpucbf/__init__.py
+++ b/src/katgpucbf/__init__.py
@@ -26,25 +26,23 @@ except PackageNotFoundError:
     # Package wasn't installed yet?
     __version__ = "unknown"
 
-__all__ = ["__version__"]
-
 BYTE_BITS: Final = 8
 COMPLEX: Final = 2
 N_POLS: Final = 2
 SPEAD_DESCRIPTOR_INTERVAL_S: Final = 5
 SEND_RATE_FACTOR = 1.1
-# Biggest power of 2 that fits in a jumbo MTU. A power of 2 isn't required but
-# it can be convenient to have packet boundaries align with the natural
-# boundaries in the payload (for antenna-channelised-voltage output). Bigger
-# is better to minimise the number of packets/second to process.
+#: Biggest power of 2 that fits in a jumbo MTU. A power of 2 isn't required but
+#: it can be convenient to have packet boundaries align with the natural
+#: boundaries in the payload (for antenna-channelised-voltage output). Bigger
+#: is better to minimise the number of packets/second to process.
 DEFAULT_PACKET_PAYLOAD_BYTES: Final = 8192
 DEFAULT_TTL: Final = 4  #: Default TTL for spead multicast transmission
 DEFAULT_KATCP_HOST: Final = ""  # All interfaces
 DEFAULT_KATCP_PORT: Final = 7147
 DIG_HEAP_SAMPLES: Final = 4096
 DIG_SAMPLE_BITS: Final = 10
-# Minimum update period (in seconds) for katcp sensors where the underlying
-# value may update extremely rapidly.
+#: Minimum update period (in seconds) for katcp sensors where the underlying
+#: value may update extremely rapidly.
 MIN_SENSOR_UPDATE_PERIOD: Final = 1.0
 
 GPU_PROC_TASK_NAME: Final[str] = "GPU Processing Loop"

--- a/src/katgpucbf/__init__.py
+++ b/src/katgpucbf/__init__.py
@@ -39,10 +39,13 @@ SEND_RATE_FACTOR = 1.1
 # is better to minimise the number of packets/second to process.
 DEFAULT_PACKET_PAYLOAD_BYTES: Final = 8192
 DEFAULT_TTL: Final = 4  #: Default TTL for spead multicast transmission
-DEFAULT_KATCP_HOST = ""  # All interfaces
-DEFAULT_KATCP_PORT = 7147
-DIG_HEAP_SAMPLES = 4096
+DEFAULT_KATCP_HOST: Final = ""  # All interfaces
+DEFAULT_KATCP_PORT: Final = 7147
+DIG_HEAP_SAMPLES: Final = 4096
 DIG_SAMPLE_BITS: Final = 10
+# Update rate (expressed in seconds) for katcp sensors where the underlying value
+# may update extremely rapidly.
+SENSOR_UPDATE_TIME: Final = 1.0
 
 GPU_PROC_TASK_NAME: Final[str] = "GPU Processing Loop"
 RECV_TASK_NAME: Final[str] = "Receiver Loop"

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -42,6 +42,7 @@ from .. import (
     N_POLS,
     RECV_TASK_NAME,
     SEND_TASK_NAME,
+    SENSOR_UPDATE_TIME,
     SPEAD_DESCRIPTOR_INTERVAL_S,
     __version__,
 )
@@ -749,6 +750,8 @@ class Engine(aiokatcp.DeviceServer):
                     "Number of digitiser samples that are saturated",
                     default=0,
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,
+                    auto_strategy=aiokatcp.SensorSampler.Strategy.EVENT_RATE,
+                    auto_strategy_parameters=(SENSOR_UPDATE_TIME, math.inf),
                 )
             )
             sensors.add(
@@ -758,6 +761,8 @@ class Engine(aiokatcp.DeviceServer):
                     "Digitiser ADC average power",
                     units="dBFS",
                     status_func=dig_pwr_dbfs_status,
+                    auto_strategy=aiokatcp.SensorSampler.Strategy.EVENT_RATE,
+                    auto_strategy_parameters=(SENSOR_UPDATE_TIME, math.inf),
                 )
             )
             sensors.add(
@@ -767,6 +772,8 @@ class Engine(aiokatcp.DeviceServer):
                     "Number of output samples that are saturated",
                     default=0,
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,
+                    auto_strategy=aiokatcp.SensorSampler.Strategy.EVENT_RATE,
+                    auto_strategy_parameters=(SENSOR_UPDATE_TIME, math.inf),
                 )
             )
 

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -39,10 +39,10 @@ from .. import (
     DESCRIPTOR_TASK_NAME,
     DIG_SAMPLE_BITS,
     GPU_PROC_TASK_NAME,
+    MIN_SENSOR_UPDATE_PERIOD,
     N_POLS,
     RECV_TASK_NAME,
     SEND_TASK_NAME,
-    SENSOR_UPDATE_TIME,
     SPEAD_DESCRIPTOR_INTERVAL_S,
     __version__,
 )
@@ -751,7 +751,7 @@ class Engine(aiokatcp.DeviceServer):
                     default=0,
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,
                     auto_strategy=aiokatcp.SensorSampler.Strategy.EVENT_RATE,
-                    auto_strategy_parameters=(SENSOR_UPDATE_TIME, math.inf),
+                    auto_strategy_parameters=(MIN_SENSOR_UPDATE_PERIOD, math.inf),
                 )
             )
             sensors.add(
@@ -762,7 +762,7 @@ class Engine(aiokatcp.DeviceServer):
                     units="dBFS",
                     status_func=dig_pwr_dbfs_status,
                     auto_strategy=aiokatcp.SensorSampler.Strategy.EVENT_RATE,
-                    auto_strategy_parameters=(SENSOR_UPDATE_TIME, math.inf),
+                    auto_strategy_parameters=(MIN_SENSOR_UPDATE_PERIOD, math.inf),
                 )
             )
             sensors.add(
@@ -773,7 +773,7 @@ class Engine(aiokatcp.DeviceServer):
                     default=0,
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,
                     auto_strategy=aiokatcp.SensorSampler.Strategy.EVENT_RATE,
-                    auto_strategy_parameters=(SENSOR_UPDATE_TIME, math.inf),
+                    auto_strategy_parameters=(MIN_SENSOR_UPDATE_PERIOD, math.inf),
                 )
             )
 

--- a/src/katgpucbf/fgpu/recv.py
+++ b/src/katgpucbf/fgpu/recv.py
@@ -34,7 +34,7 @@ from prometheus_client import Counter
 from spead2.numba import intp_to_voidptr
 from spead2.recv.numba import chunk_place_data
 
-from .. import BYTE_BITS, N_POLS, SENSOR_UPDATE_TIME
+from .. import BYTE_BITS, MIN_SENSOR_UPDATE_PERIOD, N_POLS
 from ..recv import BaseLayout, Chunk, StatsCollector
 from ..recv import make_stream as make_base_stream
 from ..recv import user_data_type
@@ -232,7 +232,7 @@ def make_sensors(sensor_timeout: float) -> aiokatcp.SensorSet:
                 default=-1,
                 initial_status=aiokatcp.Sensor.Status.ERROR,
                 auto_strategy=aiokatcp.SensorSampler.Strategy.EVENT_RATE,
-                auto_strategy_parameters=(SENSOR_UPDATE_TIME, math.inf),
+                auto_strategy_parameters=(MIN_SENSOR_UPDATE_PERIOD, math.inf),
             ),
             aiokatcp.Sensor(
                 float,
@@ -241,7 +241,7 @@ def make_sensors(sensor_timeout: float) -> aiokatcp.SensorSet:
                 default=-1.0,
                 initial_status=aiokatcp.Sensor.Status.ERROR,
                 auto_strategy=aiokatcp.SensorSampler.Strategy.EVENT_RATE,
-                auto_strategy_parameters=(SENSOR_UPDATE_TIME, math.inf),
+                auto_strategy_parameters=(MIN_SENSOR_UPDATE_PERIOD, math.inf),
             ),
         ]
         for sensor in timestamp_sensors:

--- a/src/katgpucbf/fgpu/recv.py
+++ b/src/katgpucbf/fgpu/recv.py
@@ -18,6 +18,7 @@
 
 import functools
 import logging
+import math
 from collections import deque
 from collections.abc import AsyncGenerator, Sequence
 from dataclasses import dataclass
@@ -33,7 +34,7 @@ from prometheus_client import Counter
 from spead2.numba import intp_to_voidptr
 from spead2.recv.numba import chunk_place_data
 
-from .. import BYTE_BITS, N_POLS
+from .. import BYTE_BITS, N_POLS, SENSOR_UPDATE_TIME
 from ..recv import BaseLayout, Chunk, StatsCollector
 from ..recv import make_stream as make_base_stream
 from ..recv import user_data_type
@@ -230,6 +231,8 @@ def make_sensors(sensor_timeout: float) -> aiokatcp.SensorSet:
                 "The timestamp (in samples) of the last chunk of data received from the digitiser",
                 default=-1,
                 initial_status=aiokatcp.Sensor.Status.ERROR,
+                auto_strategy=aiokatcp.SensorSampler.Strategy.EVENT_RATE,
+                auto_strategy_parameters=(SENSOR_UPDATE_TIME, math.inf),
             ),
             aiokatcp.Sensor(
                 float,
@@ -237,6 +240,8 @@ def make_sensors(sensor_timeout: float) -> aiokatcp.SensorSet:
                 "The timestamp (in UNIX time) of the last chunk of data received from the digitiser",
                 default=-1.0,
                 initial_status=aiokatcp.Sensor.Status.ERROR,
+                auto_strategy=aiokatcp.SensorSampler.Strategy.EVENT_RATE,
+                auto_strategy_parameters=(SENSOR_UPDATE_TIME, math.inf),
             ),
         ]
         for sensor in timestamp_sensors:

--- a/src/katgpucbf/utils.py
+++ b/src/katgpucbf/utils.py
@@ -28,7 +28,7 @@ from typing import TypeVar
 import aiokatcp
 from katsdptelstate.endpoint import endpoint_list_parser
 
-from . import SENSOR_UPDATE_TIME, TIME_SYNC_TASK_NAME
+from . import MIN_SENSOR_UPDATE_PERIOD, TIME_SYNC_TASK_NAME
 
 _T = TypeVar("_T")
 
@@ -264,10 +264,7 @@ def add_time_sync_sensors(sensors: aiokatcp.SensorSet) -> asyncio.Task:
                 status=aiokatcp.Sensor.Status.NOMINAL if good else aiokatcp.Sensor.Status.ERROR,
                 timestamp=mapping["state"].timestamp,
             )
-            # 1 second is pretty arbitrary. It's probably faster than
-            # necessary, but subscribers can always use a rate-limiting
-            # sampling strategy to reduce the rate of updates.
-            await asyncio.sleep(SENSOR_UPDATE_TIME)
+            await asyncio.sleep(MIN_SENSOR_UPDATE_PERIOD)
 
     return asyncio.create_task(run(), name=TIME_SYNC_TASK_NAME)
 

--- a/src/katgpucbf/utils.py
+++ b/src/katgpucbf/utils.py
@@ -28,7 +28,7 @@ from typing import TypeVar
 import aiokatcp
 from katsdptelstate.endpoint import endpoint_list_parser
 
-from . import TIME_SYNC_TASK_NAME
+from . import SENSOR_UPDATE_TIME, TIME_SYNC_TASK_NAME
 
 _T = TypeVar("_T")
 
@@ -267,7 +267,7 @@ def add_time_sync_sensors(sensors: aiokatcp.SensorSet) -> asyncio.Task:
             # 1 second is pretty arbitrary. It's probably faster than
             # necessary, but subscribers can always use a rate-limiting
             # sampling strategy to reduce the rate of updates.
-            await asyncio.sleep(1)
+            await asyncio.sleep(SENSOR_UPDATE_TIME)
 
     return asyncio.create_task(run(), name=TIME_SYNC_TASK_NAME)
 


### PR DESCRIPTION
This should prevent overloading the product controller. See NGC-859.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-859.
