### PR TITLE
Mark phase rate test as expected to fail

### DIFF
--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -532,6 +532,7 @@ async def test_delay_phase(
 
 
 @pytest.mark.requirements("CBF-REQ-0128,CBF-REQ-0112")
+@pytest.mark.xfail(reason="requirements unclear")
 async def test_phase_rate(
     correlator: CorrelatorRemoteControl,
     receive_baseline_correlation_products: BaselineCorrelationProductsReceiver,

--- a/qualification/demo.py
+++ b/qualification/demo.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2022, National Research Foundation (SARAO)
+# Copyright (c) 2022-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -77,3 +77,12 @@ def test_check(pdf_report: Reporter) -> None:
     pdf_report.step("Expect some good things")
     with check:
         assert 1 == 1
+
+
+@pytest.mark.xfail(reason="Waived")
+def test_xfail(pdf_report: Reporter) -> None:
+    """Do a test that's expected to fail."""
+    pdf_report.step("Start the test")
+    pdf_report.detail("Check that 1 == 2")
+    with check:
+        assert 1 == 2


### PR DESCRIPTION
The test is flawed, but rewriting it will require CBF-REQ-0128 to be clarified. For now mark it as xfail, and update the report generator to better handle xfail.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-897 (for now).
