### PR TITLE
Remove an invalid comment

### DIFF
--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -241,9 +241,6 @@ def matplotlib_report_style() -> Generator[None, None, None]:
 async def _correlator_config_and_description(
     pytestconfig, n_antennas: int, n_channels: int, n_dsims: int, band: str, int_time: float
 ) -> tuple[dict, dict]:
-    # Adapted from `sim_correlator.py` but with logic for using multiple dsims
-    # removed. For the time being, we're going to use a single dsim for
-    # consistency with MeerKAT's qualification testing.
 
     config: dict = {
         "version": "3.1",


### PR DESCRIPTION
Initially qualification used only a single D-sim. Later this was changed to include the possibility for more, so the comment explaining the former isn't valid anymore.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match


