### PR TITLE
Fix -c option to generate_pdf

### DIFF
--- a/qualification/report/generate_pdf.py
+++ b/qualification/report/generate_pdf.py
@@ -18,6 +18,7 @@
 
 """Generate a PDF based on the intermediate JSON output."""
 import argparse
+import copy
 import json
 import logging
 import os
@@ -444,8 +445,9 @@ def parse(input_data: list[dict]) -> tuple[TestConfiguration, list[Result]]:
 
         if line["$report_type"] != "TestReport":
             continue
-        # _from_json is an "experimental" function.
-        report = pytest.TestReport._from_json(line)
+        # _from_json is an "experimental" function. It also mutates its argument,
+        # so we have to copy it to avoid altering input_data.
+        report = pytest.TestReport._from_json(copy.deepcopy(line))
         nodeid = report.nodeid
         if not results or results[-1].nodeid != nodeid:
             # It's the first time we've seen this nodeid (otherwise we merge


### PR DESCRIPTION
It causes `parse` to be called twice. pytest.Report._from_json actually modifies the dictionary it was given, and on the second time round that causes the parsing to fail because it's already modified. Fix it by giving it a deep copy of the original.

Closes NGC-875.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [ ] If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match


