### PR TITLE
Support multiple network interfaces

### DIFF
--- a/doc/fgpu.design.rst
+++ b/doc/fgpu.design.rst
@@ -450,12 +450,22 @@ floating-point precision when accumulating a large number of samples.
 
 Network transmit
 ----------------
-The current transmit system is quite simple. A single spead2 stream is created,
-with one substream per multicast destination. For each output chunk, memory
-together with a set of heaps is created in advance. The heaps are carefully
-constructed so that they reference numpy arrays (including for the timestamps),
-rather than copying data into spead2. This allows heaps to be recycled for new
-data without having to create new heap objects.
+The current transmit system is quite simple. By default a single spead2 stream
+is created, with one substream per multicast destination. For each output
+chunk, memory together with a set of heaps is created in advance. The heaps are
+carefully constructed so that they reference numpy arrays (including for the
+timestamps), rather than copying data into spead2. This allows heaps to be
+recycled for new data without having to create new heap objects.
+
+If the traffic for a single engine exceeds the bandwidth of the network
+interface, it is necessary to distribute it over multiple interfaces. In this
+case, several spead2 streams are created (one per interface). Each of them has
+a substream for every multicast destination, but they are not all used (the
+duplication simplifies indexing). When heaps are transmitted, a stream is
+selected for each heap to balance the load. Descriptors and stop heaps are
+just sent through the first stream for simplicity. This scheme assumes that
+all the interfaces are connected to the same network and hence it does not
+matter which interface is used other than for load balancing.
 
 PeerDirect
 ^^^^^^^^^^

--- a/scratch/fgpu/run-dsim-hbw.sh
+++ b/scratch/fgpu/run-dsim-hbw.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e -u
+
+# Load variables for machine-specific config
+. ../config/$(hostname -s).sh
+
+nproc="$(nproc)"
+cpu=("0" "$(($nproc / 4))")
+iface=("$iface1" "$iface2")
+addresses=("239.102.0.64+7:7148" "239.102.0.72+7:7148")
+sync_time="$(date +%s)"
+
+set -x
+for i in 0 1; do
+    sudo `which spead2_net_raw` taskset -c $((cpu[$i] + 1)) `which dsim` \
+        --affinity "${cpu[$i]}" \
+        --ibv \
+        --interface "${iface[$i]}" \
+        --adc-sample-rate ${adc_sample_rate:-7000000000} \
+        --ttl 2 \
+        --katcp-port $(($i + 7140)) \
+        --prometheus-port $(($i + 7150)) \
+        --sync-time "$sync_time" \
+        "${addresses[$i]}" "$@" &
+done
+wait

--- a/scratch/fgpu/run-dsim.sh
+++ b/scratch/fgpu/run-dsim.sh
@@ -5,8 +5,8 @@ set -e -u
 # Load variables for machine-specific config
 . ../config/$(hostname -s).sh
 
-if [ "$#" -ne 1 ]; then
-    echo "Usage: $0 0|1|2|3" 1>&2
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $0 0|1|2|3 [args...]" 1>&2
     exit 2
 fi
 
@@ -30,6 +30,7 @@ nproc="$(nproc)"
 cpu1="$(($nproc * $1 / 4))"
 cpu2="$(($cpu1 + 1))"
 addresses="239.102.$1.64+7:7148 239.102.$1.72+7:7148"
+shift
 
 set -x
 exec spead2_net_raw taskset -c $cpu2 dsim \
@@ -40,4 +41,4 @@ exec spead2_net_raw taskset -c $cpu2 dsim \
     --ttl 2 \
     --katcp-port $katcp_port \
     --prometheus-port $prom_port \
-    $addresses
+    $addresses "$@"

--- a/scratch/fgpu/run-fgpu-hbw.sh
+++ b/scratch/fgpu/run-fgpu-hbw.sh
@@ -18,11 +18,10 @@ feng_id="0"
 
 export CUDA_VISIBLE_DEVICES="$cuda1"
 
-#    --src-chunk-samples 67108864 \
-#    --dst-chunk-jones 33554432 \
 set -x
 exec spead2_net_raw taskset -c $other_affinity fgpu \
-    --use-vkgdr \
+    --src-chunk-samples 67108864 \
+    --dst-chunk-jones 33554432 \
     --src-interface $iface1,$iface2 --src-ibv \
     --dst-interface $iface1,$iface2 --dst-ibv \
     --src-affinity $src_affinity --src-comp-vector=$src_comp \

--- a/scratch/fgpu/run-fgpu-hbw.sh
+++ b/scratch/fgpu/run-fgpu-hbw.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e -u
+
+# Load variables for machine-specific config
+. ../config/$(hostname -s).sh
+
+src_affinity="0,4"
+src_comp=$src_affinity
+dst_affinity="8"
+dst_comp=$dst_affinity
+other_affinity="12"
+srcs="239.102.0.64+7:7148 239.102.0.72+7:7148"
+dst="239.102.200.0+15:7148"
+katcp_port="7140"
+prom_port="7150"
+feng_id="0"
+
+export CUDA_VISIBLE_DEVICES="$cuda1"
+
+#    --src-chunk-samples 67108864 \
+#    --dst-chunk-jones 33554432 \
+set -x
+exec spead2_net_raw taskset -c $other_affinity fgpu \
+    --use-vkgdr \
+    --src-interface $iface1,$iface2 --src-ibv \
+    --dst-interface $iface1,$iface2 --dst-ibv \
+    --src-affinity $src_affinity --src-comp-vector=$src_comp \
+    --dst-affinity $dst_affinity --dst-comp-vector=$dst_comp \
+    --adc-sample-rate ${adc_sample_rate:-7000000000} \
+    --channels ${channels:-32768} \
+    --spectra-per-heap ${spectra_per_heap:-256} \
+    --katcp-port $katcp_port \
+    --prometheus-port $prom_port \
+    --sync-epoch 0 \
+    --array-size ${array_size:-8} \
+    --feng-id "$feng_id" \
+    $srcs $dst "$@"

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -264,6 +264,8 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     for src in args.src:
         if not isinstance(src, str) and args.src_interface is None:
             parser.error("Live source requires --src-interface")
+    if len(args.dst) % len(args.dst_interface) != 0:
+        parser.error("number of destinations must be divisible by number of destination interfaces")
     return args
 
 

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -130,7 +130,7 @@ class TestEngine:
           correctly populated.
         """
         assert engine_server._port == 0
-        assert engine_server._src_interface == "127.0.0.1"
+        assert engine_server._src_interface == ["127.0.0.1"] * N_POLS
         # TODO: `dst_interface` goes to the _sender member, which doesn't have anything we can query.
         assert engine_server.channels == CHANNELS
         assert engine_server.time_converter.sync_epoch == SYNC_EPOCH


### PR DESCRIPTION
Allow `--src-interface` to take up to two interfaces (one per pol), and `--dst-interface` to take any number of interfaces that divides into the number of endpoints. This allows bandwidths to scale beyond the amount provided by a single network port.

There are also a couple of scratch scripts I'm using to test high bandwidth operation.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
