### PR TITLE
Remove katsdptelstate dependency

### DIFF
--- a/doc/katgpucbf.endpoint.rst
+++ b/doc/katgpucbf.endpoint.rst
@@ -1,0 +1,7 @@
+katgpucbf.endpoint module
+======================
+
+.. automodule:: katgpucbf.endpoint
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/katgpucbf.endpoint.rst
+++ b/doc/katgpucbf.endpoint.rst
@@ -1,5 +1,5 @@
 katgpucbf.endpoint module
-======================
+=========================
 
 .. automodule:: katgpucbf.endpoint
    :members:

--- a/doc/katgpucbf.rst
+++ b/doc/katgpucbf.rst
@@ -17,6 +17,7 @@ Submodules
 .. toctree::
    :maxdepth: 4
 
+   katgpucbf.endpoint
    katgpucbf.meerkat
    katgpucbf.monitor
    katgpucbf.queue_item

--- a/qualification/__init__.py
+++ b/qualification/__init__.py
@@ -39,7 +39,6 @@ import scipy
 import spead2
 import spead2.recv
 import spead2.recv.asyncio
-from katsdptelstate.endpoint import endpoint_list_parser
 from numba import types
 from numpy.typing import NDArray
 from spead2.numba import intp_to_voidptr
@@ -47,6 +46,7 @@ from spead2.recv.numba import chunk_place_data
 
 import katgpucbf.recv
 from katgpucbf import COMPLEX
+from katgpucbf.endpoint import endpoint_list_parser
 from katgpucbf.utils import TimeConverter
 
 logger = logging.getLogger(__name__)

--- a/qualification/requirements.in
+++ b/qualification/requirements.in
@@ -5,7 +5,6 @@ dask
 docutils
 katsdpservices
 katsdpsigproc
-katsdptelstate
 matplotlib
 numpy
 prometheus-api-client

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -23,7 +23,6 @@ async-timeout==4.0.2
     #   -r qualification/../requirements-dev.txt
     #   -r qualification/requirements.in
     #   aiokatcp
-    #   redis
 attrs==22.1.0
     # via
     #   -r qualification/../requirements-dev.txt
@@ -76,8 +75,6 @@ decorator==5.1.1
     #   aiokatcp
     #   ipython
     #   katsdpsigproc
-deprecated==1.2.13
-    # via redis
 distlib==0.3.6
     # via
     #   -r qualification/../requirements-dev.txt
@@ -106,8 +103,6 @@ fonttools==4.37.4
     # via matplotlib
 fsspec==2022.10.0
     # via dask
-hiredis==2.0.0
-    # via katsdptelstate
 httmock==1.4.0
     # via prometheus-api-client
 identify==2.5.6
@@ -140,8 +135,6 @@ katsdpservices==1.2
     # via -r qualification/requirements.in
 katsdpsigproc==1.6.1
     # via -r qualification/requirements.in
-katsdptelstate==0.11
-    # via -r qualification/requirements.in
 kiwisolver==1.4.4
     # via matplotlib
 latexcodec==2.0.1
@@ -169,12 +162,8 @@ matplotlib-inline==0.1.6
     # via
     #   -r qualification/../requirements-dev.txt
     #   ipython
-msgpack==1.0.4
-    # via katsdptelstate
 netifaces==0.11.0
-    # via
-    #   katsdpservices
-    #   katsdptelstate
+    # via katsdpservices
 nodeenv==1.7.0
     # via
     #   -r qualification/../requirements-dev.txt
@@ -189,7 +178,6 @@ numpy==1.23.4
     #   -r qualification/requirements.in
     #   contourpy
     #   katsdpsigproc
-    #   katsdptelstate
     #   matplotlib
     #   numba
     #   pandas
@@ -206,7 +194,6 @@ packaging==21.3
     #   dask
     #   matplotlib
     #   pytest
-    #   redis
     #   sphinx
     #   xarray
 pandas==1.5.0
@@ -339,8 +326,6 @@ pyyaml==6.0
     #   dask
     #   pre-commit
     #   pybtex
-redis==4.3.4
-    # via katsdptelstate
 regex==2022.3.2
     # via dateparser
 requests==2.28.1
@@ -355,7 +340,6 @@ six==1.16.0
     # via
     #   -r qualification/../requirements-dev.txt
     #   asttokens
-    #   katsdptelstate
     #   latexcodec
     #   pybtex
     #   python-dateutil
@@ -453,9 +437,7 @@ wheel==0.37.1
     #   -r qualification/../requirements-dev.txt
     #   pip-tools
 wrapt==1.14.1
-    # via
-    #   deprecated
-    #   prometheus-async
+    # via prometheus-async
 xarray==2022.10.0
     # via -r qualification/requirements.in
 

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,6 @@ aiokatcp>=1.5.0
 dask
 katsdpservices[aiomonitor]>=1.2
 katsdpsigproc[CUDA]>=1.6.1
-katsdptelstate
 numpy
 prometheus-async[aiohttp]
 psutil  # Gives more accurate dask.system.CPU_COUNT

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@ async-timeout==4.0.2
     # via
     #   aiohttp
     #   aiokatcp
-    #   redis
 attrs==22.1.0
     # via aiohttp
 cffi==1.15.1
@@ -37,23 +36,17 @@ decorator==5.1.1
     # via
     #   aiokatcp
     #   katsdpsigproc
-deprecated==1.2.13
-    # via redis
 frozenlist==1.3.1
     # via
     #   aiohttp
     #   aiosignal
 fsspec==2022.8.2
     # via dask
-hiredis==2.0.0
-    # via katsdptelstate
 idna==3.4
     # via yarl
 katsdpservices[aiomonitor]==1.2
     # via -r requirements.in
 katsdpsigproc[cuda]==1.6.1
-    # via -r requirements.in
-katsdptelstate==0.11
     # via -r requirements.in
 llvmlite==0.39.1
     # via numba
@@ -65,23 +58,18 @@ mako==1.2.3
     #   pycuda
 markupsafe==2.1.1
     # via mako
-msgpack==1.0.4
-    # via katsdptelstate
 multidict==6.0.2
     # via
     #   aiohttp
     #   yarl
 netifaces==0.11.0
-    # via
-    #   katsdpservices
-    #   katsdptelstate
+    # via katsdpservices
 numba==0.56.3
     # via katsdpsigproc
 numpy==1.23.4
     # via
     #   -r requirements.in
     #   katsdpsigproc
-    #   katsdptelstate
     #   numba
     #   pandas
     #   scipy
@@ -90,7 +78,6 @@ numpy==1.23.4
 packaging==21.3
     # via
     #   dask
-    #   redis
     #   xarray
 pandas==1.5.0
     # via
@@ -126,14 +113,10 @@ pytz==2022.4
     # via pandas
 pyyaml==6.0
     # via dask
-redis==4.3.4
-    # via katsdptelstate
 scipy==1.9.2
     # via katsdpsigproc
 six==1.16.0
-    # via
-    #   katsdptelstate
-    #   python-dateutil
+    # via python-dateutil
 spead2==3.11.1
     # via -r requirements.in
 terminaltables==3.1.10
@@ -150,9 +133,7 @@ typing-extensions==4.4.0
 vkgdr==0.1
     # via -r requirements.in
 wrapt==1.14.1
-    # via
-    #   deprecated
-    #   prometheus-async
+    # via prometheus-async
 xarray==2022.10.0
     # via -r requirements.in
 yarl==1.8.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ install_requires =
     dask
     katsdpservices[aiomonitor]
     katsdpsigproc>=1.6.1
-    katsdptelstate
     numba
     numpy
     prometheus-async[aiohttp]

--- a/src/katgpucbf/dsim/main.py
+++ b/src/katgpucbf/dsim/main.py
@@ -31,9 +31,9 @@ import katsdpservices
 import numpy as np
 import prometheus_async
 import pyparsing as pp
-from katsdptelstate.endpoint import endpoint_list_parser
 
 from .. import BYTE_BITS, DEFAULT_KATCP_HOST, DEFAULT_KATCP_PORT, DEFAULT_TTL, SPEAD_DESCRIPTOR_INTERVAL_S
+from ..endpoint import endpoint_list_parser
 from ..send import DescriptorSender
 from ..utils import TimeConverter, add_signal_handlers
 from . import descriptors, send, signal

--- a/src/katgpucbf/endpoint.py
+++ b/src/katgpucbf/endpoint.py
@@ -1,0 +1,143 @@
+################################################################################
+# Copyright (c) 2015-2019, 2002 National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+"""Endpoint utilities.
+
+It's inelegant but we've copied this file here because it's all we use from
+katsdptelstate, and we'd prefer not to have to pull it with all its dependencies
+in.
+"""
+
+import socket
+import struct
+from typing import Any, Callable, Iterator, List
+
+
+class Endpoint:
+    """A TCP or UDP endpoint consisting of a host and a port.
+
+    Typically the host should be a string (whether a hostname or IP address) and
+    the port should be an integer, but users are free to use other conventions.
+    """
+
+    def __init__(self, host: Any, port: Any) -> None:
+        self.host = host
+        self.port = port
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Endpoint) and self.host == other.host and self.port == other.port
+
+    def __ne__(self, other: object) -> bool:
+        return not self == other
+
+    def __hash__(self) -> int:
+        return hash((self.host, self.port))
+
+    def __str__(self) -> str:
+        if ":" in self.host:
+            # IPv6 address - escape it
+            return "[{}]:{}".format(self.host, self.port)
+        else:
+            return "{}:{}".format(self.host, self.port)
+
+    def __repr__(self) -> str:
+        return "Endpoint({!r}, {!r})".format(self.host, self.port)
+
+    def __iter__(self) -> Iterator:
+        """Support `tuple(endpoint)` for passing to a socket function."""
+        return iter((self.host, self.port))
+
+
+def endpoint_parser(default_port: Any) -> Callable[[str], Endpoint]:
+    """Return a factory function that parses a string.
+
+    The string is either `hostname`, or `hostname:port`, where `port` is an
+    integer. IPv6 addresses are written in square brackets (similar to RFC
+    2732) to disambiguate the embedded colons.
+    """
+
+    def parser(text: str) -> Endpoint:
+        port = default_port
+        # Find the last :, which should separate the port
+        pos = text.rfind(":")
+        # If the host starts with a bracket, do not match a : inside the
+        # brackets.
+        if len(text) and text[0] == "[":
+            right = text.find("]")
+            if right != -1:
+                pos = text.rfind(":", right + 1)
+        if pos != -1:
+            host = text[:pos]
+            port = int(text[pos + 1 :])
+        else:
+            host = text
+        # Strip the []
+        if len(host) and host[0] == "[" and host[-1] == "]":
+            # Validate the IPv6 address
+            host = host[1:-1]
+            try:
+                socket.inet_pton(socket.AF_INET6, host)
+            except OSError as e:
+                raise ValueError(str(e))
+        return Endpoint(host, port)
+
+    return parser
+
+
+def endpoint_list_parser(default_port: Any, single_port: bool = False) -> Callable[[str], List[Endpoint]]:
+    """Return a factory function that parses a string.
+
+    The string comprises a comma-separated list, each element of which is of
+    the form taken by :func:`endpoint_parser`. Optionally, the hostname may be
+    followed by `+count`, where `count` is an integer specifying a number of
+    sequential IP addresses (in addition to the explicitly named one). This
+    variation is only valid with IPv4 addresses.
+
+    If `single_port` is true, then it will reject any list that contains
+    more than one distinct port number, as well as an empty list. This allows
+    the user to determine a unique port for the list.
+    """
+
+    def parser(text: str) -> List[Endpoint]:
+        sub_parser = endpoint_parser(default_port)
+        parts = text.split(",")
+        endpoints = []
+        for part in parts:
+            endpoint = sub_parser(part.strip())
+            pos = endpoint.host.rfind("+")
+            if pos != -1:
+                start = endpoint.host[:pos]
+                count = int(endpoint.host[pos + 1 :])
+                if count < 0:
+                    raise ValueError("bad count {}".format(count))
+                try:
+                    start_raw = struct.unpack(">I", socket.inet_aton(start))[0]
+                    for i in range(start_raw, start_raw + count + 1):
+                        host = socket.inet_ntoa(struct.pack(">I", i))
+                        endpoints.append(Endpoint(host, endpoint.port))
+                except OSError:
+                    raise ValueError("invalid IPv4 address in {}".format(start))
+            else:
+                endpoints.append(endpoint)
+        if single_port:
+            if not endpoints:
+                raise ValueError("empty list")
+            else:
+                for endpoint in endpoints:
+                    if endpoint.port != endpoints[0].port:
+                        raise ValueError("all endpoints must use the same port")
+        return endpoints
+
+    return parser

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -31,7 +31,6 @@ import numpy as np
 import spead2.recv
 from katsdpsigproc.abc import AbstractCommandQueue, AbstractContext, AbstractEvent
 from katsdpsigproc.resource import async_wait_for_events
-from katsdptelstate.endpoint import Endpoint
 
 from .. import (
     BYTE_BITS,
@@ -46,6 +45,7 @@ from .. import (
     __version__,
 )
 from .. import recv as base_recv
+from ..endpoint import Endpoint
 from ..monitor import Monitor
 from ..queue_item import QueueItem
 from ..ringbuffer import ChunkRingbuffer

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -33,9 +33,9 @@ import prometheus_async
 from katsdpservices import get_interface_address
 from katsdpservices.aiomonitor import add_aiomonitor_arguments, start_aiomonitor
 from katsdpsigproc.abc import AbstractContext
-from katsdptelstate.endpoint import endpoint_list_parser
 
 from .. import DEFAULT_KATCP_HOST, DEFAULT_KATCP_PORT, DEFAULT_PACKET_PAYLOAD_BYTES, DEFAULT_TTL, N_POLS, __version__
+from ..endpoint import endpoint_list_parser
 from ..monitor import FileMonitor, Monitor, NullMonitor
 from ..utils import add_signal_handlers, parse_source
 from .engine import Engine

--- a/src/katgpucbf/fgpu/send.py
+++ b/src/katgpucbf/fgpu/send.py
@@ -24,10 +24,10 @@ import numpy as np
 import spead2.send
 import spead2.send.asyncio
 from aiokatcp import SensorSet
-from katsdptelstate.endpoint import Endpoint
 from prometheus_client import Counter
 
 from .. import COMPLEX, N_POLS
+from ..endpoint import Endpoint
 from ..spead import FENG_ID_ID, FENG_RAW_ID, FLAVOUR, FREQUENCY_ID, IMMEDIATE_FORMAT, TIMESTAMP_ID, make_immediate
 from ..utils import TimeConverter
 from . import METRIC_NAMESPACE

--- a/src/katgpucbf/utils.py
+++ b/src/katgpucbf/utils.py
@@ -26,9 +26,9 @@ from enum import Enum
 from typing import TypeVar
 
 import aiokatcp
-from katsdptelstate.endpoint import endpoint_list_parser
 
 from . import TIME_SYNC_TASK_NAME
+from .endpoint import endpoint_list_parser
 
 _T = TypeVar("_T")
 

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -42,7 +42,6 @@ import numpy as np
 import spead2.recv
 from aiokatcp import DeviceServer
 from katsdpsigproc import accel
-from katsdptelstate.endpoint import Endpoint
 
 from .. import (
     DESCRIPTOR_TASK_NAME,
@@ -53,6 +52,7 @@ from .. import (
     __version__,
 )
 from .. import recv as base_recv
+from ..endpoint import Endpoint
 from ..monitor import Monitor
 from ..queue_item import QueueItem
 from ..ringbuffer import ChunkRingbuffer

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -39,11 +39,11 @@ import prometheus_async
 from katsdpservices import get_interface_address, setup_logging
 from katsdpservices.aiomonitor import add_aiomonitor_arguments, start_aiomonitor
 from katsdpsigproc.abc import AbstractContext
-from katsdptelstate.endpoint import endpoint_parser
 
 from katgpucbf.xbgpu.engine import XBEngine
 
 from .. import DEFAULT_KATCP_HOST, DEFAULT_KATCP_PORT, DEFAULT_PACKET_PAYLOAD_BYTES, DEFAULT_TTL, __version__
+from ..endpoint import endpoint_parser
 from ..monitor import FileMonitor, Monitor, NullMonitor
 from ..utils import add_signal_handlers, parse_source
 from .correlation import device_filter

--- a/test/test_endpoint.py
+++ b/test/test_endpoint.py
@@ -1,0 +1,102 @@
+################################################################################
+# Copyright (c) 2015-2019, 2022 National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+"""Tests for the Endpoint class."""
+
+import pytest
+
+from katgpucbf.endpoint import Endpoint, endpoint_list_parser, endpoint_parser
+
+
+class TestEndpoint:  # noqa: D101
+    def test_str(self) -> None:  # noqa: D102
+        assert "test.me:80" == str(Endpoint("test.me", 80))
+        assert "[1080::8:800:200C:417A]:12345" == str(Endpoint("1080::8:800:200C:417A", 12345))
+
+    def test_repr(self) -> None:  # noqa: D102
+        assert "Endpoint('test.me', 80)" == repr(Endpoint("test.me", 80))
+
+    def test_parser_default_port(self) -> None:  # noqa: D102
+        parser = endpoint_parser(1234)
+        assert Endpoint("hello", 1234) == parser("hello")
+        assert Endpoint("192.168.0.1", 1234) == parser("192.168.0.1")
+        assert Endpoint("1080::8:800:200C:417A", 1234) == parser("[1080::8:800:200C:417A]")
+
+    def test_parser_port(self) -> None:  # noqa: D102
+        parser = endpoint_parser(1234)
+        assert Endpoint("hello", 80) == parser("hello:80")
+        assert Endpoint("1080::8:800:200C:417A", 80) == parser("[1080::8:800:200C:417A]:80")
+
+    def test_bad_ipv6(self) -> None:  # noqa: D102
+        parser = endpoint_parser(1234)
+        with pytest.raises(ValueError):
+            parser("[notipv6]:1234")
+
+    def test_iter(self) -> None:  # noqa: D102
+        endpoint = Endpoint("hello", 80)
+        assert ("hello", 80) == tuple(endpoint)
+
+    def test_eq(self) -> None:  # noqa: D102
+        assert Endpoint("hello", 80) == Endpoint("hello", 80)
+        assert Endpoint("hello", 80) != Endpoint("hello", 90)
+        assert Endpoint("hello", 80) != Endpoint("world", 80)
+        assert Endpoint("hello", 80) != "not_an_endpoint"
+
+    def test_hash(self) -> None:  # noqa: D102
+        assert hash(Endpoint("hello", 80)) == hash(Endpoint("hello", 80))
+        assert hash(Endpoint("hello", 80)) != hash(Endpoint("hello", 90))
+
+
+class TestEndpointList:  # noqa: D101
+    def test_parser(self) -> None:  # noqa: D102
+        parser = endpoint_list_parser(1234)
+        endpoints = parser("hello:80,world,[1080::8:800:200C:417A],192.168.0.255+4,10.0.255.255+3:60")
+        expected = [
+            Endpoint("hello", 80),
+            Endpoint("world", 1234),
+            Endpoint("1080::8:800:200C:417A", 1234),
+            Endpoint("192.168.0.255", 1234),
+            Endpoint("192.168.1.0", 1234),
+            Endpoint("192.168.1.1", 1234),
+            Endpoint("192.168.1.2", 1234),
+            Endpoint("192.168.1.3", 1234),
+            Endpoint("10.0.255.255", 60),
+            Endpoint("10.1.0.0", 60),
+            Endpoint("10.1.0.1", 60),
+            Endpoint("10.1.0.2", 60),
+        ]
+        assert expected == endpoints
+
+    def test_parser_bad_count(self) -> None:  # noqa: D102
+        with pytest.raises(ValueError):
+            endpoint_list_parser(1234)("192.168.0.1+-4")
+
+    def test_parser_non_integer_count(self) -> None:  # noqa: D102
+        with pytest.raises(ValueError):
+            endpoint_list_parser(1234)("192.168.0.1+hello")
+
+    def test_parser_count_without_ipv4(self) -> None:  # noqa: D102
+        with pytest.raises(ValueError):
+            endpoint_list_parser(1234)("hello.world+4")
+
+    def test_parser_single_port(self) -> None:  # noqa: D102
+        parser = endpoint_list_parser(1234, single_port=True)
+        endpoints = parser("hello:1234,world")
+        expected = [Endpoint("hello", 1234), Endpoint("world", 1234)]
+        assert expected == endpoints
+
+    def test_parser_single_port_bad(self) -> None:  # noqa: D102
+        with pytest.raises(ValueError):
+            endpoint_list_parser(1234, single_port=True)("x:123,y:456")


### PR DESCRIPTION
This I accomplish by plagiarising the `endpoint.py` file (and its associated tests). I do remove a bunch of functionality that we don't use though.

This removes quite a lot from the requirements.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update ``setup.cfg`` and appropriate requirements files
- [x] If modules are added/removed: use sphinx-apidoc to update files in ``doc/``
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-862
