### PR TITLE
Add centre_frequency cmdline key for narrowband

### DIFF
--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -126,6 +126,7 @@ class NarrowbandOutputDict(OutputDict, total=False):
     See :class:`OutputDict` for further information.
     """
 
+    centre_frequency: float
     decimation: int
 
 
@@ -193,12 +194,15 @@ def parse_narrowband(value: str) -> NarrowbandOutputDict:
 
     - name
     - channels
+    - centre_frequency
     - decimation
     - dst
     """
 
     def field_callback(kws: NarrowbandOutputDict, key: str, data: str) -> None:
         match key:
+            case "centre_frequency":
+                kws[key] = float(data)
             case "decimation":
                 kws[key] = int(data)
             case _:
@@ -207,7 +211,7 @@ def parse_narrowband(value: str) -> NarrowbandOutputDict:
     try:
         kws: NarrowbandOutputDict = {}
         _parse_stream(value, kws, field_callback)
-        for key in ["decimation"]:
+        for key in ["centre_frequency", "decimation"]:
             if key not in kws:
                 raise ValueError(f"{key} is missing")
     except ValueError as exc:
@@ -233,7 +237,8 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         action="append",
         metavar="KEY=VALUE[,KEY=VALUE...]",
         help=(
-            "Add a narrowband output (may be repeated). The required keys are: name, decimation, channels, dst. "
+            "Add a narrowband output (may be repeated). "
+            "The required keys are: name, centre_frequency, decimation, channels, dst. "
             f"Optional keys: taps [{DEFAULT_TAPS}], w_cutoff [{DEFAULT_W_CUTOFF}]"
         ),
     )

--- a/src/katgpucbf/fgpu/output.py
+++ b/src/katgpucbf/fgpu/output.py
@@ -66,6 +66,7 @@ class WidebandOutput(Output):
 class NarrowbandOutput(Output):
     """Static configuration for a narrowband stream."""
 
+    centre_frequency: float
     decimation: int
 
     @property

--- a/test/fgpu/test_main.py
+++ b/test/fgpu/test_main.py
@@ -60,18 +60,22 @@ class TestParseNarrowband:
 
     def test_minimal(self) -> None:
         """Test with the minimum required arguments."""
-        assert parse_narrowband("name=foo,channels=1024,decimation=8,dst=239.1.2.3+1:7148") == {
+        assert parse_narrowband("name=foo,channels=1024,centre_frequency=400e6,decimation=8,dst=239.1.2.3+1:7148") == {
             "name": "foo",
             "channels": 1024,
+            "centre_frequency": 400e6,
             "decimation": 8,
             "dst": [Endpoint("239.1.2.3", 7148), Endpoint("239.1.2.4", 7148)],
         }
 
     def test_maximal(self) -> None:
         """Test with all valid arguments."""
-        assert parse_narrowband("name=foo,channels=1024,decimation=8,taps=8,w_cutoff=0.5,dst=239.1.2.3+1:7148") == {
+        assert parse_narrowband(
+            "name=foo,channels=1024,centre_frequency=400e6,decimation=8,taps=8,w_cutoff=0.5,dst=239.1.2.3+1:7148"
+        ) == {
             "name": "foo",
             "channels": 1024,
+            "centre_frequency": 400e6,
             "decimation": 8,
             "taps": 8,
             "w_cutoff": 0.5,
@@ -81,10 +85,11 @@ class TestParseNarrowband:
     @pytest.mark.parametrize(
         "missing,value",
         [
-            ("name", "channels=1024,decimation=8,dst=239.1.2.3+1:7148"),
-            ("channels", "name=foo,decimation=8,dst=239.1.2.3+1:7148"),
-            ("decimation", "name=foo,channels=1024,dst=239.1.2.3+1:7148"),
-            ("dst", "name=foo,channels=1024,decimation=8"),
+            ("name", "channels=1024,centre_frequency=400e6,decimation=8,dst=239.1.2.3+1:7148"),
+            ("channels", "name=foo,centre_frequency=400e6,decimation=8,dst=239.1.2.3+1:7148"),
+            ("centre_frequency", "name=foo,channels=1024,decimation=8,dst=239.1.2.3+1:7148"),
+            ("decimation", "name=foo,channels=1024,centre_frequency=400e6,dst=239.1.2.3+1:7148"),
+            ("dst", "name=foo,channels=1024,centre_frequency=400e6,decimation=8"),
         ],
     )
     def test_missing_key(self, missing: str, value: str) -> None:
@@ -95,7 +100,7 @@ class TestParseNarrowband:
     def test_duplicate_key(self) -> None:
         """Test with a key specified twice."""
         with pytest.raises(ValueError, match="--narrowband: channels specified twice"):
-            parse_narrowband("name=foo,channels=8,channels=9,decimation=8,dst=239.1.2.3+1:7148")
+            parse_narrowband("name=foo,channels=8,channels=9,centre_frequency=400e6,decimation=8,dst=239.1.2.3+1:7148")
 
 
 class TestParseArgs:
@@ -109,8 +114,11 @@ class TestParseArgs:
             "--adc-sample-rate=1712000000.0",
             "--sync-epoch=0",
             "--wideband=name=wideband,dst=239.0.3.0+1:7148,channels=1024,taps=64,w_cutoff=0.9",
-            "--narrowband=name=nb0,dst=239.1.0.0+1,channels=32768,decimation=8,taps=4,w_cutoff=0.8",
-            "--narrowband=name=nb1,dst=239.2.0.0+0:7149,channels=8192,decimation=16",
+            (
+                "--narrowband=name=nb0,dst=239.1.0.0+1,channels=32768,"
+                "centre_frequency=400e6,decimation=8,taps=4,w_cutoff=0.8"
+            ),
+            "--narrowband=name=nb1,dst=239.2.0.0+0:7149,channels=8192,centre_frequency=300e6,decimation=16",
             "239.0.1.0+7:7148",
             "239.0.2.0+7:7148",
         ]
@@ -127,11 +135,18 @@ class TestParseArgs:
                 name="nb0",
                 dst=[Endpoint("239.1.0.0", 7148), Endpoint("239.1.0.1", 7148)],
                 channels=32768,
+                centre_frequency=400e6,
                 decimation=8,
                 taps=4,
                 w_cutoff=0.8,
             ),
             NarrowbandOutput(
-                name="nb1", dst=[Endpoint("239.2.0.0", 7149)], channels=8192, decimation=16, taps=16, w_cutoff=1.0
+                name="nb1",
+                dst=[Endpoint("239.2.0.0", 7149)],
+                channels=8192,
+                centre_frequency=300e6,
+                decimation=16,
+                taps=16,
+                w_cutoff=1.0,
             ),
         ]


### PR DESCRIPTION
Relates to NGC-567.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
