### PR TITLE
Increase timeout for Jenkins qualification test

### DIFF
--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -59,7 +59,7 @@ pipeline {
   }
 
   options {
-    timeout(time: 1, unit: 'HOURS')
+    timeout(time: 5, unit: 'HOURS')
   }
 
   stages {


### PR DESCRIPTION
PR #517 made the qualification report include a lot more tests, so it's now exceeding the 1 hour time limit. Bump it up to 5.
