### PR TITLE
Publish test results when unit tests fail

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -140,7 +140,10 @@ pipeline {
     }
 
     stage('Build and push Docker image') {
-      when { not { changeRequest() }}
+      when {
+        not { changeRequest() }
+        equals expected: "SUCCESS", actual: currentBuild.currentResult
+      }
       environment {
         DOCKER_BUILDKIT = '1'
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021-2022, National Research Foundation (SARAO)
+ * Copyright (c) 2021-2023, National Research Foundation (SARAO)
  *
  * Licensed under the BSD 3-Clause License (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy
@@ -108,14 +108,14 @@ pipeline {
           when { not { anyOf { changeRequest target: 'main'; branch 'main' } } }
           options { timeout(time: 10, unit: 'MINUTES') }
           steps {
-            sh 'pytest -v -ra --junitxml=reports/result.xml --cov=katgpucbf --cov=test --cov-report=xml --cov-branch'
+            sh 'pytest -v -ra --junitxml=reports/result.xml --cov=katgpucbf --cov=test --cov-report=xml --cov-branch --suppress-tests-failed-exit-code'
           }
         }
         stage('Run pytest (full)') {
           when { anyOf { changeRequest target: 'main'; branch 'main' } }
           options { timeout(time: 60, unit: 'MINUTES') }
           steps {
-            sh 'pytest -v -ra --all-combinations --junitxml=reports/result.xml --cov=test --cov=katgpucbf --cov-report=xml --cov-branch'
+            sh 'pytest -v -ra --all-combinations --junitxml=reports/result.xml --cov=test --cov=katgpucbf --cov-report=xml --cov-branch --suppress-tests-failed-exit-code'
           }
         }
 

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -272,7 +272,9 @@ pytest-asyncio==0.19.0
 pytest-check==1.0.10
     # via katgpucbf (setup.cfg)
 pytest-custom-exit-code==0.3.0
-    # via katgpucbf (setup.cfg)
+    # via
+    #   -c qualification/../requirements-dev.txt
+    #   katgpucbf (setup.cfg)
 pytest-reportlog==0.1.2
     # via katgpucbf (setup.cfg)
 python-dateutil==2.8.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -278,6 +278,7 @@ pytest==7.1.3
     #   katgpucbf (setup.cfg)
     #   pytest-asyncio
     #   pytest-cov
+    #   pytest-custom-exit-code
     #   pytest-forked
     #   pytest-mock
     #   pytest-xdist
@@ -285,6 +286,8 @@ pytest-asyncio==0.19.0
     # via katgpucbf (setup.cfg)
 pytest-cov==4.0.0
     # via -r requirements-dev.in
+pytest-custom-exit-code==0.3.0
+    # via katgpucbf (setup.cfg)
 pytest-forked==1.4.0
     # via pytest-xdist
 pytest-mock==3.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ test =
     async-timeout
     pytest
     pytest-asyncio>=0.18
+    pytest-custom_exit_code
     pytest-mock
 
 qualification =


### PR DESCRIPTION
Instead of aborting the build when the unit tests fail, allow things to proceed to the result publishing stage. Still skip the Docker build if the unit tests fail, so that we don't put bad code into the Docker registry.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-903.
