### PR TITLE
Bump katsdptelstate to the latest version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
             'aiokatcp==1.6.0',
             'dask==2022.10.0',
             'katsdpsigproc==1.6.1',
-            'katsdptelstate==0.11',
+            'katsdptelstate==0.13',
             'numpy==1.23.4',
             'pyparsing==3.0.9',
             'pytest==7.1.3',

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -129,7 +129,7 @@ katsdpsigproc==1.6.1
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   katgpucbf (setup.cfg)
-katsdptelstate==0.11
+katsdptelstate==0.13
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
@@ -176,7 +176,6 @@ netifaces==0.11.0
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   katsdpservices
-    #   katsdptelstate
 numba==0.56.3
     # via
     #   -c qualification/../requirements-dev.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -136,7 +136,7 @@ katsdpsigproc==1.6.1
     # via
     #   -c requirements.txt
     #   katgpucbf (setup.cfg)
-katsdptelstate==0.11
+katsdptelstate==0.13
     # via
     #   -c requirements.txt
     #   katgpucbf (setup.cfg)
@@ -175,7 +175,6 @@ netifaces==0.11.0
     # via
     #   -c requirements.txt
     #   katsdpservices
-    #   katsdptelstate
 nodeenv==1.7.0
     # via pre-commit
 numba==0.56.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ katsdpservices==1.2
     # via katgpucbf (setup.cfg)
 katsdpsigproc==1.6.1
     # via katgpucbf (setup.cfg)
-katsdptelstate==0.11
+katsdptelstate==0.13
     # via katgpucbf (setup.cfg)
 llvmlite==0.39.1
     # via numba
@@ -72,9 +72,7 @@ multidict==6.0.2
     #   aiohttp
     #   yarl
 netifaces==0.11.0
-    # via
-    #   katsdpservices
-    #   katsdptelstate
+    # via katsdpservices
 numba==0.56.3
     # via
     #   katgpucbf (setup.cfg)


### PR DESCRIPTION
This is mainly to check that it won't break anything.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
