### PR TITLE
Use blue text instead of red borders for QTR hyperlinks

### DIFF
--- a/qualification/report/generate_pdf.py
+++ b/qualification/report/generate_pdf.py
@@ -767,6 +767,7 @@ def document_from_list(result_list: list, doc_id: str, *, make_report=True) -> D
         document_options=["11pt", "english", "twoside"],
         inputenc=None,  # katdoc inputs inputenc with specific options, so prevent a clash
     )
+    doc.packages.add(Package("hyperref", "colorlinks,linkcolor=blue"))
     today = date.today()  # TODO: should store inside the JSON
     doc.set_variable("theAuthor", "DSP Team")
     doc.set_variable("docDate", today.strftime("%d %B %Y"))

--- a/qualification/report/preamble.tex
+++ b/qualification/report/preamble.tex
@@ -1,5 +1,4 @@
 \usepackage{katdoc}
-\usepackage{hyperref}
 \usepackage{pgf}
 \usepackage{mathtools}
 \usepackage{graphicx}


### PR DESCRIPTION
I find it a bit more comfortable to read.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match