### PR TITLE
Bump redis to latest version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
             'spead2==3.11.1',
             'types-decorator==5.1.1',
             'types-docutils==0.17.1',
-            'types-redis==4.3.4',
+            'types-redis==4.5.3',
             'types-setuptools==57.0.0',
             'types-six==1.16.0',
         ]

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -80,11 +80,6 @@ decorator==5.1.1
     #   -c qualification/../requirements.txt
     #   aiokatcp
     #   katsdpsigproc
-deprecated==1.2.13
-    # via
-    #   -c qualification/../requirements-dev.txt
-    #   -c qualification/../requirements.txt
-    #   redis
 docutils==0.17.1
     # via
     #   -c qualification/../requirements-dev.txt
@@ -206,7 +201,6 @@ packaging==21.3
     #   dask
     #   matplotlib
     #   pytest
-    #   redis
     #   xarray
 pandas==1.5.0
     # via
@@ -296,7 +290,7 @@ pyyaml==6.0
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   dask
-redis==4.3.4
+redis==4.5.3
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
@@ -357,7 +351,6 @@ wrapt==1.14.1
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
-    #   deprecated
     #   prometheus-async
 xarray==2022.10.0
     # via

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -80,10 +80,6 @@ decorator==5.1.1
     #   aiokatcp
     #   ipython
     #   katsdpsigproc
-deprecated==1.2.13
-    # via
-    #   -c requirements.txt
-    #   redis
 distlib==0.3.6
     # via virtualenv
 docutils==0.17.1
@@ -199,7 +195,6 @@ packaging==21.3
     #   build
     #   dask
     #   pytest
-    #   redis
     #   sphinx
     #   xarray
 pandas==1.5.0
@@ -312,7 +307,7 @@ pyyaml==6.0
     #   dask
     #   pre-commit
     #   pybtex
-redis==4.3.4
+redis==4.5.3
     # via
     #   -c requirements.txt
     #   katsdptelstate
@@ -403,7 +398,6 @@ wheel==0.38.4
 wrapt==1.14.1
     # via
     #   -c requirements.txt
-    #   deprecated
     #   prometheus-async
 xarray==2022.10.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,8 +37,6 @@ decorator==5.1.1
     # via
     #   aiokatcp
     #   katsdpsigproc
-deprecated==1.2.13
-    # via redis
 frozenlist==1.3.1
     # via
     #   aiohttp
@@ -90,7 +88,6 @@ numpy==1.23.4
 packaging==21.3
     # via
     #   dask
-    #   redis
     #   xarray
 pandas==1.5.0
     # via
@@ -126,7 +123,7 @@ pytz==2022.4
     # via pandas
 pyyaml==6.0
     # via dask
-redis==4.3.4
+redis==4.5.3
     # via katsdptelstate
 scipy==1.9.2
     # via katsdpsigproc
@@ -150,9 +147,7 @@ typing-extensions==4.4.0
 vkgdr==0.1
     # via katgpucbf (setup.cfg)
 wrapt==1.14.1
-    # via
-    #   deprecated
-    #   prometheus-async
+    # via prometheus-async
 xarray==2022.10.0
     # via katgpucbf (setup.cfg)
 yarl==1.8.1


### PR DESCRIPTION
We're not actually using redis (it gets sucked in via katsdptelstate), but this will reduce the warnings from dependabot.

Note that the fix added in 4.5.3 is
[incomplete](https://github.com/redis/redis-py/issues/2665), so this won't completely silence dependabot.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] (N/A) Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match