### PR TITLE
Add --wideband command-line argument

### DIFF
--- a/scratch/fgpu/run-fgpu-hbw.sh
+++ b/scratch/fgpu/run-fgpu-hbw.sh
@@ -27,11 +27,11 @@ exec spead2_net_raw taskset -c $other_affinity fgpu \
     --src-affinity $src_affinity --src-comp-vector=$src_comp \
     --dst-affinity $dst_affinity --dst-comp-vector=$dst_comp \
     --adc-sample-rate ${adc_sample_rate:-7000000000} \
-    --channels ${channels:-32768} \
     --spectra-per-heap ${spectra_per_heap:-256} \
     --katcp-port $katcp_port \
     --prometheus-port $prom_port \
     --sync-epoch 0 \
     --array-size ${array_size:-8} \
     --feng-id "$feng_id" \
-    $srcs $dst "$@"
+    --wideband "name=wideband,channels=${channels:-32768},dst=$dst" \
+    $srcs "$@"

--- a/scratch/fgpu/run-fgpu.sh
+++ b/scratch/fgpu/run-fgpu.sh
@@ -53,11 +53,11 @@ exec spead2_net_raw taskset -c $other_affinity fgpu \
     --src-affinity $src_affinity --src-comp-vector=$src_comp \
     --dst-affinity $dst_affinity --dst-comp-vector=$dst_comp \
     --adc-sample-rate ${adc_sample_rate:-1712000000} \
-    --channels ${channels:-32768} \
     --spectra-per-heap ${spectra_per_heap:-256} \
     --katcp-port $katcp_port \
     --prometheus-port $prom_port \
     --sync-epoch 0 \
     --array-size ${array_size:-8} \
     --feng-id "$feng_id" \
-    $srcs $dst "$@"
+    --wideband "name=wideband,channels=${channels:-32768},dst=$dst" \
+    $srcs "$@"

--- a/test/fgpu/conftest.py
+++ b/test/fgpu/conftest.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2022, National Research Foundation (SARAO)
+# Copyright (c) 2020-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/fgpu/conftest.py
+++ b/test/fgpu/conftest.py
@@ -88,6 +88,11 @@ async def engine_server(
     :mod:`~katgpucbf.fgpu.main`, and are a set of simple parameters just to
     get the :class:`~.fgpu.Engine` running so that the KATCP interface can be
     tested.
+
+    Extra command-line arguments can be added using a ``cmdline_args`` marker.
+    If a keyword-only `remove_outputs` argument is set to true, any existing
+    arguments starting with ``--wideband=`` or ``--narrowband=`` are removed
+    first.
     """
     arglist = list(request.cls.engine_arglist)
     if request.node.get_closest_marker("use_vkgdr"):
@@ -97,6 +102,8 @@ async def engine_server(
     # that more specific markers append options to the end, overriding those
     # added by less-specific markers.
     for marker in reversed(list(request.node.iter_markers("cmdline_args"))):
+        if marker.kwargs.get("remove_outputs"):
+            arglist = [arg for arg in arglist if not arg.startswith(("--wideband=", "--narrowband="))]
         arglist.extend(marker.args)
 
     args = parse_args(arglist)

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -103,7 +103,6 @@ class TestEngine:
         "--katcp-port=0",
         "--src-interface=lo",
         "--dst-interface=lo",
-        f"--channels={CHANNELS}",
         f"--sync-epoch={SYNC_EPOCH}",
         f"--src-chunk-samples={CHUNK_SAMPLES}",
         f"--dst-chunk-jones={CHUNK_JONES}",
@@ -111,13 +110,12 @@ class TestEngine:
         f"--spectra-per-heap={SPECTRA_PER_HEAP}",
         f"--src-packet-samples={PACKET_SAMPLES}",
         f"--feng-id={FENG_ID}",
-        f"--taps={TAPS}",
         f"--adc-sample-rate={ADC_SAMPLE_RATE}",
         f"--gain={GAIN}",
         "--send-rate-factor=0",  # Infinitely fast
+        f"--wideband=name=wideband,dst=239.10.11.0+15:7149,channels={CHANNELS},taps={TAPS}",
         "239.10.10.0+7:7149",  # src1
         "239.10.10.8+7:7149",  # src2
-        "239.10.11.0+15:7149",  # dst
     ]
 
     def test_engine_required_arguments(self, engine_server: Engine) -> None:
@@ -622,7 +620,13 @@ class TestEngine:
     @pytest.mark.parametrize(
         "channels",
         [
-            pytest.param(channels, marks=pytest.mark.cmdline_args(f"--channels={channels}"))
+            pytest.param(
+                channels,
+                marks=pytest.mark.cmdline_args(
+                    f"--wideband=name=wideband,dst=239.10.11.0+15:7149,channels={channels},taps={TAPS}",
+                    remove_outputs=True,
+                ),
+            )
             for channels in [64, 2048, 8192]
         ],
     )

--- a/test/fgpu/test_katcp_interface.py
+++ b/test/fgpu/test_katcp_interface.py
@@ -60,13 +60,12 @@ class TestKatcpRequests:
         "--katcp-port=0",
         "--src-interface=lo",
         "--dst-interface=lo",
-        f"--channels={CHANNELS}",
         f"--sync-epoch={SYNC_EPOCH}",
         f"--gain={GAIN}",
         "--adc-sample-rate=1.712e9",
+        f"--wideband=name=wideband,dst=239.10.11.0+15:7149,channels={CHANNELS}",
         "239.10.10.0+7:7149",  # src1
         "239.10.10.8+7:7149",  # src2
-        "239.10.11.0+15:7149",  # dst
     ]
 
     @pytest.mark.parametrize("pol", range(N_POLS))

--- a/test/fgpu/test_main.py
+++ b/test/fgpu/test_main.py
@@ -20,7 +20,7 @@ import pytest
 from katsdptelstate.endpoint import Endpoint
 
 from katgpucbf.fgpu.main import comma_split, parse_args, parse_narrowband
-from katgpucbf.fgpu.output import NarrowbandOutput
+from katgpucbf.fgpu.output import NarrowbandOutput, WidebandOutput
 
 
 class TestCommaSplit:
@@ -107,18 +107,22 @@ class TestParseArgs:
             "--src-interface=lo",
             "--dst-interface=lo",
             "--adc-sample-rate=1712000000.0",
-            "--channels=1024",
             "--sync-epoch=0",
-            "--taps=64",
-            "--w-cutoff=0.9",
+            "--wideband=name=wideband,dst=239.0.3.0+1:7148,channels=1024,taps=64,w_cutoff=0.9",
             "--narrowband=name=nb0,dst=239.1.0.0+1,channels=32768,decimation=8,taps=4,w_cutoff=0.8",
             "--narrowband=name=nb1,dst=239.2.0.0+0:7149,channels=8192,decimation=16",
             "239.0.1.0+7:7148",
             "239.0.2.0+7:7148",
-            "239.0.3.0+7:7148",
         ]
         args = parse_args(raw_args)
-        assert args.narrowband == [
+        assert args.outputs == [
+            WidebandOutput(
+                name="wideband",
+                dst=[Endpoint("239.0.3.0", 7148), Endpoint("239.0.3.1", 7148)],
+                channels=1024,
+                taps=64,
+                w_cutoff=0.9,
+            ),
             NarrowbandOutput(
                 name="nb0",
                 dst=[Endpoint("239.1.0.0", 7148), Endpoint("239.1.0.1", 7148)],
@@ -128,6 +132,6 @@ class TestParseArgs:
                 w_cutoff=0.8,
             ),
             NarrowbandOutput(
-                name="nb1", dst=[Endpoint("239.2.0.0", 7149)], channels=8192, decimation=16, taps=64, w_cutoff=0.9
+                name="nb1", dst=[Endpoint("239.2.0.0", 7149)], channels=8192, decimation=16, taps=16, w_cutoff=1.0
             ),
         ]


### PR DESCRIPTION
This replaces the previous --channels, --taps, --w-cutoff and dst args which configured a single wideband stream. This is thus an incompatible change which will need to be coordinated with a change to katsdpcontroller.

It also highlighted a bug in the previous multi-stream PR where chunk_jones was only taking the singleton wideband stream into account for rounding purposes.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Relates to NGC-567.
