### PR TITLE
Fix a couple of minor bugs in qualification tests

### DIFF
--- a/qualification/__init__.py
+++ b/qualification/__init__.py
@@ -340,7 +340,7 @@ class BaselineCorrelationProductsReceiver:
         """
         chunks: list[tuple[int, katgpucbf.recv.Chunk]] = []
         async with async_timeout.timeout(timeout):
-            async for timestamp, chunk in self.complete_chunks(all_timestamps=True):
+            async for timestamp, chunk in self.complete_chunks(min_timestamp=min_timestamp, all_timestamps=True):
                 if chunk is None:
                     # Throw away failed attempt at getting an adjacent set
                     for _, old_chunk in chunks:

--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -271,7 +271,7 @@ def check_phases(
     actual = actual[1:]
     expected = expected[1:]
     delta = wrap_angle(actual - expected)
-    max_error = np.max(delta)
+    max_error = np.max(np.abs(delta))
     rms_error = np.sqrt(np.mean(np.square(delta)))
     pdf_report.detail(f"Maximum error is {np.rad2deg(max_error):.3f}°.")
     pdf_report.detail(f"RMS error over channels is {np.rad2deg(rms_error):.5f}°.")


### PR DESCRIPTION
These are some bugs I spotted while debugging NGC-897. I haven't generated a full qualification report to attach - let me know if you'd like one.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [ ] If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match