### PR TITLE
s/Integration/Qualification/g

### DIFF
--- a/qualification/report/generate_pdf.py
+++ b/qualification/report/generate_pdf.py
@@ -771,8 +771,9 @@ def document_from_list(result_list: list, doc_id: str, *, make_report=True) -> D
     doc.set_variable("theAuthor", "DSP Team")
     doc.set_variable("docDate", today.strftime("%d %B %Y"))
     doc.set_variable("docId", doc_id)
+    doc.set_variable("docType", f"Qualification Test {'Report' if make_report else 'Procedure'}")
     doc.preamble.append(NoEscape((RESOURCE_PATH / "preamble.tex").read_text()))
-    doc.append(Command("title", f"Integration Test {'Report' if make_report else 'Procedure'}"))
+    doc.append(Command("title", f"MeerKAT Extension CBF Qualification Test {'Report' if make_report else 'Procedure'}"))
     doc.append(Command("makekatdocbeginning"))
 
     _doc_requirements_verified(doc, requirements_verified)

--- a/qualification/report/preamble.tex
+++ b/qualification/report/preamble.tex
@@ -21,7 +21,6 @@
 \newcommand{\docClient}{NRF (National Research Foundation)}
 \newcommand{\docFacility}{SARAO (South African Radio Astronomy Observatory)}
 \newcommand{\docProject}{MeerKAT Extension}
-\newcommand{\docType}{Integration Test Report}
 \newcommand{\docFunction}{Engineering / Digital Signal Processing}
 
 \newcommand{\docRevision}{1}


### PR DESCRIPTION
For some reason the PDFs came out titled and classified as Integration Test {Report / Procedure}. It should have been Qualification all along.

This PR changes it.

[test_report.pdf](https://github.com/ska-sa/katgpucbf/files/10576487/test_report.pdf)
[test_procedure.pdf](https://github.com/ska-sa/katgpucbf/files/10576488/test_procedure.pdf)

@tyronevb once this is merged, I will tag a release.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
