### PR TITLE
Bump wheel to latest version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -396,7 +396,7 @@ virtualenv==20.16.5
     # via pre-commit
 wcwidth==0.2.5
     # via prompt-toolkit
-wheel==0.37.1
+wheel==0.38.4
     # via pip-tools
 wrapt==1.14.1
     # via


### PR DESCRIPTION
Dependabot complains about a security issue with the version we were using.

Checklist is N/A.