### PR TITLE
Update Docker image to CUDA 12.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@
 # nvidia and cuda runtime and development tools. pycuda needs nvcc, so
 # the development tools are necessary.
 
-FROM nvidia/cuda:11.7.1-devel-ubuntu22.04 as base
+FROM nvidia/cuda:12.0.1-devel-ubuntu22.04 as base
 
 # This "base" layer is modified to better support running with Vulkan. That's
 # needed by both build-base (used by Jenkins to run unit tests) and the final

--- a/README.md
+++ b/README.md
@@ -25,5 +25,5 @@ generations. Other platforms may well work, but have not been tested.
 ### Software
 * Ubuntu 22.04
 * Python 3.10.
-* CUDA version 11.4. (Most early development was done using 10.1, which may
+* CUDA version 12.0.1. (Most early development was done using 10.1, which may
   still work but has not been tested for some time.)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -255,7 +255,7 @@ pybtex==0.24.0
     #   sphinxcontrib-bibtex
 pybtex-docutils==1.0.2
     # via sphinxcontrib-bibtex
-pycuda==2022.2
+pycuda==2022.2.1
     # via
     #   -c requirements.txt
     #   katsdpsigproc

--- a/requirements.txt
+++ b/requirements.txt
@@ -110,7 +110,7 @@ psutil==5.9.2
     # via -r requirements.in
 pycparser==2.21
     # via cffi
-pycuda==2022.2
+pycuda==2022.2.1
     # via katsdpsigproc
 pygelf==0.4.2
     # via katsdpservices


### PR DESCRIPTION
This image will hopefully get more support from nvidia than the 11.7
image (which has not been updated lately with Ubuntu updates).

I didn't update to CUDA 12.1 because that wants nvidia driver >=530.30.02, which is not considered a "production" driver yet.

Also had to upgrade pycuda to make it build against CUDA 12.

Checklist is all N/A.

Closes NGC-911.