### PR TITLE
Rename Engine sensors hierarchically

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020-2021, National Research Foundation (SARAO)
+Copyright (c) 2020-2023, National Research Foundation (SARAO)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/qualification/__init__.py
+++ b/qualification/__init__.py
@@ -198,20 +198,20 @@ class BaselineCorrelationProductsReceiver:
 
         # But some we don't. Note: these could be properties. But copying them up
         # front ensures we get an exception early if the sensor is missing.
-        self.n_bls = correlator.sensors[f"{stream_name}-n-bls"].value
-        self.n_chans_per_substream = correlator.sensors[f"{stream_name}-n-chans-per-substream"].value
-        self.n_bits_per_sample = correlator.sensors[f"{stream_name}-xeng-out-bits-per-sample"].value
-        self.n_spectra_per_acc = correlator.sensors[f"{stream_name}-n-accs"].value
-        self.int_time = correlator.sensors[f"{stream_name}-int-time"].value
-        self.spectra_per_heap = correlator.sensors[f"{acv_name}-spectra-per-heap"].value
-        self.n_samples_between_spectra = correlator.sensors[f"{acv_name}-n-samples-between-spectra"].value
-        self.bls_ordering = ast.literal_eval(correlator.sensors[f"{stream_name}-bls-ordering"].value.decode())
-        self.sync_time = correlator.sensors[f"{acv_name}-sync-time"].value
-        self.scale_factor_timestamp = correlator.sensors[f"{acv_name}-scale-factor-timestamp"].value
-        self.bandwidth = correlator.sensors[f"{acv_name}-bandwidth"].value
+        self.n_bls = correlator.sensors[f"{stream_name}.n-bls"].value
+        self.n_chans_per_substream = correlator.sensors[f"{stream_name}.n-chans-per-substream"].value
+        self.n_bits_per_sample = correlator.sensors[f"{stream_name}.xeng-out-bits-per-sample"].value
+        self.n_spectra_per_acc = correlator.sensors[f"{stream_name}.n-accs"].value
+        self.int_time = correlator.sensors[f"{stream_name}.int-time"].value
+        self.spectra_per_heap = correlator.sensors[f"{acv_name}.spectra-per-heap"].value
+        self.n_samples_between_spectra = correlator.sensors[f"{acv_name}.n-samples-between-spectra"].value
+        self.bls_ordering = ast.literal_eval(correlator.sensors[f"{stream_name}.bls-ordering"].value.decode())
+        self.sync_time = correlator.sensors[f"{acv_name}.sync-time"].value
+        self.scale_factor_timestamp = correlator.sensors[f"{acv_name}.scale-factor-timestamp"].value
+        self.bandwidth = correlator.sensors[f"{acv_name}.bandwidth"].value
         self.multicast_endpoints = [
             (endpoint.host, endpoint.port)
-            for endpoint in endpoint_list_parser(7148)(correlator.sensors[f"{stream_name}-destination"].value.decode())
+            for endpoint in endpoint_list_parser(7148)(correlator.sensors[f"{stream_name}.destination"].value.decode())
         ]
         self.timestamp_step = self.n_samples_between_spectra * self.n_spectra_per_acc
         self.time_converter = TimeConverter(self.sync_time, self.scale_factor_timestamp)

--- a/qualification/__init__.py
+++ b/qualification/__init__.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2022, National Research Foundation (SARAO)
+# Copyright (c) 2022-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -234,7 +234,7 @@ async def test_delay_sensors(
         delay_tuples.append((load_ts, delay, delay_rate, phase, phase_rate))
 
     def delay_sensor_value(label: str) -> tuple:
-        return literal_eval(correlator.sensors[f"antenna_channelised_voltage.{label}-delay"].value.decode())
+        return literal_eval(correlator.sensors[f"antenna_channelised_voltage.{label}.delay"].value.decode())
 
     pdf_report.step("Load delays.")
     pdf_report.detail(f"Set delays to load at {load_time} (timestamp {load_ts}).")

--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2022, National Research Foundation (SARAO)
+# Copyright (c) 2022-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -198,8 +198,8 @@ async def test_delay_application_rate(correlator: CorrelatorRemoteControl, pdf_r
     enough.
     """
     pdf_report.step("Query rate of spectra.")
-    n_samples_between_spectra = correlator.sensors["antenna_channelised_voltage-n-samples-between-spectra"].value
-    scale_factor_timestamp = correlator.sensors["antenna_channelised_voltage-scale-factor-timestamp"].value
+    n_samples_between_spectra = correlator.sensors["antenna_channelised_voltage.n-samples-between-spectra"].value
+    scale_factor_timestamp = correlator.sensors["antenna_channelised_voltage.scale-factor-timestamp"].value
     rate = scale_factor_timestamp / n_samples_between_spectra
     pdf_report.detail(f"There are {rate:.3f} spectra per second.")
     assert rate >= 2500.0
@@ -234,7 +234,7 @@ async def test_delay_sensors(
         delay_tuples.append((load_ts, delay, delay_rate, phase, phase_rate))
 
     def delay_sensor_value(label: str) -> tuple:
-        return literal_eval(correlator.sensors[f"antenna_channelised_voltage-{label}-delay"].value.decode())
+        return literal_eval(correlator.sensors[f"antenna_channelised_voltage.{label}-delay"].value.decode())
 
     pdf_report.step("Load delays.")
     pdf_report.detail(f"Set delays to load at {load_time} (timestamp {load_ts}).")

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2022, National Research Foundation (SARAO)
+# Copyright (c) 2022-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -456,7 +456,7 @@ async def correlator(
     for name, conf in session_correlator.config["outputs"].items():
         if conf["type"] == "gpucbf.antenna_channelised_voltage":
             n_inputs = len(conf["src_streams"])
-            sync_time = session_correlator.sensors[f"{name}-sync-time"].value
+            sync_time = session_correlator.sensors[f"{name}.sync-time"].value
             await pcc.request("gain-all", name, "default")
             await pcc.request("delays", name, sync_time, *(["0,0:0,0"] * n_inputs))
         elif conf["type"] == "gpucbf.baseline_correlation_products":

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2022, National Research Foundation (SARAO)
+# Copyright (c) 2020-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -677,7 +677,7 @@ class Engine(aiokatcp.DeviceServer):
         """Initialise the delays and gains."""
         for pol in range(N_POLS):
             delay_model = MultiDelayModel(
-                callback_func=partial(self.update_delay_sensor, delay_sensor=self.sensors[f"input{pol}-delay"])
+                callback_func=partial(self.update_delay_sensor, delay_sensor=self.sensors[f"input{pol}.delay"])
             )
             self.delay_models.append(delay_model)
 
@@ -1118,7 +1118,7 @@ class Engine(aiokatcp.DeviceServer):
                 # Update the digitiser saturation count (the "extra" fields holds
                 # per-heap values).
                 assert chunk.extra is not None
-                sensor = self.sensors[f"input{pol}-dig-clip-cnt"]
+                sensor = self.sensors[f"input{pol}.dig-clip-cnt"]
                 sensor.set_value(
                     sensor.value + int(np.sum(chunk.extra, dtype=np.uint64)),
                     timestamp=self.time_converter.adc_to_unix(chunk.timestamp + layout.chunk_samples),
@@ -1233,7 +1233,7 @@ class Engine(aiokatcp.DeviceServer):
                 # want 1.0 to correspond to a sine wave rather than a square wave.
                 avg_power /= ((1 << (DIG_SAMPLE_BITS - 1)) - 1) ** 2 / 2
                 avg_power_db = 10 * math.log10(avg_power) if avg_power else -math.inf
-                self.sensors[f"input{pol}-dig-pwr-dbfs"].set_value(
+                self.sensors[f"input{pol}.dig-pwr-dbfs"].set_value(
                     avg_power_db, timestamp=self.time_converter.adc_to_unix(out_item.end_timestamp)
                 )
 

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1314,7 +1314,7 @@ class Engine(aiokatcp.DeviceServer):
         if np.all(gains == gains[0]):
             # All the values are the same, so it can be reported as a single value
             gains = gains[:1]
-        self.sensors[f"input{input}-eq"].value = "[" + ", ".join(format_complex(gain) for gain in gains) + "]"
+        self.sensors[f"input{input}.eq"].value = "[" + ", ".join(format_complex(gain) for gain in gains) + "]"
 
     def _parse_gains(self, *values: str, allow_default: bool) -> np.ndarray:
         """Parse the gains passed to :meth:`request-gain` or :meth:`request-gain-all`.

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -724,7 +724,7 @@ class Engine(aiokatcp.DeviceServer):
             sensors.add(
                 aiokatcp.Sensor(
                     str,
-                    f"input{pol}-eq",
+                    f"input{pol}.eq",
                     "For this input, the complex, unitless, per-channel digital scaling factors "
                     "implemented prior to requantisation",
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,
@@ -733,7 +733,7 @@ class Engine(aiokatcp.DeviceServer):
             sensors.add(
                 aiokatcp.Sensor(
                     str,
-                    f"input{pol}-delay",
+                    f"input{pol}.delay",
                     "The delay settings for this input: (loadmcnt <ADC sample "
                     "count when model was loaded>, delay <in seconds>, "
                     "delay-rate <unit-less or, seconds-per-second>, "
@@ -743,7 +743,7 @@ class Engine(aiokatcp.DeviceServer):
             sensors.add(
                 aiokatcp.Sensor(
                     int,
-                    f"input{pol}-dig-clip-cnt",
+                    f"input{pol}.dig-clip-cnt",
                     "Number of digitiser samples that are saturated",
                     default=0,
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,
@@ -754,7 +754,7 @@ class Engine(aiokatcp.DeviceServer):
             sensors.add(
                 aiokatcp.Sensor(
                     float,
-                    f"input{pol}-dig-pwr-dbfs",
+                    f"input{pol}.dig-pwr-dbfs",
                     "Digitiser ADC average power",
                     units="dBFS",
                     status_func=dig_pwr_dbfs_status,
@@ -765,7 +765,7 @@ class Engine(aiokatcp.DeviceServer):
             sensors.add(
                 aiokatcp.Sensor(
                     int,
-                    f"input{pol}-feng-clip-cnt",
+                    f"input{pol}.feng-clip-cnt",
                     "Number of output samples that are saturated",
                     default=0,
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,

--- a/src/katgpucbf/fgpu/recv.py
+++ b/src/katgpucbf/fgpu/recv.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2022, National Research Foundation (SARAO)
+# Copyright (c) 2020-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katgpucbf/fgpu/recv.py
+++ b/src/katgpucbf/fgpu/recv.py
@@ -335,8 +335,8 @@ async def chunk_sets(
                 lost,
             )
             unix_time = time_converter.adc_to_unix(chunk.timestamp)
-            sensors[f"input{pol}-rx-timestamp"].set_value(chunk.timestamp, timestamp=unix_time)
-            sensors[f"input{pol}-rx-unixtime"].set_value(aiokatcp.core.Timestamp(unix_time), timestamp=unix_time)
+            sensors[f"input{pol}.rx-timestamp"].set_value(chunk.timestamp, timestamp=unix_time)
+            sensors[f"input{pol}.rx-unixtime"].set_value(aiokatcp.core.Timestamp(unix_time), timestamp=unix_time)
 
             buf[pol].append(chunk)
 
@@ -377,7 +377,7 @@ async def chunk_sets(
                     if new_missing > n_missing_heaps[pol]:
                         missing_heaps_counter.labels(pol).inc(new_missing - n_missing_heaps[pol])
                         n_missing_heaps[pol] = new_missing
-                        sensors[f"input{pol}-rx-missing-unixtime"].set_value(
+                        sensors[f"input{pol}.rx-missing-unixtime"].set_value(
                             aiokatcp.core.Timestamp(unix_time), timestamp=unix_time, status=aiokatcp.Sensor.Status.ERROR
                         )
 

--- a/src/katgpucbf/fgpu/recv.py
+++ b/src/katgpucbf/fgpu/recv.py
@@ -227,7 +227,7 @@ def make_sensors(sensor_timeout: float) -> aiokatcp.SensorSet:
         timestamp_sensors: list[aiokatcp.Sensor] = [
             aiokatcp.Sensor(
                 int,
-                f"input{pol}-rx-timestamp",
+                f"input{pol}.rx-timestamp",
                 "The timestamp (in samples) of the last chunk of data received from the digitiser",
                 default=-1,
                 initial_status=aiokatcp.Sensor.Status.ERROR,
@@ -236,7 +236,7 @@ def make_sensors(sensor_timeout: float) -> aiokatcp.SensorSet:
             ),
             aiokatcp.Sensor(
                 aiokatcp.core.Timestamp,
-                f"input{pol}-rx-unixtime",
+                f"input{pol}.rx-unixtime",
                 "The timestamp (in UNIX time) of the last chunk of data received from the digitiser",
                 default=aiokatcp.core.Timestamp(-1.0),
                 initial_status=aiokatcp.Sensor.Status.ERROR,
@@ -251,7 +251,7 @@ def make_sensors(sensor_timeout: float) -> aiokatcp.SensorSet:
         missing_sensors: list[aiokatcp.Sensor] = [
             aiokatcp.Sensor(
                 aiokatcp.core.Timestamp,
-                f"input{pol}-rx-missing-unixtime",
+                f"input{pol}.rx-missing-unixtime",
                 "The timestamp (in UNIX time) when missing data was last detected",
                 default=aiokatcp.core.Timestamp(-1.0),
                 initial_status=aiokatcp.Sensor.Status.NOMINAL,

--- a/src/katgpucbf/fgpu/recv.py
+++ b/src/katgpucbf/fgpu/recv.py
@@ -227,7 +227,7 @@ def make_sensors(sensor_timeout: float) -> aiokatcp.SensorSet:
         timestamp_sensors: list[aiokatcp.Sensor] = [
             aiokatcp.Sensor(
                 int,
-                f"input{pol}.rx-timestamp",
+                f"input{pol}.rx.timestamp",
                 "The timestamp (in samples) of the last chunk of data received from the digitiser",
                 default=-1,
                 initial_status=aiokatcp.Sensor.Status.ERROR,
@@ -236,7 +236,7 @@ def make_sensors(sensor_timeout: float) -> aiokatcp.SensorSet:
             ),
             aiokatcp.Sensor(
                 aiokatcp.core.Timestamp,
-                f"input{pol}.rx-unixtime",
+                f"input{pol}.rx.unixtime",
                 "The timestamp (in UNIX time) of the last chunk of data received from the digitiser",
                 default=aiokatcp.core.Timestamp(-1.0),
                 initial_status=aiokatcp.Sensor.Status.ERROR,
@@ -251,7 +251,7 @@ def make_sensors(sensor_timeout: float) -> aiokatcp.SensorSet:
         missing_sensors: list[aiokatcp.Sensor] = [
             aiokatcp.Sensor(
                 aiokatcp.core.Timestamp,
-                f"input{pol}.rx-missing-unixtime",
+                f"input{pol}.rx.missing-unixtime",
                 "The timestamp (in UNIX time) when missing data was last detected",
                 default=aiokatcp.core.Timestamp(-1.0),
                 initial_status=aiokatcp.Sensor.Status.NOMINAL,
@@ -335,8 +335,8 @@ async def chunk_sets(
                 lost,
             )
             unix_time = time_converter.adc_to_unix(chunk.timestamp)
-            sensors[f"input{pol}.rx-timestamp"].set_value(chunk.timestamp, timestamp=unix_time)
-            sensors[f"input{pol}.rx-unixtime"].set_value(aiokatcp.core.Timestamp(unix_time), timestamp=unix_time)
+            sensors[f"input{pol}.rx.timestamp"].set_value(chunk.timestamp, timestamp=unix_time)
+            sensors[f"input{pol}.rx.unixtime"].set_value(aiokatcp.core.Timestamp(unix_time), timestamp=unix_time)
 
             buf[pol].append(chunk)
 
@@ -377,7 +377,7 @@ async def chunk_sets(
                     if new_missing > n_missing_heaps[pol]:
                         missing_heaps_counter.labels(pol).inc(new_missing - n_missing_heaps[pol])
                         n_missing_heaps[pol] = new_missing
-                        sensors[f"input{pol}.rx-missing-unixtime"].set_value(
+                        sensors[f"input{pol}.rx.missing-unixtime"].set_value(
                             aiokatcp.core.Timestamp(unix_time), timestamp=unix_time, status=aiokatcp.Sensor.Status.ERROR
                         )
 

--- a/src/katgpucbf/fgpu/send.py
+++ b/src/katgpucbf/fgpu/send.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2022, National Research Foundation (SARAO)
+# Copyright (c) 2020-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katgpucbf/fgpu/send.py
+++ b/src/katgpucbf/fgpu/send.py
@@ -171,7 +171,7 @@ class Chunk:
         end_timestamp = self._timestamp + self._timestamp_step * len(self._frames)
         end_time = time_converter.adc_to_unix(end_timestamp)
         for pol in range(N_POLS):
-            sensor = sensors[f"input{pol}-feng-clip-cnt"]
+            sensor = sensors[f"input{pol}.feng-clip-cnt"]
             sensor.set_value(sensor.value + saturated[pol], timestamp=end_time)
 
 

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2022, National Research Foundation (SARAO)
+# Copyright (c) 2020-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -471,7 +471,7 @@ class XBEngine(DeviceServer):
         sensors.add(
             aiokatcp.Sensor(
                 bool,
-                "synchronised",
+                "rx.synchronised",
                 "For the latest accumulation, was data present from all F-Engines.",
                 default=False,
                 initial_status=aiokatcp.Sensor.Status.ERROR,
@@ -552,7 +552,7 @@ class XBEngine(DeviceServer):
             tx_item.present_ants.fill(False)
 
         # Update the sync sensor (converting np.bool_ to Python bool)
-        self.sensors["synchronised"].value = bool(tx_item.present_ants.all())
+        self.sensors["rx.synchronised"].value = bool(tx_item.present_ants.all())
 
         self.correlation.reduce()
         tx_item.add_marker(self._proc_command_queue)

--- a/src/katgpucbf/xbgpu/recv.py
+++ b/src/katgpucbf/xbgpu/recv.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2022, National Research Foundation (SARAO)
+# Copyright (c) 2020-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katgpucbf/xbgpu/recv.py
+++ b/src/katgpucbf/xbgpu/recv.py
@@ -218,7 +218,7 @@ def make_sensors(sensor_timeout: float) -> SensorSet:
     timestamp_sensors: list[Sensor] = [
         Sensor(
             int,
-            "input-rx-timestamp",
+            "input.rx-timestamp",
             "The timestamp (in samples) of the last chunk of data received from an F-engine",
             default=-1,
             initial_status=Sensor.Status.ERROR,
@@ -227,7 +227,7 @@ def make_sensors(sensor_timeout: float) -> SensorSet:
         ),
         Sensor(
             Timestamp,
-            "input-rx-unixtime",
+            "input.rx-unixtime",
             "The timestamp (in UNIX time) of the last chunk of data received from an F-engine",
             default=Timestamp(-1.0),
             initial_status=Sensor.Status.ERROR,
@@ -242,7 +242,7 @@ def make_sensors(sensor_timeout: float) -> SensorSet:
     missing_sensors: list[Sensor] = [
         Sensor(
             Timestamp,
-            "input-rx-missing-unixtime",
+            "input.rx-missing-unixtime",
             "The timestamp (in UNIX time) when missing data was last detected",
             default=Timestamp(-1.0),
             initial_status=Sensor.Status.NOMINAL,
@@ -306,8 +306,8 @@ async def recv_chunks(
         # TODO: Perhaps make this 'chunk timestamp step' a property of the Layout?
         chunk.timestamp = chunk.chunk_id * layout.timestamp_step * layout.heaps_per_fengine_per_chunk
         unix_time = time_converter.adc_to_unix(chunk.timestamp)
-        sensors["input-rx-timestamp"].set_value(chunk.timestamp, timestamp=unix_time)
-        sensors["input-rx-unixtime"].set_value(Timestamp(unix_time), timestamp=unix_time)
+        sensors["input.rx-timestamp"].set_value(chunk.timestamp, timestamp=unix_time)
+        sensors["input.rx-unixtime"].set_value(Timestamp(unix_time), timestamp=unix_time)
 
         # Check if we've missed any chunks
         expected_chunk_id = prev_chunk_id + 1
@@ -322,7 +322,7 @@ async def recv_chunks(
             dropped_heaps += missed_chunks * expected_heaps
 
         if dropped_heaps > 0:
-            sensors["input-rx-missing-unixtime"].set_value(
+            sensors["input.rx-missing-unixtime"].set_value(
                 Timestamp(unix_time), Sensor.Status.ERROR, timestamp=unix_time
             )
 

--- a/src/katgpucbf/xbgpu/recv.py
+++ b/src/katgpucbf/xbgpu/recv.py
@@ -218,7 +218,7 @@ def make_sensors(sensor_timeout: float) -> SensorSet:
     timestamp_sensors: list[Sensor] = [
         Sensor(
             int,
-            "input.rx-timestamp",
+            "rx.timestamp",
             "The timestamp (in samples) of the last chunk of data received from an F-engine",
             default=-1,
             initial_status=Sensor.Status.ERROR,
@@ -227,7 +227,7 @@ def make_sensors(sensor_timeout: float) -> SensorSet:
         ),
         Sensor(
             Timestamp,
-            "input.rx-unixtime",
+            "rx.unixtime",
             "The timestamp (in UNIX time) of the last chunk of data received from an F-engine",
             default=Timestamp(-1.0),
             initial_status=Sensor.Status.ERROR,
@@ -242,7 +242,7 @@ def make_sensors(sensor_timeout: float) -> SensorSet:
     missing_sensors: list[Sensor] = [
         Sensor(
             Timestamp,
-            "input.rx-missing-unixtime",
+            "rx.missing-unixtime",
             "The timestamp (in UNIX time) when missing data was last detected",
             default=Timestamp(-1.0),
             initial_status=Sensor.Status.NOMINAL,
@@ -306,8 +306,8 @@ async def recv_chunks(
         # TODO: Perhaps make this 'chunk timestamp step' a property of the Layout?
         chunk.timestamp = chunk.chunk_id * layout.timestamp_step * layout.heaps_per_fengine_per_chunk
         unix_time = time_converter.adc_to_unix(chunk.timestamp)
-        sensors["input.rx-timestamp"].set_value(chunk.timestamp, timestamp=unix_time)
-        sensors["input.rx-unixtime"].set_value(Timestamp(unix_time), timestamp=unix_time)
+        sensors["rx.timestamp"].set_value(chunk.timestamp, timestamp=unix_time)
+        sensors["rx.unixtime"].set_value(Timestamp(unix_time), timestamp=unix_time)
 
         # Check if we've missed any chunks
         expected_chunk_id = prev_chunk_id + 1
@@ -322,9 +322,7 @@ async def recv_chunks(
             dropped_heaps += missed_chunks * expected_heaps
 
         if dropped_heaps > 0:
-            sensors["input.rx-missing-unixtime"].set_value(
-                Timestamp(unix_time), Sensor.Status.ERROR, timestamp=unix_time
-            )
+            sensors["rx.missing-unixtime"].set_value(Timestamp(unix_time), Sensor.Status.ERROR, timestamp=unix_time)
 
         # Increment Prometheus counters
         missing_heaps_counter.inc(dropped_heaps)

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2022, National Research Foundation (SARAO)
+# Copyright (c) 2020-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -775,7 +775,7 @@ class TestEngine:
         sensor = engine_server.sensors[f"input{tone_pol}.feng-clip-cnt"]
         assert sensor.value == len(timestamps)
         assert sensor.timestamp == SYNC_EPOCH + n_samples / ADC_SAMPLE_RATE
-        sensor = engine_server.sensors[f"input{1 - tone_pol}-feng-clip-cnt"]
+        sensor = engine_server.sensors[f"input{1 - tone_pol}.feng-clip-cnt"]
         assert sensor.value == 0
         assert sensor.timestamp == SYNC_EPOCH + n_samples / ADC_SAMPLE_RATE
 

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -772,7 +772,7 @@ class TestEngine:
 
         assert prom_diff.get_sample_diff("output_clipped_samples_total", {"pol": f"{tone_pol}"}) == len(timestamps)
         assert prom_diff.get_sample_diff("output_clipped_samples_total", {"pol": f"{1 - tone_pol}"}) == 0
-        sensor = engine_server.sensors[f"input{tone_pol}-feng-clip-cnt"]
+        sensor = engine_server.sensors[f"input{tone_pol}.feng-clip-cnt"]
         assert sensor.value == len(timestamps)
         assert sensor.timestamp == SYNC_EPOCH + n_samples / ADC_SAMPLE_RATE
         sensor = engine_server.sensors[f"input{1 - tone_pol}-feng-clip-cnt"]

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -578,7 +578,7 @@ class TestEngine:
     ) -> None:
         """Test loading several future delay models."""
         # Set up infrastructure for testing delay sensor updates
-        delay_sensors = [engine_server.sensors[f"input{pol}-delay"] for pol in range(N_POLS)]
+        delay_sensors = [engine_server.sensors[f"input{pol}.delay"] for pol in range(N_POLS)]
         sensor_updates_dict = self._watch_sensors(delay_sensors)
 
         # To keep things simple, we'll just use phase, not delay.
@@ -722,7 +722,7 @@ class TestEngine:
         engine_client: aiokatcp.Client,
     ) -> None:
         """Test that the ``dig-clip-cnt`` sensors are set correctly."""
-        sensors = [engine_server.sensors[f"input{pol}-dig-clip-cnt"] for pol in range(N_POLS)]
+        sensors = [engine_server.sensors[f"input{pol}.dig-clip-cnt"] for pol in range(N_POLS)]
         sensor_update_dict = self._watch_sensors(sensors)
         n_samples = 3 * CHUNK_SAMPLES
         dig_data = np.zeros((2, n_samples), np.int16)

--- a/test/fgpu/test_katcp_interface.py
+++ b/test/fgpu/test_katcp_interface.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2022, National Research Foundation (SARAO)
+# Copyright (c) 2020-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/fgpu/test_katcp_interface.py
+++ b/test/fgpu/test_katcp_interface.py
@@ -74,7 +74,7 @@ class TestKatcpRequests:
         """Test that the command-line gain is set correctly."""
         reply, _informs = await engine_client.request("gain", pol)
         assert reply == [b"0.125+0.0j"]
-        sensor_value = await get_sensor(engine_client, f"input{pol}-eq")
+        sensor_value = await get_sensor(engine_client, f"input{pol}.eq")
         assert sensor_value == "[0.125+0.0j]"
 
     @pytest.mark.parametrize("pol", range(N_POLS))
@@ -86,7 +86,7 @@ class TestKatcpRequests:
         assert_valid_complex(value)
         assert complex(value) == pytest.approx(0.2 - 3j)
 
-        sensor_value = await get_sensor(engine_client, f"input{pol}-eq")
+        sensor_value = await get_sensor(engine_client, f"input{pol}.eq")
         assert_valid_complex_list(sensor_value)
         assert safe_eval(sensor_value) == pytest.approx([0.2 - 3j])
         np.testing.assert_equal(engine_server.gains[:, pol], np.full(CHANNELS, 0.2 - 3j, np.complex64))
@@ -135,7 +135,7 @@ class TestKatcpRequests:
         reply, _informs = await engine_client.request("gain-all", "0.2-3j")
         assert reply == []
         for pol in range(N_POLS):
-            sensor_value = await get_sensor(engine_client, f"input{pol}-eq")
+            sensor_value = await get_sensor(engine_client, f"input{pol}.eq")
             assert_valid_complex_list(sensor_value)
             assert safe_eval(sensor_value) == pytest.approx([0.2 - 3j])
             np.testing.assert_equal(engine_server.gains[:, pol], np.full(CHANNELS, 0.2 - 3j, np.complex64))
@@ -147,7 +147,7 @@ class TestKatcpRequests:
         assert reply == []
         for pol in range(N_POLS):
             np.testing.assert_equal(engine_server.gains[:, pol], gains)
-            sensor_value = await get_sensor(engine_client, f"input{pol}-eq")
+            sensor_value = await get_sensor(engine_client, f"input{pol}.eq")
             assert_valid_complex_list(sensor_value)
             np.testing.assert_equal(np.array(safe_eval(sensor_value)), gains)
 
@@ -156,7 +156,7 @@ class TestKatcpRequests:
         await engine_client.request("gain-all", "2+3j")
         await engine_client.request("gain-all", "default")
         for pol in range(N_POLS):
-            sensor_value = await get_sensor(engine_client, f"input{pol}-eq")
+            sensor_value = await get_sensor(engine_client, f"input{pol}.eq")
             assert sensor_value == "[0.125+0.0j]"
 
     async def test_gain_all_empty(self, engine_client: aiokatcp.Client) -> None:
@@ -186,7 +186,7 @@ class TestKatcpRequests:
             model(1)
 
         for pol in range(N_POLS):
-            sensor_reading = await get_sensor(engine_client, f"input{pol}-delay")
+            sensor_reading = await get_sensor(engine_client, f"input{pol}.delay")
             sensor_values = sensor_reading[1:-1].split(",")[1:]  # Drop the timestamp
             sensor_values = (float(field.strip()) for field in sensor_values)
 

--- a/test/fgpu/test_katcp_interface.py
+++ b/test/fgpu/test_katcp_interface.py
@@ -107,7 +107,7 @@ class TestKatcpRequests:
         reply_array = np.array([complex(aiokatcp.decode(str, value)) for value in reply])
         np.testing.assert_equal(reply_array, gains)
 
-        sensor_value = await get_sensor(engine_client, "input0-eq")
+        sensor_value = await get_sensor(engine_client, "input0.eq")
         assert_valid_complex_list(sensor_value)
         np.testing.assert_equal(np.array(safe_eval(sensor_value)), gains)
 

--- a/test/fgpu/test_recv.py
+++ b/test/fgpu/test_recv.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2022, National Research Foundation (SARAO)
+# Copyright (c) 2020-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/fgpu/test_recv.py
+++ b/test/fgpu/test_recv.py
@@ -397,24 +397,24 @@ class TestChunkSets:
         assert get_sample_diffs("input_clipped_samples_total") == expected_clip_total
 
         # Check sensors
-        sensor = sensors["input0-rx-timestamp"]
+        sensor = sensors["input0.rx-timestamp"]
         assert sensor.value == 21 * layout.chunk_samples
         assert sensor.status == aiokatcp.Sensor.Status.NOMINAL
         assert sensor.timestamp == time_converter.adc_to_unix(sensor.value)
-        sensor = sensors["input1-rx-timestamp"]
+        sensor = sensors["input1.rx-timestamp"]
         assert sensor.value == 20 * layout.chunk_samples
         assert sensor.status == aiokatcp.Sensor.Status.NOMINAL
         assert sensor.timestamp == time_converter.adc_to_unix(sensor.value)
-        sensor = sensors["input0-rx-unixtime"]
+        sensor = sensors["input0.rx-unixtime"]
         assert sensor.value == time_converter.adc_to_unix(21 * layout.chunk_samples)
         assert sensor.status == aiokatcp.Sensor.Status.NOMINAL
         assert sensor.timestamp == sensor.value
-        sensor = sensors["input1-rx-unixtime"]
+        sensor = sensors["input1.rx-unixtime"]
         assert sensor.value == time_converter.adc_to_unix(20 * layout.chunk_samples)
         assert sensor.status == aiokatcp.Sensor.Status.NOMINAL
         assert sensor.timestamp == sensor.value
         for pol in range(N_POLS):
-            sensor = sensors[f"input{pol}-rx-missing-unixtime"]
+            sensor = sensors[f"input{pol}.rx-missing-unixtime"]
             assert sensor.value == time_converter.adc_to_unix(20 * layout.chunk_samples)
             assert sensor.status == aiokatcp.Sensor.Status.ERROR
             assert sensor.timestamp == sensor.value

--- a/test/fgpu/test_recv.py
+++ b/test/fgpu/test_recv.py
@@ -397,24 +397,24 @@ class TestChunkSets:
         assert get_sample_diffs("input_clipped_samples_total") == expected_clip_total
 
         # Check sensors
-        sensor = sensors["input0.rx-timestamp"]
+        sensor = sensors["input0.rx.timestamp"]
         assert sensor.value == 21 * layout.chunk_samples
         assert sensor.status == aiokatcp.Sensor.Status.NOMINAL
         assert sensor.timestamp == time_converter.adc_to_unix(sensor.value)
-        sensor = sensors["input1.rx-timestamp"]
+        sensor = sensors["input1.rx.timestamp"]
         assert sensor.value == 20 * layout.chunk_samples
         assert sensor.status == aiokatcp.Sensor.Status.NOMINAL
         assert sensor.timestamp == time_converter.adc_to_unix(sensor.value)
-        sensor = sensors["input0.rx-unixtime"]
+        sensor = sensors["input0.rx.unixtime"]
         assert sensor.value == time_converter.adc_to_unix(21 * layout.chunk_samples)
         assert sensor.status == aiokatcp.Sensor.Status.NOMINAL
         assert sensor.timestamp == sensor.value
-        sensor = sensors["input1.rx-unixtime"]
+        sensor = sensors["input1.rx.unixtime"]
         assert sensor.value == time_converter.adc_to_unix(20 * layout.chunk_samples)
         assert sensor.status == aiokatcp.Sensor.Status.NOMINAL
         assert sensor.timestamp == sensor.value
         for pol in range(N_POLS):
-            sensor = sensors[f"input{pol}.rx-missing-unixtime"]
+            sensor = sensors[f"input{pol}.rx.missing-unixtime"]
             assert sensor.value == time_converter.adc_to_unix(20 * layout.chunk_samples)
             assert sensor.status == aiokatcp.Sensor.Status.ERROR
             assert sensor.timestamp == sensor.value

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -470,7 +470,7 @@ class TestEngine:
             """Record sensor updates in a list for later comparison."""
             actual_sensor_updates.append((sensor_reading.value, sensor_reading.status))
 
-        xbengine.sensors["synchronised"].attach(sensor_observer)
+        xbengine.sensors["rx.synchronised"].attach(sensor_observer)
 
         def heap_factory(batch_index: int) -> list[spead2.send.HeapReference]:
             timestamp = batch_index * timestamp_step

--- a/test/xbgpu/test_recv.py
+++ b/test/xbgpu/test_recv.py
@@ -345,18 +345,18 @@ class TestStream:
         )
 
         # Check sensors
-        sensor = sensors["input.rx-timestamp"]
+        sensor = sensors["rx.timestamp"]
         # sensor.value should be of the last chunk sent
         absolute_present_timestamp = expected_chunk_ids[-1] * layout.timestamp_step * layout.heaps_per_fengine_per_chunk
         assert sensor.value == absolute_present_timestamp
         assert sensor.status == Sensor.Status.NOMINAL
         assert sensor.timestamp == time_converter.adc_to_unix(sensor.value)
-        sensor = sensors["input.rx-unixtime"]
+        sensor = sensors["rx.unixtime"]
         # Should be the same value as the previous sensor, but in UNIX time
         assert sensor.value == time_converter.adc_to_unix(absolute_present_timestamp)
         assert sensor.status == Sensor.Status.NOMINAL
         assert sensor.timestamp == sensor.value
-        sensor = sensors["input.rx-missing-unixtime"]
+        sensor = sensors["rx.missing-unixtime"]
         # sensor.value should be of the last chunk to go missing
         absolute_missing_timestamp = (
             absolute_missing_chunk_id * layout.timestamp_step * layout.heaps_per_fengine_per_chunk

--- a/test/xbgpu/test_recv.py
+++ b/test/xbgpu/test_recv.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2022, National Research Foundation (SARAO)
+# Copyright (c) 2020-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/xbgpu/test_recv.py
+++ b/test/xbgpu/test_recv.py
@@ -345,18 +345,18 @@ class TestStream:
         )
 
         # Check sensors
-        sensor = sensors["input-rx-timestamp"]
+        sensor = sensors["input.rx-timestamp"]
         # sensor.value should be of the last chunk sent
         absolute_present_timestamp = expected_chunk_ids[-1] * layout.timestamp_step * layout.heaps_per_fengine_per_chunk
         assert sensor.value == absolute_present_timestamp
         assert sensor.status == Sensor.Status.NOMINAL
         assert sensor.timestamp == time_converter.adc_to_unix(sensor.value)
-        sensor = sensors["input-rx-unixtime"]
+        sensor = sensors["input.rx-unixtime"]
         # Should be the same value as the previous sensor, but in UNIX time
         assert sensor.value == time_converter.adc_to_unix(absolute_present_timestamp)
         assert sensor.status == Sensor.Status.NOMINAL
         assert sensor.timestamp == sensor.value
-        sensor = sensors["input-rx-missing-unixtime"]
+        sensor = sensors["input.rx-missing-unixtime"]
         # sensor.value should be of the last chunk to go missing
         absolute_missing_timestamp = (
             absolute_missing_chunk_id * layout.timestamp_step * layout.heaps_per_fengine_per_chunk


### PR DESCRIPTION
The KATCP guidelines (and our CAM ICD, but this is less important because the F-engines are not directly exposed to CAM) recommend using fullstops for hierarchical separation and hyphens for word separation in sensor names.

This change separates stream-relevant (e.g. per-pol) labels from the underlying.

E.g. "input{pol}-eq" -> "input{pol}.eq"

Addresses NGC-854

(Requires https://github.com/ska-sa/katsdpcontroller/pull/651 on the controller side.)

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

