### PR TITLE
Optionally store raw data in report.json

### DIFF
--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -58,12 +58,13 @@ ini_options = [
         name="prometheus_url", help="URL to Prometheus server for querying hardware configuration", type="string"
     ),
     IniOption(name="interface", help="Name of network to use for ingest.", type="string"),
-    IniOption(name="use_ibv", help="Use ibverbs", type="bool", default="false"),
+    IniOption(name="use_ibv", help="Use ibverbs", type="bool", default=False),
     IniOption(name="product_name", help="Name of subarray product", type="string", default="qualification_correlator"),
     IniOption(name="tester", help="Name of person executing this qualification run", type="string", default="Unknown"),
     IniOption(name="max_antennas", help="Maximum number of antennas to test", type="string", default="8"),
     IniOption(name="channels", help="Space-separated list of channel counts to test", type="args", default=["8192"]),
     IniOption(name="bands", help="Space-separated list of bands to test", type="args", default=["l"]),
+    IniOption(name="raw_data", help="Include raw data for figures", type="bool", default=False),
 ]
 
 
@@ -87,7 +88,7 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line("markers", "requirements(reqs): indicate which system engineering requirements are tested")
     config.addinivalue_line("markers", "name(name): human-readable name for the test")
     for option in ini_options:
-        assert config.getini(option.name), f"{option.name} missing from pytest.ini"
+        assert config.getini(option.name) is not None, f"{option.name} missing from pytest.ini"
 
 
 def custom_report_log(pytestconfig: pytest.Config, data) -> None:
@@ -191,7 +192,7 @@ def pdf_report(request, monkeypatch) -> Reporter:
     if name_marker is not None:
         data[0]["test_name"] = name_marker.args[0]
     request.node.user_properties.append(("pdf_report_data", data))
-    reporter = Reporter(data)
+    reporter = Reporter(data, raw_data=request.config.getini("raw_data"))
     orig_log_failure = pytest_check.check_methods.log_failure
     orig_get_full_context = pytest_check.check_methods.get_full_context
 

--- a/qualification/reporter.py
+++ b/qualification/reporter.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2022, National Research Foundation (SARAO)
+# Copyright (c) 2022-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -96,7 +96,7 @@ class Reporter:
             raise ValueError("Cannot have failure without a current step")
         self._cur_step.append({"$msg_type": "failure", "message": message, "timestamp": time.time()})
 
-    def raw_figure(self, code: str) -> None:
+    def raw_figure(self, code: str, data: list = []) -> None:  # noqa: B006
         """Add raw LaTeX to the document.
 
         It will be set inside a minipage and is intended for figures, but could
@@ -104,7 +104,7 @@ class Reporter:
         """
         if self._cur_step is None:
             raise ValueError("Cannot have figure without a current step")
-        self._cur_step.append({"$msg_type": "figure", "code": code})
+        self._cur_step.append({"$msg_type": "figure", "code": code, "data": data})
 
     def figure(self, figure: matplotlib.figure.Figure) -> None:
         """Add a matplotlib figure to the report.
@@ -114,6 +114,10 @@ class Reporter:
         figure
             The figure to plot
         """
+        data = []
+        for ax in figure.axes:
+            for line in ax.get_lines():
+                data.append(line.get_xydata().tolist())
         content = io.StringIO()
         figure.savefig(content, format="pgf", backend="pgf")
-        self.raw_figure(content.getvalue())
+        self.raw_figure(content.getvalue(), data=data)

--- a/qualification/reporter.py
+++ b/qualification/reporter.py
@@ -18,6 +18,7 @@
 import io
 import logging
 import time
+from typing import Any
 
 import matplotlib.figure
 import matplotlib.ticker
@@ -62,11 +63,16 @@ class POTLocator(matplotlib.ticker.Locator):
 
 
 class Reporter:
-    """Provides mechanisms to log steps taken in a test."""
+    """Provides mechanisms to log steps taken in a test.
 
-    def __init__(self, data: list) -> None:
+    If `raw_data` is true, raw data from line plots in figures will
+    be added to the report.
+    """
+
+    def __init__(self, data: list, raw_data: bool = False) -> None:
         self._data = data
         self._cur_step: list | None = None
+        self._raw_data = raw_data
 
     def config(self, **kwargs) -> None:
         """Report the test configuration."""
@@ -104,7 +110,10 @@ class Reporter:
         """
         if self._cur_step is None:
             raise ValueError("Cannot have figure without a current step")
-        self._cur_step.append({"$msg_type": "figure", "code": code, "data": data})
+        value: dict[str, Any] = {"$msg_type": "figure", "code": code}
+        if self._raw_data:
+            value["data"] = data
+        self._cur_step.append(value)
 
     def figure(self, figure: matplotlib.figure.Figure) -> None:
         """Add a matplotlib figure to the report.


### PR DESCRIPTION
This makes it possible to extract the raw data again later if its needed
to analyze it more carefully (or in my case, to make my own figure).

It takes a lot of space, so gate it with an ini option (raw_data).

Also fix a bug that meant use_ibv was treated as true if omitted,
because it defaults to a string "false" which is truthy. And fix another
bug that prevented setting any setting to a falsey value.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match