### PR TITLE
fgpu: add command-line arguments for narrowband

### DIFF
--- a/doc/katgpucbf.fgpu.output.rst
+++ b/doc/katgpucbf.fgpu.output.rst
@@ -1,0 +1,7 @@
+katgpucbf.fgpu.output module
+============================
+
+.. automodule:: katgpucbf.fgpu.output
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/katgpucbf.fgpu.rst
+++ b/doc/katgpucbf.fgpu.rst
@@ -12,6 +12,7 @@ Submodules
    katgpucbf.fgpu.delay
    katgpucbf.fgpu.engine
    katgpucbf.fgpu.main
+   katgpucbf.fgpu.output
    katgpucbf.fgpu.pfb
    katgpucbf.fgpu.postproc
    katgpucbf.fgpu.recv

--- a/qualification/__init__.py
+++ b/qualification/__init__.py
@@ -47,6 +47,7 @@ from spead2.recv.numba import chunk_place_data
 
 import katgpucbf.recv
 from katgpucbf import COMPLEX
+from katgpucbf.spead import DEFAULT_PORT
 from katgpucbf.utils import TimeConverter
 
 logger = logging.getLogger(__name__)
@@ -211,7 +212,9 @@ class BaselineCorrelationProductsReceiver:
         self.bandwidth = correlator.sensors[f"{acv_name}.bandwidth"].value
         self.multicast_endpoints = [
             (endpoint.host, endpoint.port)
-            for endpoint in endpoint_list_parser(7148)(correlator.sensors[f"{stream_name}.destination"].value.decode())
+            for endpoint in endpoint_list_parser(DEFAULT_PORT)(
+                correlator.sensors[f"{stream_name}.destination"].value.decode()
+            )
         ]
         self.timestamp_step = self.n_samples_between_spectra * self.n_spectra_per_acc
         self.time_converter = TimeConverter(self.sync_time, self.scale_factor_timestamp)

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -80,6 +80,8 @@ def comma_split(
 
     def func(value: str) -> list[_T]:  # noqa: D102
         parts = value.split(",")
+        if parts == [""]:
+            parts = []
         n = len(parts)
         if count is not None and n == 1 and allow_single:
             parts = parts * count

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -336,8 +336,8 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         if "taps" not in output:
             output["taps"] = args.taps
         if "w_cutoff" not in output:
-            output["taps"] = args.w_cutoff
-    args.narrowband = [NarrowbandOutput(*output) for output in args.narrowband]
+            output["w_cutoff"] = args.w_cutoff
+    args.narrowband = [NarrowbandOutput(**output) for output in args.narrowband]
 
     return args
 

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -25,7 +25,7 @@ import argparse
 import asyncio
 import logging
 from collections.abc import Callable, Sequence
-from typing import TypeVar
+from typing import TypedDict, TypeVar
 
 import katsdpservices
 import katsdpsigproc.accel as accel
@@ -33,7 +33,7 @@ import prometheus_async
 from katsdpservices import get_interface_address
 from katsdpservices.aiomonitor import add_aiomonitor_arguments, start_aiomonitor
 from katsdpsigproc.abc import AbstractContext
-from katsdptelstate.endpoint import endpoint_list_parser
+from katsdptelstate.endpoint import Endpoint, endpoint_list_parser
 
 from .. import (
     DEFAULT_KATCP_HOST,
@@ -45,9 +45,11 @@ from .. import (
     __version__,
 )
 from ..monitor import FileMonitor, Monitor, NullMonitor
+from ..spead import DEFAULT_PORT
 from ..utils import add_signal_handlers, parse_source
 from . import DIG_SAMPLE_BITS_VALID
 from .engine import Engine
+from .output import NarrowbandOutput, WidebandOutput
 
 _T = TypeVar("_T")
 logger = logging.getLogger(__name__)
@@ -88,6 +90,55 @@ def comma_split(
     return func
 
 
+class NarrowbandOutputDict(TypedDict, total=False):
+    """Configuration options for a narrowband output.
+
+    Unlike :class:`NarrowbandOutput`, all the fields are optional, so that it
+    can be built up incrementally. They must all be filled in before using it
+    to construct a :class:`NarrowbandOutput`.
+    """
+
+    channels: int
+    decimation: int
+    dst: list[Endpoint]
+    taps: int
+    w_cutoff: float
+
+
+def parse_narrowband(value: str) -> NarrowbandOutputDict:
+    """Parse a string with a narrowband configuration.
+
+    The string has a comma-separated list of key=value pairs. See
+    :class:`NarrowbandOutputDict` for the valid keys and types. The following
+    keys are required:
+
+    - channels
+    - decimation
+    - dst
+    """
+    kws: NarrowbandOutputDict = {}
+    for part in value.split(","):
+        match part.split("=", 1):
+            case [key, data]:
+                match key:
+                    case _ if key in kws:
+                        raise ValueError(f"--narrowband: {key} specified twice")
+                    case "channels" | "decimation" | "taps":
+                        kws[key] = int(data)
+                    case "w_cutoff":
+                        kws[key] = float(data)
+                    case "dst":
+                        kws[key] = endpoint_list_parser(DEFAULT_PORT)(data)
+                    case _:
+                        raise ValueError(f"--narrowband: unknown key {key}")
+            case _:
+                raise ValueError(f"--narrowband: missing '=' in {part}")
+    for key in ["channels", "decimation", "dst"]:
+        if key not in kws:
+            raise ValueError(f"--narrowband: {key} is missing")
+    return kws
+
+
 def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     """Declare and parse command-line arguments.
 
@@ -99,6 +150,17 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         arguments from ``sys.argv`` will be used.
     """
     parser = argparse.ArgumentParser(prog="fgpu")
+    parser.add_argument(
+        "--narrowband",
+        type=parse_narrowband,
+        default=[],
+        action="append",
+        metavar="KEY=VALUE[,KEY=VALUE...]",
+        help=(
+            "Add a narrowband output (may be repeated). The required keys are: decimation, channels, dst. "
+            "Optional keys: taps, w_cutoff (default to the global options)"
+        ),
+    )
     parser.add_argument(
         "--katcp-host",
         type=str,
@@ -256,7 +318,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--monitor-log", help="File to write performance-monitoring data to")
     parser.add_argument("--version", action="version", version=__version__)
     parser.add_argument("src", type=parse_source, nargs=N_POLS, help="Source endpoints (or pcap file)")
-    parser.add_argument("dst", type=endpoint_list_parser(7148), help="Destination endpoints")
+    parser.add_argument("dst", type=endpoint_list_parser(DEFAULT_PORT), help="Destination endpoints")
     args = parser.parse_args(arglist)
 
     if args.use_peerdirect and not args.dst_ibv:
@@ -266,6 +328,15 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
             parser.error("Live source requires --src-interface")
     if len(args.dst) % len(args.dst_interface) != 0:
         parser.error("number of destinations must be divisible by number of destination interfaces")
+
+    # Convert narrowband from NarrowbandOutputDict to NarrowbandOutput
+    for output in args.narrowband:
+        if "taps" not in output:
+            output["taps"] = args.taps
+        if "w_cutoff" not in output:
+            output["taps"] = args.w_cutoff
+    args.narrowband = [NarrowbandOutput(*output) for output in args.narrowband]
+
     return args
 
 
@@ -286,6 +357,7 @@ def make_engine(ctx: AbstractContext, args: argparse.Namespace) -> tuple[Engine,
         monitor = NullMonitor()
 
     chunk_jones = accel.roundup(args.dst_chunk_jones, args.channels * args.spectra_per_heap)
+    wideband = WidebandOutput(channels=args.channels, taps=args.taps, w_cutoff=args.w_cutoff, dst=args.dst)
     engine = Engine(
         katcp_host=args.katcp_host,
         katcp_port=args.katcp_port,
@@ -297,13 +369,13 @@ def make_engine(ctx: AbstractContext, args: argparse.Namespace) -> tuple[Engine,
         src_comp_vector=args.src_comp_vector,
         src_packet_samples=args.src_packet_samples,
         src_buffer=args.src_buffer,
-        dst=args.dst,
         dst_interface=args.dst_interface,
         dst_ttl=args.dst_ttl,
         dst_ibv=args.dst_ibv,
         dst_packet_payload=args.dst_packet_payload,
         dst_affinity=args.dst_affinity,
         dst_comp_vector=args.dst_comp_vector,
+        outputs=[wideband] + args.narrowband,
         adc_sample_rate=args.adc_sample_rate,
         send_rate_factor=args.send_rate_factor,
         feng_id=args.feng_id,
@@ -311,9 +383,6 @@ def make_engine(ctx: AbstractContext, args: argparse.Namespace) -> tuple[Engine,
         chunk_samples=args.src_chunk_samples,
         spectra=chunk_jones // args.channels,
         spectra_per_heap=args.spectra_per_heap,
-        channels=args.channels,
-        taps=args.taps,
-        w_cutoff=args.w_cutoff,
         dig_sample_bits=args.dig_sample_bits,
         max_delay_diff=args.max_delay_diff,
         gain=args.gain,

--- a/src/katgpucbf/fgpu/output.py
+++ b/src/katgpucbf/fgpu/output.py
@@ -1,0 +1,45 @@
+################################################################################
+# Copyright (c) 2023, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Data structures capturing static configuration of a single output stream."""
+
+from dataclasses import dataclass
+
+from katsdptelstate.endpoint import Endpoint
+
+
+@dataclass
+class Output:
+    """Static configuration for an output stream."""
+
+    channels: int
+    taps: int
+    w_cutoff: float
+    dst: list[Endpoint]
+
+
+@dataclass
+class WidebandOutput(Output):
+    """Static configuration for a wideband output stream."""
+
+    pass
+
+
+@dataclass
+class NarrowbandOutput(Output):
+    """Static configuration for a narrowband stream."""
+
+    decimation: int

--- a/src/katgpucbf/spead.py
+++ b/src/katgpucbf/spead.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2022, National Research Foundation (SARAO)
+# Copyright (c) 2020-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -38,7 +38,10 @@ DIGITISER_STATUS_SATURATION_COUNT_SHIFT = 32
 #: SPEAD flavour used for all send streams
 FLAVOUR = spead2.Flavour(4, 64, 48, 0)
 
-# Format for immediate items
+#: Default UDP port
+DEFAULT_PORT = 7148
+
+#: Format for immediate items
 IMMEDIATE_FORMAT = [("u", FLAVOUR.heap_address_bits)]
 
 

--- a/src/katgpucbf/utils.py
+++ b/src/katgpucbf/utils.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2022, National Research Foundation (SARAO)
+# Copyright (c) 2020-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -28,6 +28,7 @@ import aiokatcp
 from katsdptelstate.endpoint import endpoint_list_parser
 
 from . import MIN_SENSOR_UPDATE_PERIOD, TIME_SYNC_TASK_NAME
+from .spead import DEFAULT_PORT
 
 _T = TypeVar("_T")
 
@@ -65,7 +66,7 @@ def add_signal_handlers(server: aiokatcp.DeviceServer) -> None:
 def parse_source(value: str) -> list[tuple[str, int]] | str:
     """Parse a string into a list of IP endpoints."""
     try:
-        endpoints = endpoint_list_parser(7148)(value)
+        endpoints = endpoint_list_parser(DEFAULT_PORT)(value)
         for endpoint in endpoints:
             ipaddress.IPv4Address(endpoint.host)  # Raises if invalid syntax
         return [(ep.host, ep.port) for ep in endpoints]

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2022, National Research Foundation (SARAO)
+# Copyright (c) 2020-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -45,6 +45,7 @@ from katgpucbf.xbgpu.engine import XBEngine
 
 from .. import DEFAULT_KATCP_HOST, DEFAULT_KATCP_PORT, DEFAULT_PACKET_PAYLOAD_BYTES, DEFAULT_TTL, __version__
 from ..monitor import FileMonitor, Monitor, NullMonitor
+from ..spead import DEFAULT_PORT
 from ..utils import add_signal_handlers, parse_source
 from .correlation import device_filter
 
@@ -209,7 +210,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--monitor-log", type=str, help="File to write performance-monitoring data to")
     parser.add_argument("--version", action="version", version=__version__)
     parser.add_argument("src", type=parse_source, help="Multicast address data is received from.")
-    parser.add_argument("dst", type=endpoint_parser(7148), help="Multicast address data is sent on.")
+    parser.add_argument("dst", type=endpoint_parser(DEFAULT_PORT), help="Multicast address data is sent on.")
 
     args = parser.parse_args(arglist)
 

--- a/test/fgpu/test_main.py
+++ b/test/fgpu/test_main.py
@@ -1,0 +1,94 @@
+################################################################################
+# Copyright (c) 2023, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Unit tests for argument parsing."""
+
+import pytest
+from katsdptelstate.endpoint import Endpoint
+
+from katgpucbf.fgpu.main import comma_split, parse_narrowband
+
+
+class TestCommaSplit:
+    """Test :func:`.comma_split`."""
+
+    def test_basic(self) -> None:
+        """Test normal usage, without optional features."""
+        assert comma_split(int)("3,5") == [3, 5]
+        assert comma_split(int)("3") == [3]
+        assert comma_split(int)("") == []
+
+    def test_bad_value(self) -> None:
+        """Test with a value that isn't valid for the element type."""
+        with pytest.raises(ValueError, match="invalid literal for int"):
+            assert comma_split(int)("3,hello")
+
+    def test_fixed_count(self) -> None:
+        """Test with a value for `count`."""
+        splitter = comma_split(int, 2)
+        assert splitter("3,5") == [3, 5]
+        with pytest.raises(ValueError, match="Expected 2 comma-separated fields, received 3"):
+            splitter("3,5,7")
+        with pytest.raises(ValueError, match="Expected 2 comma-separated fields, received 1"):
+            splitter("3")
+
+    def test_allow_single(self) -> None:
+        """Test with `allow_single`."""
+        splitter = comma_split(int, 2, allow_single=True)
+        assert splitter("3,5") == [3, 5]
+        assert splitter("3") == [3, 3]
+        with pytest.raises(ValueError, match="Expected 2 comma-separated fields, received 3"):
+            splitter("3,5,7")
+
+
+class TestParseNarrowband:
+    """Test :func:`.parse_narrowband`."""
+
+    def test_minimal(self) -> None:
+        """Test with the minimum required arguments."""
+        assert parse_narrowband("channels=1024,decimation=8,dst=239.1.2.3+1:7148") == {
+            "channels": 1024,
+            "decimation": 8,
+            "dst": [Endpoint("239.1.2.3", 7148), Endpoint("239.1.2.4", 7148)],
+        }
+
+    def test_maximal(self) -> None:
+        """Test with all valid arguments."""
+        assert parse_narrowband("channels=1024,decimation=8,taps=8,w_cutoff=0.5,dst=239.1.2.3+1:7148") == {
+            "channels": 1024,
+            "decimation": 8,
+            "taps": 8,
+            "w_cutoff": 0.5,
+            "dst": [Endpoint("239.1.2.3", 7148), Endpoint("239.1.2.4", 7148)],
+        }
+
+    @pytest.mark.parametrize(
+        "missing,value",
+        [
+            ("channels", "decimation=8,dst=239.1.2.3+1:7148"),
+            ("decimation", "channels=1024,dst=239.1.2.3+1:7148"),
+            ("dst", "channels=1024,decimation=8"),
+        ],
+    )
+    def test_missing_key(self, missing: str, value: str) -> None:
+        """Test without one of the required keys."""
+        with pytest.raises(ValueError, match=f"--narrowband: {missing} is missing"):
+            parse_narrowband(value)
+
+    def test_duplicate_key(self) -> None:
+        """Test with a key specified twice."""
+        with pytest.raises(ValueError, match="--narrowband: channels specified twice"):
+            parse_narrowband("channels=8,channels=9,decimation=8,dst=239.1.2.3+1:7148")


### PR DESCRIPTION
This adds a `--narrowband` command-line argument, which takes properties to set via comma-separated key=value pairs. I chose this approach rather than having lots of separate narrowband arguments (`--narrowband-channels`, `--narrowband-taps` etc) because this notation allows for multiple narrowband products to be specified (the original MK requirements called for 5 independently steerable narrowband streams, for example).

I've also put in some abstraction in Engine to take a list of outputs to produce, which should reduce the churn in the Engine constructor interface in future, although at the moment it only supports a single wideband output.

The list of parameters that are output-specific may grow in future; this is mostly about establishing the design.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-567.
