### PR TITLE
Tweak the number of workitems for the PFB FIR

### DIFF
--- a/src/katgpucbf/fgpu/pfb.py
+++ b/src/katgpucbf/fgpu/pfb.py
@@ -193,6 +193,9 @@ class PFBFIR(accel.Operation):
         # Re-compute work_spectra to balance the load
         work_spectra = accel.divup(self.spectra, groupsy)
         stepy = work_spectra * step
+        # Rounding up may have left some workgroups with nothing to do, so recalculate
+        # groupsy again.
+        groupsy = accel.divup(self.spectra, work_spectra)
         self.command_queue.enqueue_kernel(
             self.template.kernel,
             [


### PR DESCRIPTION
The new heuristic tries to balance the need for enough work to saturate the GPU with the need to give each workitem enough to do to amortise its startup cost. I've done benchmarking on a 3070 Ti, and the new scheme is improves things by up to 8.9%. The worst regression is 5.1%, but that is for 32-taps, 4-bit input which isn't relevant for MeerKAT. For 16-tap, 10-bit input the worst regression is 1.13%, and the best improvement is 4.4%.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
