### PR TITLE
Use cross-correlations to better measure channel shape

### DIFF
--- a/qualification/antenna_channelised_voltage/test_channel_shape.py
+++ b/qualification/antenna_channelised_voltage/test_channel_shape.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2022, National Research Foundation (SARAO)
+# Copyright (c) 2022-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -115,7 +115,7 @@ async def test_channel_shape(
     x = np.linspace(-2.5, 2.5, len(db_plot))
 
     for xticks, ymin, title in [
-        (np.arange(-2.5, 2.6, 0.5), -100, "Channel response"),
+        (np.arange(-2.5, 2.6, 0.5), -150, "Channel response"),
         (np.arange(-0.5, 0.55, 0.1), -1.5, "Channel response (zoomed)"),
     ]:
         fig = Figure()

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -41,7 +41,7 @@ from .reporter import Reporter
 
 logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
-DEFAULT_ANTENNAS = 4  #: Number of antennas for antenna_channelised_voltage tests
+DEFAULT_ANTENNAS = 8  #: Number of antennas for antenna_channelised_voltage tests
 FULL_ANTENNAS = [1, 4, 8, 10, 16, 20, 32, 40, 55, 64, 65, 80]
 
 


### PR DESCRIPTION
The channel shape was being limited by the dither/quantisation noise in the dsim. Because auto-correlations were being used, this noise was self-correlated. Using cross-correlations, with the same tone but independent noise, means the noise is uncorrelated and so tends to wash out.

The implementation uses the two pols of each dsim as the two sources to correlate. This simplifies the code somewhat, but halves the efficiency as it now requires two inputs to do what previous was done with one. To compensate, I've bumped DEFAULT_ANTENNAS up to 8.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
