### PR TITLE
Refactor fgpu to support multiple output streams

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -119,9 +119,9 @@ autoclass_content = "both"
 
 todo_include_todos = True
 
-# Adds \usetikzlibrary{...} to the latex preamble. We need "chains" for
-# rendering flowcharts.
-tikz_tikzlibraries = "chains"
+# Adds \usetikzlibrary{...} to the latex preamble. We need "chains" and
+# "fit" for rendering flowcharts.
+tikz_tikzlibraries = "chains,fit"
 
 # Force MathJax to render as SVG rather than CHTML, to work around
 # https://github.com/mathjax/MathJax/issues/2701

--- a/doc/engines.rst
+++ b/doc/engines.rst
@@ -88,31 +88,42 @@ The general operation of the DSP engines is illustrated in the diagram below:
             flow/.style={->, >=latex, thick},
             queue/.style={flow, <->},
             fqueue/.style={queue, color=blue}}
-   \node[proc, start chain=going below, on chain] (align) {Align, copy to GPU};
+   \begin{scope}[start chain=chain going below]
+   \node[proc, on chain] (align) {Align, copy to GPU};
    \node[pproc, draw=none, anchor=west,
          start chain=rx0 going above, on chain=rx0] (align0) at (align.west) {};
    \node[pproc, draw=none, anchor=east,
          start chain=rx1 going above, on chain=rx1] (align1) at (align.east) {};
-   \node[proc, on chain] (process) {GPU processing};
-   \node[proc, on chain] (download) {Copy from GPU};
-   \node[proc, on chain] (transmit) {Transmit};
-   \node[pproc, draw=none, anchor=west,
-         start chain=tx0 going below, on chain=tx0] (transmit0) at (transmit.west) {};
-   \node[pproc, draw=none, anchor=east,
-         start chain=tx1 going below, on chain=tx1] (transmit1) at (transmit.east) {};
+   \begin{scope}[start branch=stream0 going below]
+     \node[proc, on chain=going below left] (process0) {GPU processing};
+   \end{scope}
+   \begin{scope}[start branch=stream1 going below]
+     \node[proc, on chain=going below right] (process1) {GPU processing};
+   \end{scope}
+   \foreach \s in {0, 1} {
+     \begin{scope}[continue chain=chain/stream\s]
+     \node[proc, on chain] (download\s) {Copy from GPU};
+     \node[proc, on chain] (transmit\s) {Transmit};
+     \node[pproc, draw=none, anchor=west,
+           start chain=tx\s-0 going below, on chain=tx\s-0] (transmit\s-0) at (transmit\s.west) {};
+     \node[pproc, draw=none, anchor=east,
+           start chain=tx\s-1 going below, on chain=tx\s-1] (transmit\s-1) at (transmit\s.east) {};
+     \foreach \i in {0, 1} {
+       \node[pproc, on chain=tx\s-\i] (outstream\s-\i) {Stream};
+       \draw[flow] (transmit\s-\i) -- (outstream\s-\i);
+     }
+     \draw[queue] (align) -- (process\s);
+     \draw[queue] (process\s) -- (download\s);
+     \draw[queue] (download\s) -- (transmit\s);
+     \end{scope}
+   }
    \foreach \i in {0, 1} {
      \node[pproc, on chain=rx\i] (receive\i) {Receive};
      \node[pproc, on chain=rx\i] (stream\i) {Stream};
-     \node[pproc, on chain=tx\i] (outstream\i) {Stream};
-   }
-   \foreach \i in {0, 1} {
      \draw[flow] (stream\i) -- (receive\i);
      \draw[queue] (receive\i) -- (align\i);
-     \draw[flow] (transmit\i) -- (outstream\i);
    }
-   \draw[queue] (align) -- (process);
-   \draw[queue] (process) -- (download);
-   \draw[queue] (download) -- (transmit);
+   \end{scope}
 
 The F-engine uses two input streams and aligns two incoming polarisations, but
 in the XB-engine there is only one.
@@ -143,6 +154,14 @@ approach allows all memory to be allocated up front. Slow components thus
 cause back-pressure on up-stream components by not returning buffers through
 the free queue fast enough. The number of buffers needs to be large enough to
 smooth out jitter in processing times.
+
+A special case is the split from the receiver into multiple processing
+pipelines. In this case each processing pipeline has an incoming queue with new
+data (and each buffer is placed in each of these queues), but a single queue
+for returning free buffers. Since a buffer can only be placed on the free queue
+once it has been processed by all the pipelines, a reference count is held with
+the buffer to track how many usages it has. This should not be confused with
+the Python interpreter's reference count, although the purpose is similar.
 
 Transfers and events
 ^^^^^^^^^^^^^^^^^^^^

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -419,7 +419,7 @@ class Pipeline:
         self.gains = np.zeros((output.channels, self.pols), np.complex64)
         self._init_delay_gain()
 
-        self._descriptor_heap = send.make_descriptor_heap(
+        self.descriptor_heap = send.make_descriptor_heap(
             channels_per_substream=output.channels // len(output.dst),
             spectra_per_heap=engine.spectra_per_heap,
         )
@@ -1502,7 +1502,7 @@ class Engine(aiokatcp.DeviceServer):
         for pipeline in self._pipelines:
             descriptor_sender = DescriptorSender(
                 self._send_streams[0],
-                pipeline._descriptor_heap,  # TODO[nb]: make public
+                pipeline.descriptor_heap,
                 self.n_ants * descriptor_interval_s,
                 (self.feng_id + 1) * descriptor_interval_s,
                 all_substreams=True,  # TODO[nb]: need to restrict to the relevant substreams

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -951,7 +951,7 @@ class Engine(aiokatcp.DeviceServer):
     chunk_samples
         Number of samples in each input chunk, excluding padding samples.
     chunk_jones
-        Number of Jones vectorsin each output chunk.
+        Number of Jones vectors in each output chunk.
     spectra_per_heap
         Number of spectra in each output heap.
     max_delay_diff

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1233,7 +1233,7 @@ class Engine(aiokatcp.DeviceServer):
 
     @staticmethod
     async def _push_recv_chunks(chunks: Iterable[recv.Chunk], events: Iterable[AbstractEvent]) -> None:
-        """Return chunks to the streams once `event` has fired.
+        """Return chunks to the streams once `events` have fired.
 
         This is only used when using vkgdr.
         """

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -428,7 +428,7 @@ class Pipeline:
 
     def _init_delay_gain(self) -> None:
         """Initialise the delays and gains."""
-        # TODO: create per-pipeline sensors
+        # TODO[nb]: create per-pipeline sensors
         for pol in range(N_POLS):
             delay_model = MultiDelayModel(
                 callback_func=partial(self.update_delay_sensor, delay_sensor=self.engine.sensors[f"input{pol}.delay"])

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1029,7 +1029,6 @@ class Engine(aiokatcp.DeviceServer):
         self._src_ibv = src_ibv
         self.src_layout = recv.Layout(dig_sample_bits, src_packet_samples, chunk_samples, mask_timestamp)
         self.adc_sample_rate = adc_sample_rate
-        self.send_rate_factor = send_rate_factor
         self.feng_id = feng_id
         self.n_ants = num_ants
         self.spectra_per_heap = spectra_per_heap

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -397,10 +397,12 @@ class Pipeline:
         self.output = output
         self.substreams = substreams
         assert len(substreams) == len(output.dst)
-        self._in_queue: asyncio.Queue[InItem | None] = engine.monitor.make_queue("in_queue", engine.n_in)
-        self._out_queue: asyncio.Queue[OutItem | None] = engine.monitor.make_queue("out_queue", n_out)
-        self._out_free_queue: asyncio.Queue[OutItem] = engine.monitor.make_queue("out_free_queue", n_out)
-        self._send_free_queue: asyncio.Queue[send.Chunk] = engine.monitor.make_queue("send_free_queue", n_send)
+        self._in_queue: asyncio.Queue[InItem | None] = engine.monitor.make_queue(f"{output.name}.in_queue", engine.n_in)
+        self._out_queue: asyncio.Queue[OutItem | None] = engine.monitor.make_queue(f"{output.name}.out_queue", n_out)
+        self._out_free_queue: asyncio.Queue[OutItem] = engine.monitor.make_queue(f"{output.name}.out_free_queue", n_out)
+        self._send_free_queue: asyncio.Queue[send.Chunk] = engine.monitor.make_queue(
+            f"{output.name}.send_free_queue", n_send
+        )
         self._in_item: InItem | None = None
 
         # Initialise self._compute

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -17,6 +17,7 @@
 """Engine class, which combines all the processing steps for a single digitiser data stream."""
 
 import asyncio
+import itertools
 import logging
 import math
 import numbers
@@ -139,9 +140,12 @@ class InItem(QueueItem):
 
     Parameters
     ----------
-    compute
-        F-engine Operation Sequence detailing the computation operations which
-        will take place on the data in :attr:`PolInItem.samples`.
+    context
+        CUDA context in which to allocate memory.
+    layout
+        Layout of the source stream.
+    samples
+        Number of digitised samples to hold, per polarisation
     timestamp
         Timestamp of the oldest digitiser sample represented in the data.
     packet_samples
@@ -158,21 +162,30 @@ class InItem(QueueItem):
     #: Bitwidth of the data in :attr:`PolInItem.samples`
     dig_sample_bits: int
 
-    def __init__(self, compute: Compute, timestamp: int = 0, *, packet_samples: int, use_vkgdr: bool = False) -> None:
-        self.dig_sample_bits = compute.dig_sample_bits
+    def __init__(
+        self,
+        context: AbstractContext,
+        layout: recv.Layout,
+        samples: int,
+        timestamp: int = 0,
+        *,
+        use_vkgdr: bool = False,
+    ) -> None:
+        self.dig_sample_bits = layout.sample_bits
         self.pol_data = []
-        present_size = accel.divup(compute.samples, packet_samples)
-        for pol in range(N_POLS):
+        present_size = accel.divup(samples, layout.heap_samples)
+        data_size = samples * self.dig_sample_bits // BYTE_BITS
+        for _pol in range(N_POLS):
             if use_vkgdr:
                 # Memory belongs to the chunks, and we set samples when
                 # initialising the item from the chunks.
-                samples = None
+                sample_data = None
             else:
-                allocator = accel.DeviceAllocator(compute.template.context)
-                samples = compute.slots[f"in{pol}"].allocate(allocator, bind=False)
+                # Compute requires 1 byte of padding
+                sample_data = accel.DeviceArray(context, (data_size,), np.uint8, padded_shape=(data_size + 1,))
             self.pol_data.append(
                 PolInItem(
-                    samples=samples,
+                    samples=sample_data,
                     present=np.zeros(present_size, dtype=bool),
                     present_cumsum=np.zeros(present_size + 1, np.uint32),
                 )
@@ -342,6 +355,572 @@ def dig_pwr_dbfs_status(value: float) -> aiokatcp.Sensor.Status:
         return aiokatcp.Sensor.Status.WARN
 
 
+def _parse_gains(self, *values: str, channels: int, default_gain: complex, allow_default: bool) -> np.ndarray:
+    """Parse the gains passed to :meth:`request-gain` or :meth:`request-gain-all`.
+
+    If a single value is given it is expanded to a value per channel. If
+    `allow_default` is true, the string "default" may be given to restore
+    the default gains set via command line.
+
+    The caller must ensure that `values` contains either 1 or `channels`
+    items. :meth:`request_gain` handles the case where no values are given
+    for querying existing gains.
+
+    Failures are reported by raising an appropriate
+    :exc:`aiokatcp.FailReply`.
+    """
+    if allow_default and values == ("default",):
+        gains = np.full(channels, default_gain, dtype=np.complex64)
+    else:
+        try:
+            gains = np.array([complex(v) for v in values], dtype=np.complex64)
+        except ValueError:
+            raise aiokatcp.FailReply("invalid formatting of complex number")
+    if not np.all(np.isfinite(gains)):
+        raise aiokatcp.FailReply("non-finite gains are not permitted")
+    if len(gains) == 1:
+        gains = gains.repeat(channels)
+    return gains
+
+
+class Pipeline:
+    """Processing pipeline for a single output stream."""
+
+    def __init__(self, output: Output, engine: "Engine") -> None:
+        # Tuning knobs not exposed via arguments
+        n_send = 4
+        n_out = n_send if engine.use_peerdirect else 2
+
+        self.engine = engine
+        self.output = output
+        self._out_queue: asyncio.Queue[OutItem | None] = engine.monitor.make_queue("out_queue", n_out)
+        self._out_free_queue: asyncio.Queue[OutItem] = engine.monitor.make_queue("out_free_queue", n_out)
+        self._send_free_queue: asyncio.Queue[send.Chunk] = engine.monitor.make_queue("send_free_queue", n_send)
+        self._in_items: deque[InItem] = deque()
+
+        # Initialise self._compute
+        context = engine.upload_queue.context
+        compute_queue = context.create_command_queue()
+        template = ComputeTemplate(context, output.taps, output.channels, engine.src_layout.sample_bits)
+        self._compute = template.instantiate(compute_queue, engine.samples, self.spectra, engine.spectra_per_heap)
+        device_weights = self._compute.slots["weights"].allocate(accel.DeviceAllocator(context))
+        device_weights.set(compute_queue, generate_weights(output.channels, output.taps, output.w_cutoff))
+
+        # Initialize sending
+        self.send_chunks = self._init_send(len(output.dst), engine.use_peerdirect)
+        self._out_item = self._out_free_queue.get_nowait()
+        self._out_item.reset_all(self._compute.command_queue)
+
+        # Initialize delays and gains
+        self.delay_models: list[MultiDelayModel] = []
+        self.gains = np.zeros((output.channels, self.pols), np.complex64)
+        self._init_delay_gain()
+
+        self._descriptor_heap = send.make_descriptor_heap(
+            channels_per_substream=output.channels // len(output.dst),
+            spectra_per_heap=engine.spectra_per_heap,
+        )
+
+    def _init_delay_gain(self) -> None:
+        """Initialise the delays and gains."""
+        # TODO: create per-pipeline sensors
+        for pol in range(N_POLS):
+            delay_model = MultiDelayModel(
+                callback_func=partial(self.update_delay_sensor, delay_sensor=self.engine.sensors[f"input{pol}.delay"])
+            )
+            self.delay_models.append(delay_model)
+
+        for pol in range(N_POLS):
+            self.set_gains(pol, np.full(self.output.channels, self.engine.default_gain, dtype=np.complex64))
+
+    def _init_send(self, substreams: int, use_peerdirect: bool) -> list[send.Chunk]:
+        """Initialise the send side of the pipeline."""
+        send_chunks: list[send.Chunk] = []
+        for _ in range(self._out_free_queue.maxsize):
+            item = OutItem(self._compute)
+            if use_peerdirect:
+                dev_buffer = item.spectra.buffer.gpudata.as_buffer(item.spectra.buffer.nbytes)
+                # buf is structurally a numpy array, but the pointer in it is a CUDA
+                # pointer and so actually trying to use it as such will cause a
+                # segfault.
+                buf = np.frombuffer(dev_buffer, dtype=item.spectra.dtype).reshape(item.spectra.shape)
+                chunk = send.Chunk(
+                    buf,
+                    saturated=item.saturated.empty_like(),
+                    substreams=substreams,
+                    feng_id=self.engine.feng_id,
+                )
+                item.chunk = chunk
+                send_chunks.append(chunk)
+            self._out_free_queue.put_nowait(item)
+
+        spectra = self._compute.spectra
+        if not use_peerdirect:
+            # When using PeerDirect, the chunks are created along with the items
+            heaps = spectra // self.engine.spectra_per_heap
+            send_shape = (heaps, self.channels, self.engine.spectra_per_heap, N_POLS, COMPLEX)
+            for _ in range(self._send_free_queue.maxsize):
+                send_chunks.append(
+                    send.Chunk(
+                        accel.HostArray(send_shape, send.SEND_DTYPE, context=self._compute.template.context),
+                        accel.HostArray((heaps, N_POLS), np.uint32, context=self._compute.template.context),
+                        substreams=substreams,
+                        feng_id=self.engine.feng_id,
+                    )
+                )
+                self._send_free_queue.put_nowait(send_chunks[-1])
+        return send_chunks
+
+    @property
+    def spectra(self) -> int:  # noqa: D401
+        """Number of spectra per output chunk."""
+        return self.engine.chunk_jones // self.output.channels
+
+    @property
+    def pols(self) -> int:  # noqa: D401
+        """Number of polarisations."""
+        return N_POLS
+
+    @property
+    def channels(self) -> int:  # noqa: D401
+        """Number of channels into which the incoming signal is decomposed."""
+        return self._compute.template.channels
+
+    @property
+    def taps(self) -> int:  # noqa: D401
+        """Number of taps in the PFB-FIR filter."""
+        return self._compute.template.taps
+
+    @property
+    def spectra_samples(self) -> int:  # noqa: D401
+        """Number of incoming digitiser samples needed per spectrum.
+
+        Note that this is the spacing between spectra. Each spectrum uses
+        an overlapping window with more samples than this.
+        """
+        return self.output.spectra_samples
+
+    @property
+    def data_heaps(self) -> int:
+        """Maximum number of data heaps that can be in flight."""
+        return len(self.send_chunks) * self.spectra // self.engine.spectra_per_heap * len(self.output.dst)
+
+    def add_in_item(self, item: InItem) -> None:
+        """Append a newly-received :class:`~.InItem`."""
+        self._in_items.append(item)
+        # print(f'Received input with timestamp {self._in_items[-1].timestamp}, '
+        #       f'{self._in_items[-1].n_samples} samples')
+
+        # Make sure that all events associated with the item are past.
+        self._in_items[-1].enqueue_wait_for_events(self._compute.command_queue)
+
+    async def _fill_in(self) -> bool:
+        """Load sufficient InItems to continue processing.
+
+        Tries to get at least two items into ``self._in_items``, and if
+        loading a second item that is adjacent to the first, copies the overlap
+        region.
+
+        Returns true if processing can proceed, false if the stream is
+        exhausted.
+        """
+        if len(self._in_items) == 0:
+            if not (await self.engine._next_in()):
+                return False
+        if len(self._in_items) == 1:
+            # Copy the head of the new chunk to the tail of the older chunk
+            # to allow for PFB windows to fit and for some protection against
+            # sharp changes in delay.
+            #
+            # This could only fail if we'd lost a whole input chunk of
+            # data from the digitiser. In that case the data we'd like
+            # to copy is missing so we can't do this step.
+            #
+            # TODO[nb]: This will need to be reworked to be done by the engine.
+            chunk_packets = self._in_items[0].n_samples // self.engine.src_layout.heap_samples
+            copy_packets = len(self._in_items[0].pol_data[0].present) - chunk_packets
+            if (await self.engine._next_in()) and self._in_items[0].end_timestamp == self._in_items[1].timestamp:
+                sample_bits = self._in_items[0].dig_sample_bits
+                copy_samples = self._in_items[0].capacity - self._in_items[0].n_samples
+                copy_samples = min(copy_samples, self._in_items[1].n_samples)
+                copy_bytes = copy_samples * sample_bits // BYTE_BITS
+                for pol_data0, pol_data1 in zip(self._in_items[0].pol_data, self._in_items[1].pol_data):
+                    assert pol_data0.samples is not None
+                    assert pol_data1.samples is not None
+                    pol_data1.samples.copy_region(
+                        self._compute.command_queue,
+                        pol_data0.samples,
+                        np.s_[:copy_bytes],
+                        np.s_[-copy_bytes:],
+                    )
+                    pol_data0.present[-copy_packets:] = pol_data1.present[:copy_packets]
+                self._in_items[0].n_samples += copy_samples
+            else:
+                for pol_data in self._in_items[0].pol_data:
+                    pol_data.present[-copy_packets:] = 0  # Mark tail as absent, for each pol
+            # Update the cumulative sums. Note that during shutdown this may be
+            # done more than once, but since it is shutdown the performance
+            # implications aren't too important.
+            # np.cumsum doesn't provide an initial zero, so we output starting at
+            # position 1.
+            for pol_data in self._in_items[0].pol_data:
+                np.cumsum(pol_data.present, dtype=pol_data.present_cumsum.dtype, out=pol_data.present_cumsum[1:])
+        return True
+
+    def _pop_in(self) -> None:
+        """Remove the oldest InItem."""
+        # TODO[nb]: needs to be re-worked with refcounting
+        item = self._in_items.popleft()
+        self.engine.free_in_item(item)
+
+    async def _next_out(self, new_timestamp: int) -> OutItem:
+        """Grab the next free OutItem in the queue."""
+        with self.engine.monitor.with_state(f"{self.output.name}.run_processing", "wait out_free_queue"):
+            item = await self._out_free_queue.get()
+
+        # Just make double-sure that all events associated with the item are past.
+        item.enqueue_wait_for_events(self._compute.command_queue)
+        item.reset_all(self._compute.command_queue, new_timestamp)
+        return item
+
+    async def _flush_out(self, new_timestamp: int) -> None:
+        """Start the backend processing and prepare the data for transmission.
+
+        Kick off the `run_backend()` processing, and put an event on the
+        relevant command queue. This lets the next coroutine (run_transmit) know
+        that the backend processing is finished, and the data can be transmitted
+        out.
+
+        Parameters
+        ----------
+        new_timestamp
+            The timestamp that will immediately follow the current OutItem.
+        """
+        # Round down to a multiple of accs (don't send heap with partial
+        # data).
+        accs = self._out_item.n_spectra // self.engine.spectra_per_heap
+        self._out_item.n_spectra = accs * self.engine.spectra_per_heap
+        if self._out_item.n_spectra > 0:
+            # Take a copy of the gains synchronously. This avoids race conditions
+            # with gains being updated at the same time as they're in the
+            # middle of being transferred.
+            self._out_item.gains[:] = self.gains
+            # TODO: only need to copy the relevant region, and can limit
+            # postprocessing to the relevant range (the FFT size is baked into
+            # the plan, so is harder to modify on the fly).
+            # Without this, saturation counts can be wrong.
+            self._compute.buffer("fine_delay").set_async(self._compute.command_queue, self._out_item.fine_delay)
+            self._compute.buffer("phase").set_async(self._compute.command_queue, self._out_item.phase)
+            self._compute.buffer("gains").set_async(self._compute.command_queue, self._out_item.gains)
+            self._compute.run_backend(self._out_item.spectra, self._out_item.saturated)
+            # Note: we also need to wait for any frontend calls because they
+            # write directly to self._out_item.dig_total_power, but this
+            # marker will take care of that too.
+            self._out_item.add_marker(self._compute.command_queue)
+            self._out_queue.put_nowait(self._out_item)
+            # TODO: could set it to None, since we only need it when we're
+            # ready to flush again?
+            self._out_item = await self._next_out(new_timestamp)
+        else:
+            self._out_item.timestamp = new_timestamp
+
+    async def run_processing(self) -> None:
+        """Do the hard work of the F-engine.
+
+        This function takes place entirely on the GPU. First, a little bit of
+        the next chunk is copied to the end of the previous one, to allow for
+        the overlap required by the PFB. Coarse delay happens. Then a batch FFT
+        operation is applied, and finally, fine-delay, phase correction,
+        quantisation and corner-turn are performed.
+        """
+        while await self._fill_in():
+            # If the input starts too late for the next expected timestamp,
+            # we need to skip ahead to the next heap after the start, and
+            # flush what we already have.
+            start_timestamp = self._out_item.end_timestamp
+            orig_start_timestamps = [model(start_timestamp)[0] for model in self.delay_models]
+            if min(orig_start_timestamps) < self._in_items[0].timestamp:
+                align = self.engine.spectra_per_heap * self.spectra_samples
+                # This loop is needed because MultiDelayModel is not necessarily
+                # monotonic, and so simply taking the larger of the two skip
+                # results does not guarantee a suitable timestamp.
+                while min(orig_start_timestamps) < self._in_items[0].timestamp:
+                    start_timestamp = max(
+                        model.skip(self._in_items[0].timestamp, start_timestamp + 1, align)
+                        for model in self.delay_models
+                    )
+                    orig_start_timestamps = [model(start_timestamp)[0] for model in self.delay_models]
+                await self._flush_out(start_timestamp)
+            # When we add new spectra they must follow contiguously for any
+            # that we've already buffered.
+            assert start_timestamp == self._out_item.end_timestamp
+
+            # Compute the coarse delay for the first sample.
+            # `orig_timestamp` is the timestamp of first sample from the input
+            # to process in the PFB to produce the output spectrum with
+            # `timestamp`. `offset` is the sample index corresponding to
+            # `orig_timestamp` within the InItem.
+            start_coarse_delays = [start_timestamp - orig_timestamp for orig_timestamp in orig_start_timestamps]
+            offsets = [orig_timestamp - self._in_items[0].timestamp for orig_timestamp in orig_start_timestamps]
+
+            # Identify a block of frontend work. We can grow it until
+            # - we run out of the current input array;
+            # - we fill up the output array; or
+            # - the coarse delay changes.
+            # We speculatively calculate delays until one of the first two is
+            # met, then truncate if we observe a coarse delay change. Note:
+            # max_end_in is computed assuming the coarse delay does not change.
+            max_end_in = (
+                self._in_items[0].end_timestamp + min(start_coarse_delays) - self.taps * self.spectra_samples + 1
+            )
+            max_end_out = self._out_item.timestamp + self._out_item.capacity * self.spectra_samples
+            max_end = min(max_end_in, max_end_out)
+            # Speculatively evaluate until one of the first two conditions is met
+            timestamps = np.arange(start_timestamp, max_end, self.spectra_samples)
+            orig_timestamps, fine_delays, phase = _sample_models(
+                self.delay_models, start_timestamp, max_end, self.spectra_samples
+            )
+            # timestamps can be empty if we fast-forwarded the output right over the
+            # end of the current input item, and it causes problems if we don't check
+            # for it (argmax of an empty sequence).
+            if timestamps.size:
+                for pol in range(len(orig_timestamps)):
+                    coarse_delays = timestamps - orig_timestamps[pol]
+                    # Uses fact that argmax returns first maximum i.e. first true value
+                    delay_change = int(np.argmax(coarse_delays != start_coarse_delays[pol]))
+                    if coarse_delays[delay_change] != start_coarse_delays[pol]:
+                        logger.debug(
+                            "Coarse delay on pol %d changed from %d to %d at %d",
+                            pol,
+                            start_coarse_delays[pol],
+                            coarse_delays[delay_change],
+                            orig_timestamps[pol, delay_change],
+                        )
+                        timestamps = timestamps[:delay_change]
+                        orig_timestamps = orig_timestamps[:, :delay_change]
+                        fine_delays = fine_delays[:, :delay_change]
+                        phase = phase[:, :delay_change]
+                batch_spectra = orig_timestamps.shape[1]
+
+                # Here we run the "frontend" which handles:
+                # - 10-bit to float conversion
+                # - Coarse delay
+                # - The PFB-FIR.
+                if batch_spectra > 0:
+                    logging.debug("Processing %d spectra", batch_spectra)
+                    out_slice = np.s_[self._out_item.n_spectra : self._out_item.n_spectra + batch_spectra]
+                    self._out_item.fine_delay[out_slice] = fine_delays.T
+                    # Divide by pi because the arguments of sincospif() used in the
+                    # kernel are in radians/PI.
+                    self._out_item.phase[out_slice] = phase.T / np.pi
+                    samples = []
+                    for pol_data in self._in_items[0].pol_data:
+                        assert pol_data.samples is not None
+                        samples.append(pol_data.samples)
+                    self._compute.run_frontend(
+                        samples, self._out_item.dig_total_power, offsets, self._out_item.n_spectra, batch_spectra
+                    )
+                    # Replace events rather than adding to it, since this event
+                    # will be sequenced after any prior events
+                    self._in_items[0].events = [self._compute.command_queue.enqueue_marker()]
+                    self._out_item.n_spectra += batch_spectra
+                    # Work out which output spectra contain missing data.
+                    self._out_item.present[out_slice] = True
+                    for pol, pol_data in enumerate(self._in_items[0].pol_data):
+                        # Offset in the chunk of the first sample for each spectrum
+                        first_offset = np.arange(
+                            offsets[pol],
+                            offsets[pol] + batch_spectra * self.spectra_samples,
+                            self.spectra_samples,
+                        )
+                        # Offset of the last sample (inclusive, rather than past-the-end)
+                        last_offset = first_offset + self.taps * self.spectra_samples - 1
+                        first_packet = first_offset // self.engine.src_layout.heap_samples
+                        # last_packet is exclusive
+                        last_packet = last_offset // self.engine.src_layout.heap_samples + 1
+                        present_packets = pol_data.present_cumsum[last_packet] - pol_data.present_cumsum[first_packet]
+                        self._out_item.present[out_slice] &= present_packets == last_packet - first_packet
+
+            # The _flush_out method calls the "backend" which triggers the FFT
+            # and postproc operations.
+            end_timestamp = self._out_item.end_timestamp
+            if end_timestamp >= max_end_out:
+                # We've filled up the output buffer.
+                await self._flush_out(end_timestamp)
+
+            if end_timestamp >= max_end_in:
+                # We've exhausted the input buffer.
+                # TODO: should maybe also do this if _in_items[1] would work
+                # just as well and we've filled the output buffer.
+                self._pop_in()
+        # Timestamp mostly doesn't matter because we're finished, but if a
+        # katcp request arrives at this point we want to ensure the
+        # steady-state-timestamp sensor is updated to a later timestamp than
+        # anything we'll actually send.
+        await self._flush_out(self._out_item.end_timestamp)
+        logger.debug("run_processing completed")
+        self._out_queue.put_nowait(None)
+
+    def _chunk_finished(self, chunk: send.Chunk, future: asyncio.Future) -> None:
+        """Return a chunk to the free queue after it has completed transmission.
+
+        This is intended to be used as a callback on an :class:`asyncio.Future`.
+        """
+        if chunk.cleanup is not None:
+            chunk.cleanup()
+            chunk.cleanup = None  # Potentially helps break reference cycles
+        try:
+            future.result()  # No result, but want the exception
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.exception("Error sending chunk")
+
+    async def run_transmit(self, streams: list["spead2.send.asyncio.AsyncStream"]) -> None:
+        """Get the processed data from the GPU to the Network.
+
+        This could be done either with or without PeerDirect. In the
+        non-PeerDirect case, :class:`OutItem` objects are pulled from the
+        `_out_queue`. We wait for the events that mark the end of the processing,
+        then copy the data to host memory before turning it over to the
+        :obj:`sender` for transmission on the network. The "empty" item is then
+        returned to :meth:`run_processing` via the `_out_free_queue`, and once
+        the chunk has been transmitted it is returned to `_send_free_queue`.
+
+        In the PeerDirect case, the item and the chunk are bound together and
+        share memory. In this case `_send_free_queue` is unused. The item is
+        only returned to `_out_free_queue` once it has been fully transmitted.
+
+        Parameters
+        ----------
+        streams
+            The streams transmitting data.
+        """
+        task: asyncio.Future | None = None
+        last_end_timestamp: int | None = None
+        context = self._compute.template.context
+        func_name = f"{self.output.name}.run_transmit"
+        # Scratch space for transferring digitiser power
+        dig_total_power = [self._compute.slots[f"dig_total_power{pol}"].allocate_host(context) for pol in range(N_POLS)]
+        while True:
+            with self.engine.monitor.with_state(func_name, "wait out_queue"):
+                out_item = await self._out_queue.get()
+            if not out_item:
+                break
+            events = []
+            if out_item.chunk is not None:
+                # We're using PeerDirect
+                chunk = out_item.chunk
+                chunk.cleanup = partial(self._out_free_queue.put_nowait, out_item)
+                events.extend(out_item.events)
+            else:
+                with self.engine.monitor.with_state(func_name, "wait send_free_queue"):
+                    chunk = await self._send_free_queue.get()
+                chunk.cleanup = partial(self._send_free_queue.put_nowait, chunk)
+                self.engine.download_queue.enqueue_wait_for_events(out_item.events)
+                assert isinstance(chunk.data, accel.HostArray)
+                # TODO: use get_region since it might be partial
+                out_item.spectra.get_async(self.engine.download_queue, chunk.data)
+            out_item.saturated.get_async(self.engine.download_queue, chunk.saturated)
+            for pol in range(N_POLS):
+                out_item.dig_total_power[pol].get_async(self.engine.download_queue, dig_total_power[pol])
+            events.append(self.engine.download_queue.enqueue_marker())
+
+            chunk.timestamp = out_item.timestamp
+            # Each frame is valid if all spectra in it are valid
+            out_item.present.reshape(-1, self.engine.spectra_per_heap).all(axis=-1, out=chunk.present)
+            with self.engine.monitor.with_state(func_name, "wait transfer"):
+                await async_wait_for_events(events)
+
+            for pol in range(N_POLS):
+                total_power = float(dig_total_power[pol])
+                avg_power = total_power / (out_item.n_spectra * self.spectra_samples)
+                # Normalise relative to full scale. The factor of 2 is because we
+                # want 1.0 to correspond to a sine wave rather than a square wave.
+                avg_power /= ((1 << (self.engine.src_layout.sample_bits - 1)) - 1) ** 2 / 2
+                avg_power_db = 10 * math.log10(avg_power) if avg_power else -math.inf
+                # TODO[nb]: needs to be computed (or at least set) by just one of
+                # the streams.
+                self.engine.sensors[f"input{pol}.dig-pwr-dbfs"].set_value(
+                    avg_power_db, timestamp=self.engine.time_converter.adc_to_unix(out_item.end_timestamp)
+                )
+
+            n_frames = out_item.n_spectra // self.engine.spectra_per_heap
+            if last_end_timestamp is not None and out_item.timestamp > last_end_timestamp:
+                # Account for heaps skipped between the end of the previous out_item and the
+                # start of the current one.
+                skipped_samples = out_item.timestamp - last_end_timestamp
+                skipped_frames = skipped_samples // (self.engine.spectra_per_heap * self.spectra_samples)
+                send.skipped_heaps_counter.inc(skipped_frames * streams[0].num_substreams)
+            last_end_timestamp = out_item.end_timestamp
+            out_item.reset()  # Safe to call in PeerDirect mode since it doesn't touch the raw data
+            if out_item.chunk is None:
+                # We're not in PeerDirect mode
+                # (when we are the cleanup callback returns the item)
+                self._out_free_queue.put_nowait(out_item)
+            task = asyncio.create_task(chunk.send(streams, n_frames, self.engine.time_converter, self.engine.sensors))
+            task.add_done_callback(partial(self._chunk_finished, chunk))
+
+        if task:
+            try:
+                await task
+            except Exception:
+                pass  # It's already logged by the chunk_finished callback
+        stop_heap = spead2.send.Heap(send.FLAVOUR)
+        stop_heap.add_end()
+        for substream_index in range(streams[0].num_substreams):
+            await streams[0].async_send_heap(stop_heap, substream_index=substream_index)
+        logger.debug("run_transmit completed")
+
+    def delay_update_timestamp(self) -> int:
+        """Return a timestamp by which an update to the delay model will take effect."""
+        # end_timestamp is updated whenever delays are written into the out_item
+        return self._out_item.end_timestamp
+
+    def update_delay_sensor(self, delay_models: Sequence[LinearDelayModel], *, delay_sensor: aiokatcp.Sensor) -> None:
+        """Update the delay sensor upon loading of a new model.
+
+        Accepting the delay_models as a read-only Sequence from the
+        MultiDelayModel, even though we only need the first one to update
+        the sensor.
+
+        The delay and phase-rate values need to be scaled back to their
+        original values (delay (s), phase-rate (rad/s)).
+        """
+        logger.debug("Updating delay sensor: %s", delay_sensor.name)
+
+        orig_delay = delay_models[0].delay / self.engine.adc_sample_rate
+        phase_rate_correction = 0.5 * np.pi * delay_models[0].delay_rate
+        orig_phase = wrap_angle(delay_models[0].phase - 0.5 * np.pi * delay_models[0].delay)
+        orig_phase_rate = (delay_models[0].phase_rate - phase_rate_correction) * self.engine.adc_sample_rate
+        delay_sensor.value = (
+            f"({delay_models[0].start}, "
+            f"{orig_delay}, "
+            f"{delay_models[0].delay_rate}, "
+            f"{orig_phase}, "
+            f"{orig_phase_rate})"
+        )
+
+    def set_gains(self, input: int, gains: np.ndarray) -> None:
+        """Set the eq gains for one polarisation and update the sensor.
+
+        The `gains` must contain one entry per channel; the shortcut of
+        supplying a single value is handled by :meth:`request_gain`.
+        """
+        self.gains[:, input] = gains
+        # This timestamp is conservative: self._out_item.timestamp is almost
+        # always valid, except while _flush_out is waiting to update
+        # self._out_item. If a less conservative answer is needed, one would
+        # need to track a separate timestamp in the class that is updated
+        # as gains are copied to the OutItem.
+        self.engine._update_steady_state_timestamp(self._out_item.end_timestamp)
+        if np.all(gains == gains[0]):
+            # All the values are the same, so it can be reported as a single value
+            gains = gains[:1]
+        # TODO[nb]: Will need to be namespaced with self.output.name
+        self.engine.sensors[f"input{input}.eq"].value = "[" + ", ".join(format_complex(gain) for gain in gains) + "]"
+
+
 class Engine(aiokatcp.DeviceServer):
     """Top-level class running the whole thing.
 
@@ -464,7 +1043,7 @@ class Engine(aiokatcp.DeviceServer):
         feng_id: int,
         num_ants: int,
         chunk_samples: int,
-        spectra: int,
+        chunk_jones: int,
         spectra_per_heap: int,
         dig_sample_bits: int,
         max_delay_diff: int,
@@ -482,8 +1061,7 @@ class Engine(aiokatcp.DeviceServer):
         )
 
         # Narrowband is not supported yet
-        assert len(outputs) == 1
-        assert isinstance(outputs[0], WidebandOutput)
+        assert all(isinstance(x, WidebandOutput) for x in outputs)
 
         # Attributes copied or initialised from arguments
         self._srcs = list(srcs)
@@ -491,44 +1069,44 @@ class Engine(aiokatcp.DeviceServer):
         self._src_interface = src_interface
         self._src_buffer = src_buffer
         self._src_ibv = src_ibv
-        self._src_layout = recv.Layout(dig_sample_bits, src_packet_samples, chunk_samples, mask_timestamp)
-        self._src_packet_samples = src_packet_samples
+        self.src_layout = recv.Layout(dig_sample_bits, src_packet_samples, chunk_samples, mask_timestamp)
         self.adc_sample_rate = adc_sample_rate
         self.send_rate_factor = send_rate_factor
         self.feng_id = feng_id
         self.n_ants = num_ants
+        self.spectra_per_heap = spectra_per_heap
+        self.chunk_jones = chunk_jones
+        self.dig_sample_bits = dig_sample_bits
+        self.max_delay_diff = max_delay_diff
         self.default_gain = gain
         self.time_converter = TimeConverter(sync_epoch, adc_sample_rate)
         self.monitor = monitor
         self.use_vkgdr = use_vkgdr
+        self.use_peerdirect = use_peerdirect
 
         # Tuning knobs not exposed via arguments
         n_in = 4
-        n_send = 4
-        n_out = n_send if use_peerdirect else 2
 
         self._in_queue: asyncio.Queue[InItem | None] = monitor.make_queue("in_queue", n_in)
         self._in_free_queue: asyncio.Queue[InItem] = monitor.make_queue("in_free_queue", n_in)
-        self._out_queue: asyncio.Queue[OutItem | None] = monitor.make_queue("out_queue", n_out)
-        self._out_free_queue: asyncio.Queue[OutItem] = monitor.make_queue("out_free_queue", n_out)
-        self._send_free_queue: asyncio.Queue[send.Chunk] = monitor.make_queue("send_free_queue", n_send)
-
-        self._init_compute(
-            context=context,
-            spectra=spectra,
-            spectra_per_heap=spectra_per_heap,
-            channels=outputs[0].channels,
-            taps=outputs[0].taps,
-            w_cutoff=outputs[0].w_cutoff,
-            max_delay_diff=max_delay_diff,
-        )
-
-        self._in_items: deque[InItem] = deque()
         self._init_recv(src_affinity, monitor)
 
-        send_chunks = self._init_send(len(outputs[0].dst), use_peerdirect)
+        self.upload_queue = context.create_command_queue()
+        self.download_queue = context.create_command_queue()
+
+        extra_samples = max_delay_diff + max(output.taps * output.spectra_samples for output in outputs)
+        if extra_samples > self.src_layout.chunk_samples:
+            raise RuntimeError(f"chunk_samples is too small; it must be at least {extra_samples}")
+        self.samples = self.src_layout.chunk_samples + extra_samples
+        self.outputs = outputs
+        self._pipelines = [Pipeline(output, self) for output in outputs]
+
+        all_endpoints = list(itertools.chain.from_iterable(output.dst for output in outputs))
+        rate_scale = sum(1.0 / output.send_rate_factor() for output in outputs)
+        data_heaps = sum(pipeline.data_heaps for pipeline in self._pipelines)
+        send_chunks = list(itertools.chain.from_iterable(pipeline.send_chunks for pipeline in self._pipelines))
         self._send_streams = send.make_streams(
-            endpoints=outputs[0].dst,
+            endpoints=all_endpoints,
             interfaces=dst_interface,
             ttl=dst_ttl,
             ibv=dst_ibv,
@@ -536,62 +1114,22 @@ class Engine(aiokatcp.DeviceServer):
             affinity=dst_affinity,
             comp_vector=dst_comp_vector,
             adc_sample_rate=adc_sample_rate,
-            send_rate_factor=send_rate_factor,
+            send_rate_factor=send_rate_factor * rate_scale,
             feng_id=feng_id,
             num_ants=num_ants,
-            spectra=spectra,
-            spectra_per_heap=spectra_per_heap,
-            channels=outputs[0].channels,
+            data_heaps=data_heaps,
             chunks=send_chunks,
         )
-        self._out_item = self._out_free_queue.get_nowait()
-        self._out_item.reset_all(self._compute.command_queue)
-
-        self.delay_models: list[MultiDelayModel] = []
-        self.gains = np.zeros((outputs[0].channels, self.pols), np.complex64)
-        self._init_delay_gain()
-
-        self._descriptor_heap = send.make_descriptor_heap(
-            channels_per_substream=outputs[0].channels // len(outputs[0].dst),
-            spectra_per_heap=spectra_per_heap,
-        )
-
-    def _init_compute(
-        self,
-        context: AbstractContext,
-        spectra: int,
-        spectra_per_heap: int,
-        channels: int,
-        taps: int,
-        w_cutoff: float,
-        max_delay_diff: int,
-    ) -> None:
-        """Initialise ``self._compute`` and related resources."""
-        compute_queue = context.create_command_queue()
-        self._upload_queue = context.create_command_queue()
-        self._download_queue = context.create_command_queue()
-
-        extra_samples = max_delay_diff + taps * channels * 2
-        if extra_samples > self._src_layout.chunk_samples:
-            raise RuntimeError(f"chunk_samples is too small; it must be at least {extra_samples}")
-        samples = self._src_layout.chunk_samples + extra_samples
-
-        template = ComputeTemplate(context, taps, channels, self._src_layout.sample_bits)
-        self._compute = template.instantiate(compute_queue, samples, spectra, spectra_per_heap)
-        device_weights = self._compute.slots["weights"].allocate(accel.DeviceAllocator(context))
-        device_weights.set(compute_queue, generate_weights(channels, taps, w_cutoff))
 
     def _init_recv(self, src_affinity: list[int], monitor: Monitor) -> None:
         """Initialise the receive side of the engine."""
         src_chunks_per_stream = 4
         ringbuffer_capacity = src_chunks_per_stream * N_POLS
 
+        context = self.upload_queue.context
         for _ in range(self._in_free_queue.maxsize):
-            self._in_free_queue.put_nowait(
-                InItem(self._compute, packet_samples=self._src_packet_samples, use_vkgdr=self.use_vkgdr)
-            )
+            self._in_free_queue.put_nowait(InItem(context, self.src_layout, self.samples, use_vkgdr=self.use_vkgdr))
 
-        context = self._compute.template.context
         if self.use_vkgdr:
             import vkgdr.pycuda
 
@@ -605,14 +1143,13 @@ class Engine(aiokatcp.DeviceServer):
             ringbuffer_capacity, name="recv_data_ringbuffer", task_name="run_receive", monitor=monitor
         )
         free_ringbuffers = [spead2.recv.ChunkRingbuffer(src_chunks_per_stream) for _ in range(N_POLS)]
-        self._src_streams = recv.make_streams(self._src_layout, data_ringbuffer, free_ringbuffers, src_affinity)
-        chunk_bytes = self._src_layout.chunk_samples * self._src_layout.sample_bits // BYTE_BITS
-        for pol, stream in enumerate(self._src_streams):
+        self._src_streams = recv.make_streams(self.src_layout, data_ringbuffer, free_ringbuffers, src_affinity)
+        chunk_bytes = self.src_layout.chunk_samples * self.src_layout.sample_bits // BYTE_BITS
+        for stream in self._src_streams:
             for _ in range(src_chunks_per_stream):
                 if self.use_vkgdr:
-                    slot = self._compute.slots[f"in{pol}"]
-                    assert isinstance(slot, accel.IOSlot)
-                    device_bytes = slot.required_bytes()
+                    array_bytes = self.samples * self.src_layout.sample_bits // BYTE_BITS
+                    device_bytes = array_bytes + 1  # Compute requires 1 byte of padding
                     with context:
                         mem = vkgdr.pycuda.Memory(vkgdr_handle, device_bytes)
                     buf = np.array(mem, copy=False).view(np.uint8)
@@ -621,7 +1158,7 @@ class Engine(aiokatcp.DeviceServer):
                     # mapping.
                     buf = buf[:chunk_bytes]
                     device_array = accel.DeviceArray(
-                        context, slot.shape, np.uint8, padded_shape=(device_bytes,), raw=mem
+                        context, (array_bytes,), np.uint8, padded_shape=(device_bytes,), raw=mem
                     )
                 else:
                     buf = accel.HostArray((chunk_bytes,), np.uint8, context=context)
@@ -629,94 +1166,11 @@ class Engine(aiokatcp.DeviceServer):
                 chunk = recv.Chunk(
                     data=buf,
                     device=device_array,
-                    present=np.zeros(self._src_layout.chunk_samples // self._src_packet_samples, np.uint8),
-                    extra=np.zeros(self._src_layout.chunk_samples // self._src_packet_samples, np.uint16),
+                    present=np.zeros(self.src_layout.chunk_samples // self.src_layout.heap_samples, np.uint8),
+                    extra=np.zeros(self.src_layout.chunk_samples // self.src_layout.heap_samples, np.uint16),
                     stream=stream,
                 )
                 chunk.recycle()  # Make available to the stream
-
-    def _init_send(self, substreams: int, use_peerdirect: bool) -> list[send.Chunk]:
-        """Initialise the send side of the engine, with the exception of ``_send_stream``."""
-        send_chunks: list[send.Chunk] = []
-        for _ in range(self._out_free_queue.maxsize):
-            item = OutItem(self._compute)
-            if use_peerdirect:
-                dev_buffer = item.spectra.buffer.gpudata.as_buffer(item.spectra.buffer.nbytes)
-                # buf is structurally a numpy array, but the pointer in it is a CUDA
-                # pointer and so actually trying to use it as such will cause a
-                # segfault.
-                buf = np.frombuffer(dev_buffer, dtype=item.spectra.dtype).reshape(item.spectra.shape)
-                chunk = send.Chunk(
-                    buf,
-                    saturated=item.saturated.empty_like(),
-                    substreams=substreams,
-                    feng_id=self.feng_id,
-                )
-                item.chunk = chunk
-                send_chunks.append(chunk)
-            self._out_free_queue.put_nowait(item)
-
-        spectra = self._compute.spectra
-        if not use_peerdirect:
-            # When using PeerDirect, the chunks are created along with the items
-            heaps = spectra // self.spectra_per_heap
-            send_shape = (heaps, self.channels, self.spectra_per_heap, N_POLS, COMPLEX)
-            for _ in range(self._send_free_queue.maxsize):
-                send_chunks.append(
-                    send.Chunk(
-                        accel.HostArray(send_shape, send.SEND_DTYPE, context=self._compute.template.context),
-                        accel.HostArray((heaps, N_POLS), np.uint32, context=self._compute.template.context),
-                        substreams=substreams,
-                        feng_id=self.feng_id,
-                    )
-                )
-                self._send_free_queue.put_nowait(send_chunks[-1])
-        return send_chunks
-
-    def _init_delay_gain(self) -> None:
-        """Initialise the delays and gains."""
-        for pol in range(N_POLS):
-            delay_model = MultiDelayModel(
-                callback_func=partial(self.update_delay_sensor, delay_sensor=self.sensors[f"input{pol}.delay"])
-            )
-            self.delay_models.append(delay_model)
-
-        for pol in range(N_POLS):
-            self.set_gains(pol, np.full(self.channels, self.default_gain, dtype=np.complex64))
-
-    @property
-    def channels(self) -> int:  # noqa: D401
-        """Number of channels into which the incoming signal is decomposed."""
-        return self._compute.template.channels
-
-    @property
-    def taps(self) -> int:  # noqa: D401
-        """Number of taps in the PFB-FIR filter."""
-        return self._compute.template.taps
-
-    @property
-    def spectra_per_heap(self) -> int:  # noqa: D401
-        """The number of spectra which will be transmitted per output heap."""
-        return self._compute.spectra_per_heap
-
-    @property
-    def dig_sample_bits(self) -> int:  # noqa: D401
-        """Bitwidth of the incoming digitiser samples."""
-        return self._compute.dig_sample_bits
-
-    @property
-    def spectra_samples(self) -> int:  # noqa: D401
-        """Number of incoming digitiser samples needed per spectrum.
-
-        Note that this is the spacing between spectra. Each spectrum uses
-        an overlapping window with more samples than this.
-        """
-        return 2 * self.channels
-
-    @property
-    def pols(self) -> int:  # noqa: D401
-        """Number of polarisations."""
-        return N_POLS
 
     def _populate_sensors(self, sensors: aiokatcp.SensorSet, rx_sensor_timeout: float) -> None:
         """Define the sensors for an engine."""
@@ -793,6 +1247,11 @@ class Engine(aiokatcp.DeviceServer):
         self.add_service_task(time_sync_task)
         self._cancel_tasks.append(time_sync_task)
 
+    def _update_steady_state_timestamp(self, timestamp: int) -> None:
+        """Update the ``steady-state-timestamp`` sensor to at least a given value."""
+        sensor = self.sensors["steady-state-timestamp"]
+        sensor.value = max(sensor.value, timestamp)
+
     async def _next_in(self) -> InItem | None:
         """Load next InItem for processing.
 
@@ -803,74 +1262,18 @@ class Engine(aiokatcp.DeviceServer):
             item = await self._in_queue.get()
 
         if item is not None:
-            self._in_items.append(item)
-            # print(f'Received input with timestamp {self._in_items[-1].timestamp}, '
-            #       f'{self._in_items[-1].n_samples} samples')
-
-            # Make sure that all events associated with the item are past.
-            self._in_items[-1].enqueue_wait_for_events(self._compute.command_queue)
+            for pipeline in self._pipelines:
+                pipeline.add_in_item(item)
         else:
-            # To keep _run_processing simple, it may make further calls to
+            # To keep run_processing simple, it may make further calls to
             # _next_in after receiving a None. To keep things simple, put
             # a None back into the queue so that the next call also gets
             # None rather than hanging.
             self._in_queue.put_nowait(None)
         return item
 
-    async def _fill_in(self) -> bool:
-        """Load sufficient InItems to continue processing.
-
-        Tries to get at least two items into ``self._in_items``, and if
-        loading a second item that is adjacent to the first, copies the overlap
-        region.
-
-        Returns true if processing can proceed, false if the stream is
-        exhausted.
-        """
-        if len(self._in_items) == 0:
-            if not (await self._next_in()):
-                return False
-        if len(self._in_items) == 1:
-            # Copy the head of the new chunk to the tail of the older chunk
-            # to allow for PFB windows to fit and for some protection against
-            # sharp changes in delay.
-            #
-            # This could only fail if we'd lost a whole input chunk of
-            # data from the digitiser. In that case the data we'd like
-            # to copy is missing so we can't do this step.
-            chunk_packets = self._in_items[0].n_samples // self._src_packet_samples
-            copy_packets = len(self._in_items[0].pol_data[0].present) - chunk_packets
-            if (await self._next_in()) and self._in_items[0].end_timestamp == self._in_items[1].timestamp:
-                sample_bits = self._in_items[0].dig_sample_bits
-                copy_samples = self._in_items[0].capacity - self._in_items[0].n_samples
-                copy_samples = min(copy_samples, self._in_items[1].n_samples)
-                copy_bytes = copy_samples * sample_bits // BYTE_BITS
-                for pol_data0, pol_data1 in zip(self._in_items[0].pol_data, self._in_items[1].pol_data):
-                    assert pol_data0.samples is not None
-                    assert pol_data1.samples is not None
-                    pol_data1.samples.copy_region(
-                        self._compute.command_queue,
-                        pol_data0.samples,
-                        np.s_[:copy_bytes],
-                        np.s_[-copy_bytes:],
-                    )
-                    pol_data0.present[-copy_packets:] = pol_data1.present[:copy_packets]
-                self._in_items[0].n_samples += copy_samples
-            else:
-                for pol_data in self._in_items[0].pol_data:
-                    pol_data.present[-copy_packets:] = 0  # Mark tail as absent, for each pol
-            # Update the cumulative sums. Note that during shutdown this may be
-            # done more than once, but since it is shutdown the performance
-            # implications aren't too important.
-            # np.cumsum doesn't provide an initial zero, so we output starting at
-            # position 1.
-            for pol_data in self._in_items[0].pol_data:
-                np.cumsum(pol_data.present, dtype=pol_data.present_cumsum.dtype, out=pol_data.present_cumsum[1:])
-        return True
-
-    def _pop_in(self) -> None:
-        """Remove the oldest InItem."""
-        item = self._in_items.popleft()
+    def free_in_item(self, item: InItem) -> None:
+        """Return an InItem to the free queue."""
         if self.use_vkgdr:
             chunks = []
             for pol_data in item.pol_data:
@@ -881,57 +1284,6 @@ class Engine(aiokatcp.DeviceServer):
             asyncio.create_task(self._push_recv_chunks(chunks, item.events))
         self._in_free_queue.put_nowait(item)
 
-    async def _next_out(self, new_timestamp: int) -> OutItem:
-        """Grab the next free OutItem in the queue."""
-        with self.monitor.with_state("run_processing", "wait out_free_queue"):
-            item = await self._out_free_queue.get()
-
-        # Just make double-sure that all events associated with the item are past.
-        item.enqueue_wait_for_events(self._compute.command_queue)
-        item.reset_all(self._compute.command_queue, new_timestamp)
-        return item
-
-    async def _flush_out(self, new_timestamp: int) -> None:
-        """Start the backend processing and prepare the data for transmission.
-
-        Kick off the `run_backend()` processing, and put an event on the
-        relevant command queue. This lets the next coroutine (_run_transmit) know
-        that the backend processing is finished, and the data can be transmitted
-        out.
-
-        Parameters
-        ----------
-        new_timestamp
-            The timestamp that will immediately follow the current OutItem.
-        """
-        # Round down to a multiple of accs (don't send heap with partial
-        # data).
-        accs = self._out_item.n_spectra // self.spectra_per_heap
-        self._out_item.n_spectra = accs * self.spectra_per_heap
-        if self._out_item.n_spectra > 0:
-            # Take a copy of the gains synchronously. This avoids race conditions
-            # with gains being updated at the same time as they're in the
-            # middle of being transferred.
-            self._out_item.gains[:] = self.gains
-            # TODO: only need to copy the relevant region, and can limit
-            # postprocessing to the relevant range (the FFT size is baked into
-            # the plan, so is harder to modify on the fly).
-            # Without this, saturation counts can be wrong.
-            self._compute.buffer("fine_delay").set_async(self._compute.command_queue, self._out_item.fine_delay)
-            self._compute.buffer("phase").set_async(self._compute.command_queue, self._out_item.phase)
-            self._compute.buffer("gains").set_async(self._compute.command_queue, self._out_item.gains)
-            self._compute.run_backend(self._out_item.spectra, self._out_item.saturated)
-            # Note: we also need to wait for any frontend calls because they
-            # write directly to self._out_item.dig_total_power, but this
-            # marker will take care of that too.
-            self._out_item.add_marker(self._compute.command_queue)
-            self._out_queue.put_nowait(self._out_item)
-            # TODO: could set it to None, since we only need it when we're
-            # ready to flush again?
-            self._out_item = await self._next_out(new_timestamp)
-        else:
-            self._out_item.timestamp = new_timestamp
-
     @staticmethod
     async def _push_recv_chunks(chunks: Iterable[recv.Chunk], events: Iterable[AbstractEvent]) -> None:
         """Return chunks to the streams once `event` has fired.
@@ -941,143 +1293,6 @@ class Engine(aiokatcp.DeviceServer):
         await async_wait_for_events(events)
         for chunk in chunks:
             chunk.recycle()
-
-    async def _run_processing(self) -> None:
-        """Do the hard work of the F-engine.
-
-        This function takes place entirely on the GPU. First, a little bit of
-        the next chunk is copied to the end of the previous one, to allow for
-        the overlap required by the PFB. Coarse delay happens. Then a batch FFT
-        operation is applied, and finally, fine-delay, phase correction,
-        quantisation and corner-turn are performed.
-        """
-        while await self._fill_in():
-            # If the input starts too late for the next expected timestamp,
-            # we need to skip ahead to the next heap after the start, and
-            # flush what we already have.
-            start_timestamp = self._out_item.end_timestamp
-            orig_start_timestamps = [model(start_timestamp)[0] for model in self.delay_models]
-            if min(orig_start_timestamps) < self._in_items[0].timestamp:
-                align = self.spectra_per_heap * self.spectra_samples
-                # This loop is needed because MultiDelayModel is not necessarily
-                # monotonic, and so simply taking the larger of the two skip
-                # results does not guarantee a suitable timestamp.
-                while min(orig_start_timestamps) < self._in_items[0].timestamp:
-                    start_timestamp = max(
-                        model.skip(self._in_items[0].timestamp, start_timestamp + 1, align)
-                        for model in self.delay_models
-                    )
-                    orig_start_timestamps = [model(start_timestamp)[0] for model in self.delay_models]
-                await self._flush_out(start_timestamp)
-            # When we add new spectra they must follow contiguously for any
-            # that we've already buffered.
-            assert start_timestamp == self._out_item.end_timestamp
-
-            # Compute the coarse delay for the first sample.
-            # `orig_timestamp` is the timestamp of first sample from the input
-            # to process in the PFB to produce the output spectrum with
-            # `timestamp`. `offset` is the sample index corresponding to
-            # `orig_timestamp` within the InItem.
-            start_coarse_delays = [start_timestamp - orig_timestamp for orig_timestamp in orig_start_timestamps]
-            offsets = [orig_timestamp - self._in_items[0].timestamp for orig_timestamp in orig_start_timestamps]
-
-            # Identify a block of frontend work. We can grow it until
-            # - we run out of the current input array;
-            # - we fill up the output array; or
-            # - the coarse delay changes.
-            # We speculatively calculate delays until one of the first two is
-            # met, then truncate if we observe a coarse delay change. Note:
-            # max_end_in is computed assuming the coarse delay does not change.
-            max_end_in = (
-                self._in_items[0].end_timestamp + min(start_coarse_delays) - self.taps * self.spectra_samples + 1
-            )
-            max_end_out = self._out_item.timestamp + self._out_item.capacity * self.spectra_samples
-            max_end = min(max_end_in, max_end_out)
-            # Speculatively evaluate until one of the first two conditions is met
-            timestamps = np.arange(start_timestamp, max_end, self.spectra_samples)
-            orig_timestamps, fine_delays, phase = _sample_models(
-                self.delay_models, start_timestamp, max_end, self.spectra_samples
-            )
-            # timestamps can be empty if we fast-forwarded the output right over the
-            # end of the current input item, and it causes problems if we don't check
-            # for it (argmax of an empty sequence).
-            if timestamps.size:
-                for pol in range(len(orig_timestamps)):
-                    coarse_delays = timestamps - orig_timestamps[pol]
-                    # Uses fact that argmax returns first maximum i.e. first true value
-                    delay_change = int(np.argmax(coarse_delays != start_coarse_delays[pol]))
-                    if coarse_delays[delay_change] != start_coarse_delays[pol]:
-                        logger.debug(
-                            "Coarse delay on pol %d changed from %d to %d at %d",
-                            pol,
-                            start_coarse_delays[pol],
-                            coarse_delays[delay_change],
-                            orig_timestamps[pol, delay_change],
-                        )
-                        timestamps = timestamps[:delay_change]
-                        orig_timestamps = orig_timestamps[:, :delay_change]
-                        fine_delays = fine_delays[:, :delay_change]
-                        phase = phase[:, :delay_change]
-                batch_spectra = orig_timestamps.shape[1]
-
-                # Here we run the "frontend" which handles:
-                # - 10-bit to float conversion
-                # - Coarse delay
-                # - The PFB-FIR.
-                if batch_spectra > 0:
-                    logging.debug("Processing %d spectra", batch_spectra)
-                    out_slice = np.s_[self._out_item.n_spectra : self._out_item.n_spectra + batch_spectra]
-                    self._out_item.fine_delay[out_slice] = fine_delays.T
-                    # Divide by pi because the arguments of sincospif() used in the
-                    # kernel are in radians/PI.
-                    self._out_item.phase[out_slice] = phase.T / np.pi
-                    samples = []
-                    for pol_data in self._in_items[0].pol_data:
-                        assert pol_data.samples is not None
-                        samples.append(pol_data.samples)
-                    self._compute.run_frontend(
-                        samples, self._out_item.dig_total_power, offsets, self._out_item.n_spectra, batch_spectra
-                    )
-                    # Replace events rather than adding to it, since this event
-                    # will be sequenced after any prior events
-                    self._in_items[0].events = [self._compute.command_queue.enqueue_marker()]
-                    self._out_item.n_spectra += batch_spectra
-                    # Work out which output spectra contain missing data.
-                    self._out_item.present[out_slice] = True
-                    for pol, pol_data in enumerate(self._in_items[0].pol_data):
-                        # Offset in the chunk of the first sample for each spectrum
-                        first_offset = np.arange(
-                            offsets[pol],
-                            offsets[pol] + batch_spectra * self.spectra_samples,
-                            self.spectra_samples,
-                        )
-                        # Offset of the last sample (inclusive, rather than past-the-end)
-                        last_offset = first_offset + self.taps * self.spectra_samples - 1
-                        first_packet = first_offset // self._src_packet_samples
-                        # last_packet is exclusive
-                        last_packet = last_offset // self._src_packet_samples + 1
-                        present_packets = pol_data.present_cumsum[last_packet] - pol_data.present_cumsum[first_packet]
-                        self._out_item.present[out_slice] &= present_packets == last_packet - first_packet
-
-            # The _flush_out method calls the "backend" which triggers the FFT
-            # and postproc operations.
-            end_timestamp = self._out_item.end_timestamp
-            if end_timestamp >= max_end_out:
-                # We've filled up the output buffer.
-                await self._flush_out(end_timestamp)
-
-            if end_timestamp >= max_end_in:
-                # We've exhausted the input buffer.
-                # TODO: should maybe also do this if _in_items[1] would work
-                # just as well and we've filled the output buffer.
-                self._pop_in()
-        # Timestamp mostly doesn't matter because we're finished, but if a
-        # katcp request arrives at this point we want to ensure the
-        # steady-state-timestamp sensor is updated to a later timestamp than
-        # anything we'll actually send.
-        await self._flush_out(self._out_item.end_timestamp)
-        logger.debug("_run_processing completed")
-        self._out_queue.put_nowait(None)
 
     async def _run_receive(self, streams: list[spead2.recv.ChunkRingStream], layout: recv.Layout) -> None:
         """Receive data from the network, queue it up for processing.
@@ -1106,7 +1321,7 @@ class Engine(aiokatcp.DeviceServer):
             # the data. This is not needed for vkgdr because in that case it's
             # handled by _push_recv_chunks.
             if not self.use_vkgdr:
-                in_item.enqueue_wait_for_events(self._upload_queue)
+                in_item.enqueue_wait_for_events(self.upload_queue)
             in_item.reset(chunks[0].timestamp)
 
             # In steady-state, chunks should be the same size, but during
@@ -1136,11 +1351,11 @@ class Engine(aiokatcp.DeviceServer):
                 for pol_data, chunk in zip(in_item.pol_data, chunks):
                     assert pol_data.samples is not None
                     pol_data.samples.set_region(
-                        self._upload_queue, chunk.data, np.s_[: chunk.data.nbytes], np.s_[:], blocking=False
+                        self.upload_queue, chunk.data, np.s_[: chunk.data.nbytes], np.s_[:], blocking=False
                     )
-                    transfer_events.append(self._upload_queue.enqueue_marker())
+                    transfer_events.append(self.upload_queue.enqueue_marker())
 
-                # Put events on the queue so that _run_processing() knows when to
+                # Put events on the queue so that run_processing() knows when to
                 # start.
                 in_item.events.extend(transfer_events)
                 self._in_queue.put_nowait(in_item)
@@ -1158,193 +1373,6 @@ class Engine(aiokatcp.DeviceServer):
         logger.debug("run_receive completed")
         self._in_queue.put_nowait(None)
 
-    def _chunk_finished(self, chunk: send.Chunk, future: asyncio.Future) -> None:
-        """Return a chunk to the free queue after it has completed transmission.
-
-        This is intended to be used as a callback on an :class:`asyncio.Future`.
-        """
-        if chunk.cleanup is not None:
-            chunk.cleanup()
-            chunk.cleanup = None  # Potentially helps break reference cycles
-        try:
-            future.result()  # No result, but want the exception
-        except asyncio.CancelledError:
-            pass
-        except Exception:
-            logger.exception("Error sending chunk")
-
-    async def _run_transmit(self, streams: list["spead2.send.asyncio.AsyncStream"]) -> None:
-        """Get the processed data from the GPU to the Network.
-
-        This could be done either with or without PeerDirect. In the
-        non-PeerDirect case, :class:`OutItem` objects are pulled from the
-        `_out_queue`. We wait for the events that mark the end of the processing,
-        then copy the data to host memory before turning it over to the
-        :obj:`sender` for transmission on the network. The "empty" item is then
-        returned to :meth:`_run_processing` via the `_out_free_queue`, and once
-        the chunk has been transmitted it is returned to `_send_free_queue`.
-
-        In the PeerDirect case, the item and the chunk are bound together and
-        share memory. In this case `_send_free_queue` is unused. The item is
-        only returned to `_out_free_queue` once it has been fully transmitted.
-
-        Parameters
-        ----------
-        streams
-            The streams transmitting data.
-        """
-        task: asyncio.Future | None = None
-        last_end_timestamp: int | None = None
-        context = self._compute.template.context
-        # Scratch space for transferring digitiser power
-        dig_total_power = [self._compute.slots[f"dig_total_power{pol}"].allocate_host(context) for pol in range(N_POLS)]
-        while True:
-            with self.monitor.with_state("run_transmit", "wait out_queue"):
-                out_item = await self._out_queue.get()
-            if not out_item:
-                break
-            events = []
-            if out_item.chunk is not None:
-                # We're using PeerDirect
-                chunk = out_item.chunk
-                chunk.cleanup = partial(self._out_free_queue.put_nowait, out_item)
-                events.extend(out_item.events)
-            else:
-                with self.monitor.with_state("run_transmit", "wait send_free_queue"):
-                    chunk = await self._send_free_queue.get()
-                chunk.cleanup = partial(self._send_free_queue.put_nowait, chunk)
-                self._download_queue.enqueue_wait_for_events(out_item.events)
-                assert isinstance(chunk.data, accel.HostArray)
-                # TODO: use get_region since it might be partial
-                out_item.spectra.get_async(self._download_queue, chunk.data)
-            out_item.saturated.get_async(self._download_queue, chunk.saturated)
-            for pol in range(N_POLS):
-                out_item.dig_total_power[pol].get_async(self._download_queue, dig_total_power[pol])
-            events.append(self._download_queue.enqueue_marker())
-
-            chunk.timestamp = out_item.timestamp
-            # Each frame is valid if all spectra in it are valid
-            out_item.present.reshape(-1, self.spectra_per_heap).all(axis=-1, out=chunk.present)
-            with self.monitor.with_state("run_transmit", "wait transfer"):
-                await async_wait_for_events(events)
-
-            for pol in range(N_POLS):
-                total_power = float(dig_total_power[pol])
-                avg_power = total_power / (out_item.n_spectra * self.spectra_samples)
-                # Normalise relative to full scale. The factor of 2 is because we
-                # want 1.0 to correspond to a sine wave rather than a square wave.
-                avg_power /= ((1 << (self._src_layout.sample_bits - 1)) - 1) ** 2 / 2
-                avg_power_db = 10 * math.log10(avg_power) if avg_power else -math.inf
-                self.sensors[f"input{pol}.dig-pwr-dbfs"].set_value(
-                    avg_power_db, timestamp=self.time_converter.adc_to_unix(out_item.end_timestamp)
-                )
-
-            n_frames = out_item.n_spectra // self.spectra_per_heap
-            if last_end_timestamp is not None and out_item.timestamp > last_end_timestamp:
-                # Account for heaps skipped between the end of the previous out_item and the
-                # start of the current one.
-                skipped_samples = out_item.timestamp - last_end_timestamp
-                skipped_frames = skipped_samples // (self.spectra_per_heap * self.spectra_samples)
-                send.skipped_heaps_counter.inc(skipped_frames * streams[0].num_substreams)
-            last_end_timestamp = out_item.end_timestamp
-            out_item.reset()  # Safe to call in PeerDirect mode since it doesn't touch the raw data
-            if out_item.chunk is None:
-                # We're not in PeerDirect mode
-                # (when we are the cleanup callback returns the item)
-                self._out_free_queue.put_nowait(out_item)
-            task = asyncio.create_task(chunk.send(streams, n_frames, self.time_converter, self.sensors))
-            task.add_done_callback(partial(self._chunk_finished, chunk))
-
-        if task:
-            try:
-                await task
-            except Exception:
-                pass  # It's already logged by the chunk_finished callback
-        stop_heap = spead2.send.Heap(send.FLAVOUR)
-        stop_heap.add_end()
-        for substream_index in range(streams[0].num_substreams):
-            await streams[0].async_send_heap(stop_heap, substream_index=substream_index)
-        logger.debug("run_transmit completed")
-
-    def delay_update_timestamp(self) -> int:
-        """Return a timestamp by which an update to the delay model will take effect."""
-        # end_timestamp is updated whenever delays are written into the out_item
-        return self._out_item.end_timestamp
-
-    def update_delay_sensor(self, delay_models: Sequence[LinearDelayModel], *, delay_sensor: aiokatcp.Sensor) -> None:
-        """Update the delay sensor upon loading of a new model.
-
-        Accepting the delay_models as a read-only Sequence from the
-        MultiDelayModel, even though we only need the first one to update
-        the sensor.
-
-        The delay and phase-rate values need to be scaled back to their
-        original values (delay (s), phase-rate (rad/s)).
-        """
-        logger.debug("Updating delay sensor: %s", delay_sensor.name)
-
-        orig_delay = delay_models[0].delay / self.adc_sample_rate
-        phase_rate_correction = 0.5 * np.pi * delay_models[0].delay_rate
-        orig_phase = wrap_angle(delay_models[0].phase - 0.5 * np.pi * delay_models[0].delay)
-        orig_phase_rate = (delay_models[0].phase_rate - phase_rate_correction) * self.adc_sample_rate
-        delay_sensor.value = (
-            f"({delay_models[0].start}, "
-            f"{orig_delay}, "
-            f"{delay_models[0].delay_rate}, "
-            f"{orig_phase}, "
-            f"{orig_phase_rate})"
-        )
-
-    def _update_steady_state_timestamp(self, timestamp: int) -> None:
-        """Update the ``steady-state-timestamp`` sensor to at least a given value."""
-        sensor = self.sensors["steady-state-timestamp"]
-        sensor.value = max(sensor.value, timestamp)
-
-    def set_gains(self, input: int, gains: np.ndarray) -> None:
-        """Set the eq gains for one polarisation and update the sensor.
-
-        The `gains` must contain one entry per channel; the shortcut of
-        supplying a single value is handled by :meth:`request_gain`.
-        """
-        self.gains[:, input] = gains
-        # This timestamp is conservative: self._out_item.timestamp is almost
-        # always valid, except while _flush_out is waiting to update
-        # self._out_item. If a less conservative answer is needed, one would
-        # need to track a separate timestamp in the class that is updated
-        # as gains are copied to the OutItem.
-        self._update_steady_state_timestamp(self._out_item.end_timestamp)
-        if np.all(gains == gains[0]):
-            # All the values are the same, so it can be reported as a single value
-            gains = gains[:1]
-        self.sensors[f"input{input}.eq"].value = "[" + ", ".join(format_complex(gain) for gain in gains) + "]"
-
-    def _parse_gains(self, *values: str, allow_default: bool) -> np.ndarray:
-        """Parse the gains passed to :meth:`request-gain` or :meth:`request-gain-all`.
-
-        If a single value is given it is expanded to a value per channel. If
-        `allow_default` is true, the string "default" may be given to restore
-        the default gains set via command line.
-
-        The caller must ensure that `values` contains either 1 or `channels`
-        items. :meth:`request_gain` handles the case where no values are given
-        for querying existing gains.
-
-        Failures are reported by raising an appropriate
-        :exc:`aiokatcp.FailReply`.
-        """
-        if allow_default and values == ("default",):
-            gains = np.full(self.channels, self.default_gain, dtype=np.complex64)
-        else:
-            try:
-                gains = np.array([complex(v) for v in values], dtype=np.complex64)
-            except ValueError:
-                raise aiokatcp.FailReply("invalid formatting of complex number")
-        if not np.all(np.isfinite(gains)):
-            raise aiokatcp.FailReply("non-finite gains are not permitted")
-        if len(gains) == 1:
-            gains = gains.repeat(self.channels)
-        return gains
-
     async def request_gain(self, ctx, input: int, *values: str) -> tuple[str, ...]:
         """Set or query the eq gains.
 
@@ -1358,15 +1386,17 @@ class Engine(aiokatcp.DeviceServer):
             Complex values. There must either be a single value (used for all
             channels), or a value per channel.
         """
+        pipeline = self._pipelines[0]  # TODO[nb]: need to add a request argument
+        output = pipeline.output
         if not 0 <= input < N_POLS:
             raise aiokatcp.FailReply("input is out of range")
-        if len(values) not in {0, 1, self.channels}:
-            raise aiokatcp.FailReply(f"invalid number of values provided (must be 0, 1 or {self.channels})")
+        if len(values) not in {0, 1, output.channels}:
+            raise aiokatcp.FailReply(f"invalid number of values provided (must be 0, 1 or {output.channels})")
         if not values:
-            gains = self.gains[:, input]
+            gains = pipeline.gains[:, input]
         else:
-            gains = self._parse_gains(*values, allow_default=False)
-            self.set_gains(input, gains)
+            gains = _parse_gains(*values, channels=output.channels, default_gain=self.default_gain, allow_default=False)
+            pipeline.set_gains(input, gains)
 
         # Return the current values.
         # If they're all the same, we can return just a single value.
@@ -1384,11 +1414,13 @@ class Engine(aiokatcp.DeviceServer):
             channels), or a value per channel, or ``"default"`` to reset gains
             to the default.
         """
-        if len(values) not in {1, self.channels}:
-            raise aiokatcp.FailReply(f"invalid number of values provided (must be 1 or {self.channels})")
-        gains = self._parse_gains(*values, allow_default=True)
+        pipeline = self._pipelines[0]  # TODO[nb]: need to add a request argument
+        output = pipeline.output
+        if len(values) not in {1, output.channels}:
+            raise aiokatcp.FailReply(f"invalid number of values provided (must be 1 or {output.channels})")
+        gains = _parse_gains(*values, channels=output.channels, default_gain=self.default_gain, allow_default=True)
         for i in range(N_POLS):
-            self.set_gains(i, gains)
+            pipeline.set_gains(i, gains)
 
     async def request_delays(self, ctx, start_time: aiokatcp.Timestamp, *delays: str) -> None:
         """Add a new first-order polynomial to the delay and fringe correction model.
@@ -1405,8 +1437,9 @@ class Engine(aiokatcp.DeviceServer):
             b = float(b_str)
             return a, b
 
-        if len(delays) != len(self.delay_models):
-            raise aiokatcp.FailReply(f"wrong number of delay coefficient sets (expected {len(self.delay_models)})")
+        pipeline = self._pipelines[0]  # TODO[nb]: need to add a request argument
+        if len(delays) != len(pipeline.delay_models):
+            raise aiokatcp.FailReply(f"wrong number of delay coefficient sets (expected {len(pipeline.delay_models)})")
 
         # This will round the start time of the new delay model to the nearest
         # ADC sample. If the start time given doesn't coincide with an ADC sample,
@@ -1444,9 +1477,9 @@ class Engine(aiokatcp.DeviceServer):
                 )
             )
 
-        for delay_model, new_linear_model in zip(self.delay_models, new_linear_models):
+        for delay_model, new_linear_model in zip(pipeline.delay_models, new_linear_models):
             delay_model.add(new_linear_model)
-        self._update_steady_state_timestamp(self.delay_update_timestamp())
+        self._update_steady_state_timestamp(pipeline.delay_update_timestamp())
 
     async def start(self, descriptor_interval_s: float = SPEAD_DESCRIPTOR_INTERVAL_S) -> None:
         """Start the engine.
@@ -1486,23 +1519,24 @@ class Engine(aiokatcp.DeviceServer):
                 buffer=self._src_buffer,
             )
 
-        proc_task = asyncio.create_task(
-            self._run_processing(),
-            name=GPU_PROC_TASK_NAME,
-        )
-        self.add_service_task(proc_task)
-
         recv_task = asyncio.create_task(
-            self._run_receive(self._src_streams, self._src_layout),
+            self._run_receive(self._src_streams, self.src_layout),
             name=RECV_TASK_NAME,
         )
         self.add_service_task(recv_task)
 
-        send_task = asyncio.create_task(
-            self._run_transmit(self._send_streams),
-            name=SEND_TASK_NAME,
-        )
-        self.add_service_task(send_task)
+        for pipeline in self._pipelines:
+            proc_task = asyncio.create_task(
+                pipeline.run_processing(),
+                name=f"{pipeline.output.name}.{GPU_PROC_TASK_NAME}",
+            )
+            self.add_service_task(proc_task)
+
+            send_task = asyncio.create_task(
+                pipeline.run_transmit(self._send_streams),
+                name=f"{pipeline.output.name}.{SEND_TASK_NAME}",
+            )
+            self.add_service_task(send_task)
 
         await super().start()
 

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1076,7 +1076,6 @@ class Engine(aiokatcp.DeviceServer):
         self.n_ants = num_ants
         self.spectra_per_heap = spectra_per_heap
         self.chunk_jones = chunk_jones
-        self.dig_sample_bits = dig_sample_bits
         self.max_delay_diff = max_delay_diff
         self.default_gain = gain
         self.time_converter = TimeConverter(sync_epoch, adc_sample_rate)
@@ -1099,7 +1098,6 @@ class Engine(aiokatcp.DeviceServer):
         self._in_free_queue: asyncio.Queue[InItem] = monitor.make_queue("in_free_queue", n_in)
         self._init_recv(src_affinity, monitor)
 
-        self.outputs = outputs
         self._pipelines = [Pipeline(output, self) for output in outputs]
 
         all_endpoints = list(itertools.chain.from_iterable(output.dst for output in outputs))
@@ -1327,7 +1325,7 @@ class Engine(aiokatcp.DeviceServer):
 
             # In steady-state, chunks should be the same size, but during
             # shutdown, the last chunk may be short.
-            in_item.n_samples = chunks[0].data.nbytes * BYTE_BITS // self.dig_sample_bits
+            in_item.n_samples = chunks[0].data.nbytes * BYTE_BITS // self.src_layout.sample_bits
 
             transfer_events = []
             for pol, (pol_data, chunk) in enumerate(zip(in_item.pol_data, chunks)):

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1058,7 +1058,7 @@ class Engine(aiokatcp.DeviceServer):
         self._pipelines = [Pipeline(output, self, context) for output in outputs]
 
         all_endpoints = list(itertools.chain.from_iterable(output.dst for output in outputs))
-        rate_scale = sum(1.0 / output.send_rate_factor() for output in outputs)
+        rate_scale = sum(output.send_rate_factor for output in outputs)
         data_heaps = sum(pipeline.data_heaps for pipeline in self._pipelines)
         send_chunks = list(itertools.chain.from_iterable(pipeline.send_chunks for pipeline in self._pipelines))
         self._send_streams = send.make_streams(

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -355,7 +355,7 @@ def dig_pwr_dbfs_status(value: float) -> aiokatcp.Sensor.Status:
         return aiokatcp.Sensor.Status.WARN
 
 
-def _parse_gains(self, *values: str, channels: int, default_gain: complex, allow_default: bool) -> np.ndarray:
+def _parse_gains(*values: str, channels: int, default_gain: complex, allow_default: bool) -> np.ndarray:
     """Parse the gains passed to :meth:`request-gain` or :meth:`request-gain-all`.
 
     If a single value is given it is expanded to a value per channel. If

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -680,9 +680,7 @@ class Pipeline:
                     self._compute.run_frontend(
                         samples, self._out_item.dig_total_power, offsets, self._out_item.n_spectra, batch_spectra
                     )
-                    # Replace events rather than adding to it, since this event
-                    # will be sequenced after any prior events
-                    in_item.events = [self._compute.command_queue.enqueue_marker()]
+                    in_item.add_marker(self._compute.command_queue)
                     self._out_item.n_spectra += batch_spectra
                     # Work out which output spectra contain missing data.
                     self._out_item.present[out_slice] = True

--- a/src/katgpucbf/fgpu/output.py
+++ b/src/katgpucbf/fgpu/output.py
@@ -32,6 +32,7 @@ class Output(ABC):
     w_cutoff: float
     dst: list[Endpoint]
 
+    @property
     @abstractmethod
     def send_rate_factor(self) -> float:
         """Output stream rate, relative to a wideband stream."""
@@ -52,6 +53,7 @@ class Output(ABC):
 class WidebandOutput(Output):
     """Static configuration for a wideband output stream."""
 
+    @property
     def send_rate_factor(self) -> float:  # noqa: D102
         return 1.0
 
@@ -66,6 +68,7 @@ class NarrowbandOutput(Output):
 
     decimation: int
 
+    @property
     def send_rate_factor(self) -> float:  # noqa: D102
         return 1.0 / self.decimation
 

--- a/src/katgpucbf/fgpu/output.py
+++ b/src/katgpucbf/fgpu/output.py
@@ -16,26 +16,48 @@
 
 """Data structures capturing static configuration of a single output stream."""
 
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 from katsdptelstate.endpoint import Endpoint
 
 
 @dataclass
-class Output:
+class Output(ABC):
     """Static configuration for an output stream."""
 
+    name: str
     channels: int
     taps: int
     w_cutoff: float
     dst: list[Endpoint]
+
+    @abstractmethod
+    def send_rate_factor(self) -> float:
+        """Output stream rate, relative to a wideband stream."""
+        raise NotImplementedError  # pragma: nocover
+
+    @abstractmethod
+    @property
+    def spectra_samples(self) -> int:
+        """Number of incoming digitiser samples needed per spectrum.
+
+        Note that this is the spacing between spectra. Each spectrum uses
+        an overlapping window with more samples than this.
+        """
+        raise NotImplementedError  # pragma: nocover
 
 
 @dataclass
 class WidebandOutput(Output):
     """Static configuration for a wideband output stream."""
 
-    pass
+    def send_rate_factor(self) -> float:  # noqa: D102
+        return 1.0
+
+    @property
+    def spectra_samples(self) -> int:  # noqa: D102
+        return 2 * self.channels
 
 
 @dataclass
@@ -43,3 +65,10 @@ class NarrowbandOutput(Output):
     """Static configuration for a narrowband stream."""
 
     decimation: int
+
+    def send_rate_factor(self) -> float:  # noqa: D102
+        return 1.0 / self.decimation
+
+    @property
+    def spectra_samples(self) -> int:  # noqa: D102
+        return 2 * self.channels * self.decimation

--- a/src/katgpucbf/fgpu/output.py
+++ b/src/katgpucbf/fgpu/output.py
@@ -37,8 +37,8 @@ class Output(ABC):
         """Output stream rate, relative to a wideband stream."""
         raise NotImplementedError  # pragma: nocover
 
-    @abstractmethod
     @property
+    @abstractmethod
     def spectra_samples(self) -> int:
         """Number of incoming digitiser samples needed per spectrum.
 

--- a/src/katgpucbf/fgpu/send.py
+++ b/src/katgpucbf/fgpu/send.py
@@ -200,6 +200,7 @@ class Chunk:
         end_timestamp = self._timestamp + self._timestamp_step * len(self._frames)
         end_time = time_converter.adc_to_unix(end_timestamp)
         for pol in range(N_POLS):
+            # TODO[nb]:
             sensor = sensors[f"input{pol}.feng-clip-cnt"]
             sensor.set_value(sensor.value + saturated[pol], timestamp=end_time)
 
@@ -217,9 +218,7 @@ def make_streams(
     send_rate_factor: float,
     feng_id: int,
     num_ants: int,
-    spectra: int,
-    spectra_per_heap: int,
-    channels: int,
+    data_heaps: int,
     chunks: Sequence[Chunk],
 ) -> list["spead2.send.asyncio.AsyncStream"]:
     """Create asynchronous SPEAD streams for transmission.
@@ -237,7 +236,7 @@ def make_streams(
         rate=rate,
         max_packet_size=packet_payload + PREAMBLE_SIZE,
         # Adding len(endpoints) to accommodate descriptors sent for each substream
-        max_heaps=(len(chunks) * spectra // spectra_per_heap * len(endpoints)) + len(endpoints),
+        max_heaps=data_heaps + len(endpoints),
     )
     streams: list["spead2.send.asyncio.AsyncStream"]
     if ibv:

--- a/src/katgpucbf/fgpu/send.py
+++ b/src/katgpucbf/fgpu/send.py
@@ -219,7 +219,7 @@ def make_streams(
     send_rate_factor: float,
     feng_id: int,
     num_ants: int,
-    data_heaps: int,
+    n_data_heaps: int,
     chunks: Sequence[Chunk],
 ) -> list["spead2.send.asyncio.AsyncStream"]:
     """Create asynchronous SPEAD streams for transmission.
@@ -237,7 +237,7 @@ def make_streams(
         rate=rate,
         max_packet_size=packet_payload + PREAMBLE_SIZE,
         # Adding len(endpoints) to accommodate descriptors sent for each substream
-        max_heaps=data_heaps + len(endpoints),
+        max_heaps=n_data_heaps + len(endpoints),
     )
     streams: list["spead2.send.asyncio.AsyncStream"]
     if ibv:

--- a/src/katgpucbf/fgpu/send.py
+++ b/src/katgpucbf/fgpu/send.py
@@ -36,6 +36,7 @@ from . import METRIC_NAMESPACE
 PREAMBLE_SIZE = 72
 #: Data type of the output payload
 SEND_DTYPE = np.dtype(np.int8)
+# TODO[nb]: add label for the stream name
 output_heaps_counter = Counter("output_heaps", "number of heaps transmitted", namespace=METRIC_NAMESPACE)
 output_bytes_counter = Counter("output_bytes", "number of payload bytes transmitted", namespace=METRIC_NAMESPACE)
 output_samples_counter = Counter("output_samples", "number of samples transmitted", namespace=METRIC_NAMESPACE)

--- a/src/katgpucbf/send.py
+++ b/src/katgpucbf/send.py
@@ -18,6 +18,7 @@
 
 import asyncio
 import logging
+from typing import Iterable
 
 import spead2.send.asyncio
 
@@ -44,9 +45,9 @@ class DescriptorSender:
     first_interval
         Delay (in seconds) immediately after starting. If not specified, it
         defaults to `interval`.
-    all_substreams
-        Send descriptors to all substreams if true, otherwise default behaviour
-        is to send only to the first substream.
+    substreams
+        Substream indexes to which descriptors are sent. If not specified,
+        send only to the first substream.
     """
 
     def __init__(
@@ -56,13 +57,11 @@ class DescriptorSender:
         interval: float,
         first_interval: float | None = None,
         *,
-        all_substreams: bool = False,
+        substreams: Iterable[int] = (0,),
     ) -> None:
         self._stream = stream
         self._heap_reference_list = spead2.send.HeapReferenceList(
-            [spead2.send.HeapReference(descriptors, substream_index=i) for i in range(stream.num_substreams)]
-            if all_substreams
-            else [spead2.send.HeapReference(descriptors, substream_index=0)]
+            [spead2.send.HeapReference(descriptors, substream_index=i) for i in substreams]
         )
         self._interval = interval
         self._first_interval = interval if first_interval is None else first_interval

--- a/src/katgpucbf/send.py
+++ b/src/katgpucbf/send.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2022, National Research Foundation (SARAO)
+# Copyright (c) 2022-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katgpucbf/send.py
+++ b/src/katgpucbf/send.py
@@ -46,7 +46,7 @@ class DescriptorSender:
         Delay (in seconds) immediately after starting. If not specified, it
         defaults to `interval`.
     substreams
-        Substream indexes to which descriptors are sent. If not specified,
+        Substream indices to which descriptors are sent. If not specified,
         send only to the first substream.
     """
 

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -720,7 +720,7 @@ class TestEngine:
         sensor_update_dict = self._watch_sensors(sensors)
         n_samples = 3 * CHUNK_SAMPLES
         dig_data = np.zeros((2, n_samples), np.int16)
-        saturation_value = 2 ** (engine_server.dig_sample_bits - 1) - 1
+        saturation_value = 2 ** (engine_server.src_layout.sample_bits - 1) - 1
         dig_data[0, 10000:15000] = saturation_value
         dig_data[1, 2 * CHUNK_SAMPLES + 50000 : 2 * CHUNK_SAMPLES + 60000] = -saturation_value
         await self._send_data(

--- a/test/fgpu/test_main.py
+++ b/test/fgpu/test_main.py
@@ -60,7 +60,8 @@ class TestParseNarrowband:
 
     def test_minimal(self) -> None:
         """Test with the minimum required arguments."""
-        assert parse_narrowband("channels=1024,decimation=8,dst=239.1.2.3+1:7148") == {
+        assert parse_narrowband("name=foo,channels=1024,decimation=8,dst=239.1.2.3+1:7148") == {
+            "name": "foo",
             "channels": 1024,
             "decimation": 8,
             "dst": [Endpoint("239.1.2.3", 7148), Endpoint("239.1.2.4", 7148)],
@@ -68,7 +69,8 @@ class TestParseNarrowband:
 
     def test_maximal(self) -> None:
         """Test with all valid arguments."""
-        assert parse_narrowband("channels=1024,decimation=8,taps=8,w_cutoff=0.5,dst=239.1.2.3+1:7148") == {
+        assert parse_narrowband("name=foo,channels=1024,decimation=8,taps=8,w_cutoff=0.5,dst=239.1.2.3+1:7148") == {
+            "name": "foo",
             "channels": 1024,
             "decimation": 8,
             "taps": 8,
@@ -79,9 +81,10 @@ class TestParseNarrowband:
     @pytest.mark.parametrize(
         "missing,value",
         [
-            ("channels", "decimation=8,dst=239.1.2.3+1:7148"),
-            ("decimation", "channels=1024,dst=239.1.2.3+1:7148"),
-            ("dst", "channels=1024,decimation=8"),
+            ("name", "channels=1024,decimation=8,dst=239.1.2.3+1:7148"),
+            ("channels", "name=foo,decimation=8,dst=239.1.2.3+1:7148"),
+            ("decimation", "name=foo,channels=1024,dst=239.1.2.3+1:7148"),
+            ("dst", "name=foo,channels=1024,decimation=8"),
         ],
     )
     def test_missing_key(self, missing: str, value: str) -> None:
@@ -92,7 +95,7 @@ class TestParseNarrowband:
     def test_duplicate_key(self) -> None:
         """Test with a key specified twice."""
         with pytest.raises(ValueError, match="--narrowband: channels specified twice"):
-            parse_narrowband("channels=8,channels=9,decimation=8,dst=239.1.2.3+1:7148")
+            parse_narrowband("name=foo,channels=8,channels=9,decimation=8,dst=239.1.2.3+1:7148")
 
 
 class TestParseArgs:
@@ -108,8 +111,8 @@ class TestParseArgs:
             "--sync-epoch=0",
             "--taps=64",
             "--w-cutoff=0.9",
-            "--narrowband=dst=239.1.0.0+1,channels=32768,decimation=8,taps=4,w_cutoff=0.8",
-            "--narrowband=dst=239.2.0.0+0:7149,channels=8192,decimation=16",
+            "--narrowband=name=nb0,dst=239.1.0.0+1,channels=32768,decimation=8,taps=4,w_cutoff=0.8",
+            "--narrowband=name=nb1,dst=239.2.0.0+0:7149,channels=8192,decimation=16",
             "239.0.1.0+7:7148",
             "239.0.2.0+7:7148",
             "239.0.3.0+7:7148",
@@ -117,11 +120,14 @@ class TestParseArgs:
         args = parse_args(raw_args)
         assert args.narrowband == [
             NarrowbandOutput(
+                name="nb0",
                 dst=[Endpoint("239.1.0.0", 7148), Endpoint("239.1.0.1", 7148)],
                 channels=32768,
                 decimation=8,
                 taps=4,
                 w_cutoff=0.8,
             ),
-            NarrowbandOutput(dst=[Endpoint("239.2.0.0", 7149)], channels=8192, decimation=16, taps=64, w_cutoff=0.9),
+            NarrowbandOutput(
+                name="nb1", dst=[Endpoint("239.2.0.0", 7149)], channels=8192, decimation=16, taps=64, w_cutoff=0.9
+            ),
         ]


### PR DESCRIPTION
The result of this refactoring is that fgpu should be pretty close to working with multiple output streams, with all the major refactoring done, but it is not actually supported or tested. This is a stepping stone that should still be backwards compatible, before changing the interface with katsdpcontroller. Getting it onto main now should reduce future merge conflicts.

The main change is that the bulk of `run_processing` and `run_transmit` and their related data structures are moved into a separate class called `Pipeline`. There is a single `Engine` which potentially manages multiple pipelines. Each pipeline has its own compute and download command queues. There is still only a single spead2 transmit stream: this makes the packet pacing global for the engine, and avoids the need for extra transmission threads.  This uber-stream has a set of substreams per output, and each `run_transmit` sends data to the appropriate subsets (this bit may still be a bit buggy and will need testing).

Copying the prefix of each chunk to the tail of the previous chunk used to happen as part of `run_processing`, but is now moved to the receive code, since it only needs to be done once for all Pipelines. I think this actually simplifies the processing loop a lot and I wish I'd done it to start with. I introduced a new command queue for this (`_copy_queue`) since there isn't an Engine-wide compute queue any more.

InItems have a `refcount` field to keep track of how many Pipelines are still using them, so that they can be returned to the free queue only when none of the Pipelines need them any more.

One slight worry I have with the design is that there is no mechanism enforcing fairness between the pipelines. If one pipeline ends up getting its GPU work prioritised, it could end up several chunks ahead of another, and that would lock up a bunch of InItems and stall the receiver. But I think that's a bridge we can burn when we get to it.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-573.
