### PR TITLE
Bump ipython to the latest version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -122,7 +122,7 @@ imagesize==1.4.1
     # via sphinx
 iniconfig==1.1.1
     # via pytest
-ipython==8.5.0
+ipython==8.10.0
     # via -r requirements-dev.in
 jedi==0.18.1
     # via ipython


### PR DESCRIPTION
Dependabot was complaining about the old version. It's not used programmatically (just a convenience for requirements-dev.txt to install it), so I think this is a zero-risk change.
