### PR TITLE
Make report generation more robust to tests that fail early

### DIFF
--- a/qualification/report/generate_pdf.py
+++ b/qualification/report/generate_pdf.py
@@ -738,9 +738,9 @@ def _doc_outcome(section: Container, test_configuration: TestConfiguration, resu
         section.append(NoEscape(r"\ "))
         section.append(f"({result.xfail_reason})")
     section.append(Command("hspace", "1cm"))
-    assert result.start_time is not None
-    section.append(f"Test start time: {datetime.fromtimestamp(float(result.start_time)).strftime('%T')}")
-    section.append(Command("hspace", "1cm"))
+    if result.start_time is not None:
+        section.append(f"Test start time: {datetime.fromtimestamp(float(result.start_time)).strftime('%T')}")
+        section.append(Command("hspace", "1cm"))
     section.append(f"Duration: {readable_duration(result.duration)} seconds\n")
 
     with section.create(LongTable(r"|l|p{0.4\linewidth}|")) as config_table:
@@ -818,8 +818,8 @@ def document_from_list(result_list: list, doc_id: str, *, make_report=True) -> D
                     if make_report:
                         with procedure.create(LongTable(r"|l|p{0.7\linewidth}|")) as procedure_table:
                             procedure_table.add_hline()
-                            assert result.start_time is not None
                             for step in result.steps:
+                                assert result.start_time is not None
                                 procedure_table.add_row((MultiColumn(2, align="|l|", data=bold(step.message)),))
                                 procedure_table.add_hline()
                                 for item in step.items:


### PR DESCRIPTION
If a test fails early enough, we don't get the `start_time` information. Instead of failing the entire report generation, just don't try to report it.

It's not the prettiest thing, because we also don't get the test name or parameters, but at least it lets us see results for any tests that did run properly, while also being aware that there was a failure and seeing the backtrace/exception.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
