### PR TITLE
raw_antenna_voltage -> baseband_voltage

### DIFF
--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -249,7 +249,7 @@ async def _correlator_config_and_description(
             name = f"{dsim_name}{pol}"
             dig_names.append(name)
             config["outputs"][name] = {
-                "type": "sim.dig.raw_antenna_voltage",
+                "type": "sim.dig.baseband_voltage",
                 "band": band,
                 "adc_sample_rate": adc_sample_rate,
                 "centre_frequency": centre_frequency,

--- a/scratch/populate_telstate_for_sdp.py
+++ b/scratch/populate_telstate_for_sdp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 ################################################################################
-# Copyright (c) 2021-2022, National Research Foundation (SARAO)
+# Copyright (c) 2021-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/scratch/populate_telstate_for_sdp.py
+++ b/scratch/populate_telstate_for_sdp.py
@@ -101,7 +101,7 @@ async def main():
                 converter.set("instrument_dev_name", "dummy")
                 # TODO: get sky centre frequency from digitiser config?
                 converter.set("center_freq", 1284e6)
-            elif stream["type"] == "sim.dig.raw_antenna_voltage" and name.endswith("h"):
+            elif stream["type"] == "sim.dig.baseband_voltage" and name.endswith("h"):
                 # Both pols are represented, but we're only interested in one per antenna.
                 converter = SensorConverter(client, telstate, name[:-1])
                 converter.set("observer", stream["antenna"])

--- a/scratch/sim_correlator.py
+++ b/scratch/sim_correlator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 ################################################################################
-# Copyright (c) 2021-2022, National Research Foundation (SARAO)
+# Copyright (c) 2021-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/scratch/sim_correlator.py
+++ b/scratch/sim_correlator.py
@@ -104,7 +104,7 @@ def generate_config(args: argparse.Namespace) -> dict:
             dig_names.append(name)
             if args.digitiser_address is None:
                 config["outputs"][name] = {
-                    "type": "sim.dig.raw_antenna_voltage",
+                    "type": "sim.dig.baseband_voltage",
                     "band": args.band,
                     "adc_sample_rate": args.adc_sample_rate,
                     "centre_frequency": args.centre_frequency,
@@ -112,7 +112,7 @@ def generate_config(args: argparse.Namespace) -> dict:
                 }
             else:
                 config["inputs"][name] = {
-                    "type": "dig.raw_antenna_voltage",
+                    "type": "dig.baseband_voltage",
                     "band": args.band,
                     "adc_sample_rate": args.adc_sample_rate,
                     "centre_frequency": args.centre_frequency,


### PR DESCRIPTION
As per the (draft) CBF-CAM ICD, the stream type name for raw digitiser data has been updated.

I've attached an example `product_config.json` to show the update - GitHub doesn't support JSON so I renamed to TXT.
- [sim_baseband.txt](https://github.com/ska-sa/katgpucbf/files/10443651/sim_baseband.txt)

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-861.
