### PR TITLE
NGC-860 Stop correlator if still running after qualification tests

### DIFF
--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -89,8 +89,9 @@ pipeline {
   /* This post stage is configured to always run at the end of this pipeline,
    * regardless of the completion status. In this stage an email is sent to
    * the specified address with details of the Jenkins job and a PDF report
-   * containing the qualification test results. The final step removes the workspace when
-   * the build is complete.
+   * containing the qualification test results. Any runnning correlator part
+   * of the Jenkins qualification test that continues to run at this point will be
+   * stopped. The final step removes the workspace when the build is complete.
    */
   post {
     always {
@@ -107,6 +108,14 @@ pipeline {
       subject: 'Qualification Tests - katgpucbf - $BUILD_STATUS!',
       to: '$DEFAULT_RECIPIENTS'
 
+      script {
+        ARRAYS = sh(script: 'katcpcmd lab5.sdp.kat.ac.za:5001 product-list', returnStdout: true).trim()
+        echo "Currently Running Arrays: ${ARRAYS}"
+        if (ARRAYS.contains("jenkins_qualification_correlator")) {
+          sh 'katcpcmd lab5.sdp.kat.ac.za:5001 product-deconfigure jenkins_qualification_correlator 1'
+          echo "Destroying jenkins_qualification_correlator"
+        }
+      }
       cleanWs()
     }
   }


### PR DESCRIPTION
With this change, a check is performed at the end of the Jenkins qualification test to see if there is an associated correlator still running. If this is the case, it is usually due to some fault or error, and the correlator is stopped.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-860
