### PR TITLE
Fix test_delay_application_time

### DIFF
--- a/qualification/__init__.py
+++ b/qualification/__init__.py
@@ -266,7 +266,7 @@ class BaselineCorrelationProductsReceiver:
         Parameters
         ----------
         min_timestamp
-            Chunks with a timestamp less then this value are discarded. If the
+            Chunks with a timestamp less than this value are discarded. If the
             default of ``None`` is used, a value is computed via
             :meth:`CorrelatorRemoteControl.steady_state_timestamp`.
         all_timestamps

--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -77,7 +77,7 @@ async def test_delay_application_time(
         target_ts = round(receiver.time_converter.unix_to_adc(target))
         target_acc_ts = target_ts // receiver.timestamp_step * receiver.timestamp_step
         acc = None
-        async for timestamp, chunk in receiver.complete_chunks(max_delay=0):
+        async for timestamp, chunk in receiver.complete_chunks(min_timestamp=target_acc_ts):
             with chunk:
                 pdf_report.detail(f"Received chunk with timestamp {timestamp}, target is {target_acc_ts}.")
                 total = np.sum(chunk.data[:, bl_idx, :], axis=0)  # Sum over channels


### PR DESCRIPTION
The test sets a delay model for 200ms in the future, then tries to grab the dump that brackets that change. The *start* of that dump may be in the past, so (implicitly) using steady_state_timestamp means we might just throw away the dump we actually want.

I'm not sure why we've only run into this with UHF and not with other bands.

Partly addresses NGC-897.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
