### PR TITLE
Round RAM in the qualification report

### DIFF
--- a/qualification/report/generate_pdf.py
+++ b/qualification/report/generate_pdf.py
@@ -400,6 +400,11 @@ def _parse_host(msg: dict) -> tuple[str, Host]:
             cpus[int(labels["package"])] = labels["model_name"]
         elif metric_name == "node_memory_MemTotal_bytes":
             ram = int(value)
+            # Round ram to the nearest MiB. For unknown reasons, some machines
+            # have a few KiB more or less RAM available than others even when
+            # the hardware is identical, and this rounding helps coalesce
+            # them in the report.
+            ram = round(value / 2**20) * 2**20
         elif metric_name == "node_ethtool_info":
             interfaces.append(_parse_interface(labels))
         elif metric_name == "DCGM_FI_DEV_FB_TOTAL":


### PR DESCRIPTION
This allows otherwise identical hosts with sub-MiB differences in available RAM to appear as a group.

Closes NGC-896.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match