### PR TITLE
Amortise some unpack calculations

### DIFF
--- a/src/katgpucbf/fgpu/kernels/pfb_fir.mako
+++ b/src/katgpucbf/fgpu/kernels/pfb_fir.mako
@@ -91,10 +91,12 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void pfb_fir(
      * case not worth worrying about).
      */
     float samples[TAPS];
+    unpack_t unpack;
+    unpack_init(&unpack, in, in_offset);
     for (int i = 0; i < TAPS - 1; i++)
     {
-        samples[i] = get_sample(in, in_offset);
-        in_offset += step;  // and we shift the in_offset along, this makes the indexing simpler later.
+        samples[i] = unpack_read(&unpack);
+        unpack_advance(&unpack, step);
     }
 
     // Load the relevant weights for this branch of the PFB-FIR.
@@ -122,7 +124,8 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void pfb_fir(
          * This, combined with the way they are then read out below, avoids
          * having to manually shift things along in the array each loop.
          */
-        int sample = get_sample(in, in_offset + idx);
+        int sample = unpack_read(&unpack);
+        unpack_advance(&unpack, step);
         total_power += sample * sample;
         samples[(i + TAPS - 1) % TAPS] = (float) sample;
 


### PR DESCRIPTION
A lot of the work in figuring out how to unpack in the PFB kernel is fixed for each thread (because the step size is a multiple of 8). So it can be precomputed and stored in an unpack_t struct.

This is a pretty minor optimisation since the kernel is not compute-bound, but it does improve things by about 1%. It may also facilitate some future optimisations.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
