### PR TITLE
Fix test_accum_length for UHF

### DIFF
--- a/qualification/baseline_correlation_products/test_accum_length.py
+++ b/qualification/baseline_correlation_products/test_accum_length.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2022, National Research Foundation (SARAO)
+# Copyright (c) 2022-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -57,7 +57,8 @@ async def test_accum_length(
     delta_s = delta / receiver.scale_factor_timestamp
     pdf_report.detail(f"Difference is {delta} samples, {delta_s * 1000:.3f} ms.")
     with check:
-        assert delta_s == receiver.int_time
+        # pytest.approx just to allow for floating-point rounding
+        assert delta_s == pytest.approx(receiver.int_time, rel=1e-15)
 
     pdf_report.step("Compare power against expected value.")
     # Sum over channels, but use only one baseline and real part because


### PR DESCRIPTION
It was testing that two floating-point numbers, computed in different ways, were identical. Allow a relative error of 1e-15.

Partly addresses NGC-897.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [ ] If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
