### PR TITLE
Generate test procedure alongside report

### DIFF
--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -77,8 +77,8 @@ pipeline {
              sh 'spead2_net_raw pytest -v -c qualification/pytest-jenkins.ini qualification --image-override katgpucbf:harbor.sdp.kat.ac.za/cbf/katgpucbf:latest'
            }
            finally {
-             COMMIT_ID = sh(script: 'qualification/report/generate_pdf.py report.json report.pdf -c', returnStdout: true)
-             publishHTML(target: [keepAll: true, reportName: 'Qualification Test Report', reportDir: '', reportFiles: 'report.pdf, report.json', reportTitles: 'report.pdf, report.json'])
+             COMMIT_ID = sh(script: 'qualification/report/generate_pdf.py report.json test -c', returnStdout: true)
+             publishHTML(target: [keepAll: true, reportName: 'Qualification Test Report / Procedure', reportDir: '', reportFiles: 'test_report.pdf, report.json', reportTitles: 'test_report.pdf, report.json'])
              currentBuild.displayName = "#${BUILD_NUMBER} (${COMMIT_ID})"
            }
          }

--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
            }
            finally {
              COMMIT_ID = sh(script: 'qualification/report/generate_pdf.py report.json test -c', returnStdout: true)
-             publishHTML(target: [keepAll: true, reportName: 'Qualification Test Report / Procedure', reportDir: '', reportFiles: 'test_report.pdf, report.json', reportTitles: 'test_report.pdf, report.json'])
+             publishHTML(target: [keepAll: true, reportName: 'Qualification Test Report / Procedure', reportDir: '', reportFiles: 'test_procedure.pdf test_report.pdf, report.json', reportTitles: 'test_report.pdf, report.json'])
              currentBuild.displayName = "#${BUILD_NUMBER} (${COMMIT_ID})"
            }
          }

--- a/qualification/report/generate_pdf.py
+++ b/qualification/report/generate_pdf.py
@@ -37,6 +37,7 @@ from docutils.core import publish_parts
 from pylatex import (
     Command,
     Document,
+    Enumerate,
     LongTable,
     MiniPage,
     MultiColumn,
@@ -805,14 +806,16 @@ def document_from_list(result_list: list, report_doc_id: str, procedure_doc_id: 
                     detailed_results.create(Subsubsection("Test Detail", label=False)) as test_detail,
                     procedures.create(Subsubsection("Test Procedure")) as test_procedure,
                 ):
-                    with test_detail.create(LongTable(r"|l|p{0.7\linewidth}|")) as detail_table:
+                    with (
+                        test_detail.create(LongTable(r"|l|p{0.7\linewidth}|")) as detail_table,
+                        test_procedure.create(Enumerate()) as test_steps,
+                    ):
                         detail_table.add_hline()
                         assert result.start_time is not None
                         for step in result.steps:
                             detail_table.add_row((MultiColumn(2, align="|l|", data=bold(step.message)),))
-                            test_procedure.append(step.message)
-                            test_procedure.append("\n\n")
                             detail_table.add_hline()
+                            test_steps.add_item(step.message)
                             for item in step.items:
                                 if isinstance(item, Detail):
                                     detail_table.add_row(

--- a/qualification/report/generate_pdf.py
+++ b/qualification/report/generate_pdf.py
@@ -774,24 +774,24 @@ def document_from_list(result_list: list, doc_id: str) -> Document:
     with report_doc.create(Section("Result Summary")) as summary_section:
         _doc_result_summary(summary_section, results)
 
-    with report_doc.create(Section("Detailed Test Results")) as section:
+    with report_doc.create(Section("Detailed Test Results")) as detailed_results:
         for result in results:
-            with section.create(Subsection(result.full_text_name, label=result.name)):
-                section.append(NoEscape(rst2latex(result.blurb) + "\n\n"))
-                with section.create(Subsubsection("Requirements Verified")) as requirements_sec:
+            with detailed_results.create(Subsection(result.full_text_name, label=result.name)):
+                detailed_results.append(NoEscape(rst2latex(result.blurb) + "\n\n"))
+                with detailed_results.create(Subsubsection("Requirements Verified")) as requirements_sec:
                     _doc_requirements(requirements_sec, result.requirements)
-                with section.create(Subsubsection("Results")) as results_sec:
+                with detailed_results.create(Subsubsection("Results")) as results_sec:
                     _doc_outcome(results_sec, test_configuration, result)
-                with section.create(Subsubsection("Procedure", label=False)) as procedure:
-                    with section.create(LongTable(r"|l|p{0.7\linewidth}|")) as procedure_table:
-                        procedure_table.add_hline()
+                with detailed_results.create(Subsubsection("Test Detail", label=False)) as test_detail:
+                    with test_detail.create(LongTable(r"|l|p{0.7\linewidth}|")) as detail_table:
+                        detail_table.add_hline()
                         assert result.start_time is not None
                         for step in result.steps:
-                            procedure_table.add_row((MultiColumn(2, align="|l|", data=bold(step.message)),))
-                            procedure_table.add_hline()
+                            detail_table.add_row((MultiColumn(2, align="|l|", data=bold(step.message)),))
+                            detail_table.add_hline()
                             for item in step.items:
                                 if isinstance(item, Detail):
-                                    procedure_table.add_row(
+                                    detail_table.add_row(
                                         [
                                             f"{readable_duration(item.timestamp - result.start_time)}",
                                             item.message,
@@ -806,7 +806,7 @@ def document_from_list(result_list: list, doc_id: str) -> Document:
                                     cell = r"\color{red}\begin{Bflushleft}\begin{lstlisting}"
                                     cell += "\n" + item.message + "\n"
                                     cell += r"\end{lstlisting}\end{Bflushleft}"
-                                    procedure_table.add_row(
+                                    detail_table.add_row(
                                         [
                                             f"{readable_duration(item.timestamp - result.start_time)}",
                                             NoEscape(cell),
@@ -816,11 +816,11 @@ def document_from_list(result_list: list, doc_id: str) -> Document:
                                     mp = MiniPage(width=NoEscape(r"\textwidth"))
                                     mp.append(NoEscape(r"\center"))
                                     mp.append(NoEscape(item.code))
-                                    procedure_table.add_row((MultiColumn(2, align="|c|", data=mp),))
-                                procedure_table.add_hline()
+                                    detail_table.add_row((MultiColumn(2, align="|c|", data=mp),))
+                                detail_table.add_hline()
 
                     if result.failure_messages:
-                        with procedure.create(LstListing()) as failure_message:
+                        with test_detail.create(LstListing()) as failure_message:
                             for message in result.failure_messages:
                                 failure_message.append(message)
 


### PR DESCRIPTION
I do this by just making two documents in parallel, and only putting the "steps" and not the "detail" into the procedure document. Unfortunately it is not possible to generate the procedure without actually running the test, but we can perhaps look at that as a feature and not a bug, because you won't be able to generate a "procedure" for tests that don't actually work. Though you could fudge things by just commenting stuff out I guess.

It could probably use a little bit of polish, but I'm fairly pleased with how this is structured so far. 

[test_report.pdf](https://github.com/ska-sa/katgpucbf/files/10466443/test_report.pdf)
[test_procedure.pdf](https://github.com/ska-sa/katgpucbf/files/10466444/test_procedure.pdf)

This may be easier to review on a per-commit basis, as I had to do a fair amount of refactoring first.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-878.
