### PR TITLE
fgpu: make some katcp sensors pipeline-specific

### DIFF
--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -419,6 +419,7 @@ class Pipeline:
         # Initialize delays and gains
         self.delay_models: list[MultiDelayModel] = []
         self.gains = np.zeros((output.channels, self.pols), np.complex64)
+        self._populate_sensors()
         self._init_delay_gain()
 
         self.descriptor_heap = send.make_descriptor_heap(
@@ -426,12 +427,60 @@ class Pipeline:
             spectra_per_heap=engine.spectra_per_heap,
         )
 
+    def _populate_sensors(self) -> None:
+        sensors = self.engine.sensors
+        for pol in range(N_POLS):
+            sensors.add(
+                aiokatcp.Sensor(
+                    str,
+                    f"{self.output.name}.input{pol}.eq",
+                    "For this input, the complex, unitless, per-channel digital scaling factors "
+                    "implemented prior to requantisation",
+                    initial_status=aiokatcp.Sensor.Status.NOMINAL,
+                )
+            )
+            sensors.add(
+                aiokatcp.Sensor(
+                    str,
+                    f"{self.output.name}.input{pol}.delay",
+                    "The delay settings for this input: (loadmcnt <ADC sample "
+                    "count when model was loaded>, delay <in seconds>, "
+                    "delay-rate <unit-less or, seconds-per-second>, "
+                    "phase <radians>, phase-rate <radians per second>).",
+                )
+            )
+            # TODO[nb]: it may be better to make this a single sensor and
+            # have only one of the pipelines update it.
+            sensors.add(
+                aiokatcp.Sensor(
+                    float,
+                    f"{self.output.name}.input{pol}.dig-pwr-dbfs",
+                    "Digitiser ADC average power",
+                    units="dBFS",
+                    status_func=dig_pwr_dbfs_status,
+                    auto_strategy=aiokatcp.SensorSampler.Strategy.EVENT_RATE,
+                    auto_strategy_parameters=(MIN_SENSOR_UPDATE_PERIOD, math.inf),
+                )
+            )
+            sensors.add(
+                aiokatcp.Sensor(
+                    int,
+                    f"{self.output.name}.input{pol}.feng-clip-cnt",
+                    "Number of output samples that are saturated",
+                    default=0,
+                    initial_status=aiokatcp.Sensor.Status.NOMINAL,
+                    auto_strategy=aiokatcp.SensorSampler.Strategy.EVENT_RATE,
+                    auto_strategy_parameters=(MIN_SENSOR_UPDATE_PERIOD, math.inf),
+                )
+            )
+
     def _init_delay_gain(self) -> None:
         """Initialise the delays and gains."""
-        # TODO[nb]: create per-pipeline sensors
         for pol in range(N_POLS):
             delay_model = MultiDelayModel(
-                callback_func=partial(self.update_delay_sensor, delay_sensor=self.engine.sensors[f"input{pol}.delay"])
+                callback_func=partial(
+                    self.update_delay_sensor, delay_sensor=self.engine.sensors[f"{self.output.name}.input{pol}.delay"]
+                )
             )
             self.delay_models.append(delay_model)
 
@@ -799,9 +848,7 @@ class Pipeline:
                 # want 1.0 to correspond to a sine wave rather than a square wave.
                 avg_power /= ((1 << (self.engine.src_layout.sample_bits - 1)) - 1) ** 2 / 2
                 avg_power_db = 10 * math.log10(avg_power) if avg_power else -math.inf
-                # TODO[nb]: needs to be computed (or at least set) by just one of
-                # the streams.
-                self.engine.sensors[f"input{pol}.dig-pwr-dbfs"].set_value(
+                self.engine.sensors[f"{self.output.name}.input{pol}.dig-pwr-dbfs"].set_value(
                     avg_power_db, timestamp=self.engine.time_converter.adc_to_unix(out_item.end_timestamp)
                 )
 
@@ -818,7 +865,9 @@ class Pipeline:
                 # We're not in PeerDirect mode
                 # (when we are the cleanup callback returns the item)
                 self._out_free_queue.put_nowait(out_item)
-            task = asyncio.create_task(chunk.send(streams, n_frames, self.engine.time_converter, self.engine.sensors))
+            task = asyncio.create_task(
+                chunk.send(streams, n_frames, self.engine.time_converter, self.engine.sensors, self.output.name)
+            )
             task.add_done_callback(partial(self._chunk_finished, chunk))
 
         if task:
@@ -877,8 +926,8 @@ class Pipeline:
         if np.all(gains == gains[0]):
             # All the values are the same, so it can be reported as a single value
             gains = gains[:1]
-        # TODO[nb]: Will need to be namespaced with self.output.name
-        self.engine.sensors[f"input{input}.eq"].value = "[" + ", ".join(format_complex(gain) for gain in gains) + "]"
+        sensor = self.engine.sensors[f"{self.output.name}.input{input}.eq"]
+        sensor.value = "[" + ", ".join(format_complex(gain) for gain in gains) + "]"
 
 
 class Engine(aiokatcp.DeviceServer):
@@ -1135,54 +1184,13 @@ class Engine(aiokatcp.DeviceServer):
                 chunk.recycle()  # Make available to the stream
 
     def _populate_sensors(self, sensors: aiokatcp.SensorSet, rx_sensor_timeout: float) -> None:
-        """Define the sensors for an engine."""
+        """Define the sensors for an engine (excluding pipeline-specific sensors)."""
         for pol in range(N_POLS):
-            sensors.add(
-                aiokatcp.Sensor(
-                    str,
-                    f"input{pol}.eq",
-                    "For this input, the complex, unitless, per-channel digital scaling factors "
-                    "implemented prior to requantisation",
-                    initial_status=aiokatcp.Sensor.Status.NOMINAL,
-                )
-            )
-            sensors.add(
-                aiokatcp.Sensor(
-                    str,
-                    f"input{pol}.delay",
-                    "The delay settings for this input: (loadmcnt <ADC sample "
-                    "count when model was loaded>, delay <in seconds>, "
-                    "delay-rate <unit-less or, seconds-per-second>, "
-                    "phase <radians>, phase-rate <radians per second>).",
-                )
-            )
             sensors.add(
                 aiokatcp.Sensor(
                     int,
                     f"input{pol}.dig-clip-cnt",
                     "Number of digitiser samples that are saturated",
-                    default=0,
-                    initial_status=aiokatcp.Sensor.Status.NOMINAL,
-                    auto_strategy=aiokatcp.SensorSampler.Strategy.EVENT_RATE,
-                    auto_strategy_parameters=(MIN_SENSOR_UPDATE_PERIOD, math.inf),
-                )
-            )
-            sensors.add(
-                aiokatcp.Sensor(
-                    float,
-                    f"input{pol}.dig-pwr-dbfs",
-                    "Digitiser ADC average power",
-                    units="dBFS",
-                    status_func=dig_pwr_dbfs_status,
-                    auto_strategy=aiokatcp.SensorSampler.Strategy.EVENT_RATE,
-                    auto_strategy_parameters=(MIN_SENSOR_UPDATE_PERIOD, math.inf),
-                )
-            )
-            sensors.add(
-                aiokatcp.Sensor(
-                    int,
-                    f"input{pol}.feng-clip-cnt",
-                    "Number of output samples that are saturated",
                     default=0,
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,
                     auto_strategy=aiokatcp.SensorSampler.Strategy.EVENT_RATE,

--- a/src/katgpucbf/fgpu/send.py
+++ b/src/katgpucbf/fgpu/send.py
@@ -178,6 +178,7 @@ class Chunk:
         frames: int,
         time_converter: TimeConverter,
         sensors: SensorSet,
+        output_name: str,
     ) -> None:
         """Transmit heaps over SPEAD streams.
 
@@ -201,8 +202,7 @@ class Chunk:
         end_timestamp = self._timestamp + self._timestamp_step * len(self._frames)
         end_time = time_converter.adc_to_unix(end_timestamp)
         for pol in range(N_POLS):
-            # TODO[nb]:
-            sensor = sensors[f"input{pol}.feng-clip-cnt"]
+            sensor = sensors[f"{output_name}.input{pol}.feng-clip-cnt"]
             sensor.set_value(sensor.value + saturated[pol], timestamp=end_time)
 
 

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -570,7 +570,7 @@ class TestEngine:
     ) -> None:
         """Test loading several future delay models."""
         # Set up infrastructure for testing delay sensor updates
-        delay_sensors = [engine_server.sensors[f"input{pol}.delay"] for pol in range(N_POLS)]
+        delay_sensors = [engine_server.sensors[f"wideband.input{pol}.delay"] for pol in range(N_POLS)]
         sensor_updates_dict = self._watch_sensors(delay_sensors)
 
         # To keep things simple, we'll just use phase, not delay.
@@ -770,10 +770,10 @@ class TestEngine:
 
         assert prom_diff.get_sample_diff("output_clipped_samples_total", {"pol": f"{tone_pol}"}) == len(timestamps)
         assert prom_diff.get_sample_diff("output_clipped_samples_total", {"pol": f"{1 - tone_pol}"}) == 0
-        sensor = engine_server.sensors[f"input{tone_pol}.feng-clip-cnt"]
+        sensor = engine_server.sensors[f"wideband.input{tone_pol}.feng-clip-cnt"]
         assert sensor.value == len(timestamps)
         assert sensor.timestamp == SYNC_EPOCH + n_samples / ADC_SAMPLE_RATE
-        sensor = engine_server.sensors[f"input{1 - tone_pol}.feng-clip-cnt"]
+        sensor = engine_server.sensors[f"wideband.input{1 - tone_pol}.feng-clip-cnt"]
         assert sensor.value == 0
         assert sensor.timestamp == SYNC_EPOCH + n_samples / ADC_SAMPLE_RATE
 

--- a/test/fgpu/test_katcp_interface.py
+++ b/test/fgpu/test_katcp_interface.py
@@ -73,7 +73,7 @@ class TestKatcpRequests:
         """Test that the command-line gain is set correctly."""
         reply, _informs = await engine_client.request("gain", pol)
         assert reply == [b"0.125+0.0j"]
-        sensor_value = await get_sensor(engine_client, f"input{pol}.eq")
+        sensor_value = await get_sensor(engine_client, f"wideband.input{pol}.eq")
         assert sensor_value == "[0.125+0.0j]"
 
     @pytest.mark.parametrize("pol", range(N_POLS))
@@ -86,7 +86,7 @@ class TestKatcpRequests:
         assert_valid_complex(value)
         assert complex(value) == pytest.approx(0.2 - 3j)
 
-        sensor_value = await get_sensor(engine_client, f"input{pol}.eq")
+        sensor_value = await get_sensor(engine_client, f"wideband.input{pol}.eq")
         assert_valid_complex_list(sensor_value)
         assert safe_eval(sensor_value) == pytest.approx([0.2 - 3j])
         np.testing.assert_equal(engine_server._pipelines[0].gains[:, pol], np.full(CHANNELS, 0.2 - 3j, np.complex64))
@@ -108,7 +108,7 @@ class TestKatcpRequests:
         reply_array = np.array([complex(aiokatcp.decode(str, value)) for value in reply])
         np.testing.assert_equal(reply_array, gains)
 
-        sensor_value = await get_sensor(engine_client, "input0.eq")
+        sensor_value = await get_sensor(engine_client, "wideband.input0.eq")
         assert_valid_complex_list(sensor_value)
         np.testing.assert_equal(np.array(safe_eval(sensor_value)), gains)
 
@@ -137,7 +137,7 @@ class TestKatcpRequests:
         reply, _informs = await engine_client.request("gain-all", "0.2-3j")
         assert reply == []
         for pol in range(N_POLS):
-            sensor_value = await get_sensor(engine_client, f"input{pol}.eq")
+            sensor_value = await get_sensor(engine_client, f"wideband.input{pol}.eq")
             assert_valid_complex_list(sensor_value)
             assert safe_eval(sensor_value) == pytest.approx([0.2 - 3j])
             np.testing.assert_equal(
@@ -152,7 +152,7 @@ class TestKatcpRequests:
         assert reply == []
         for pol in range(N_POLS):
             np.testing.assert_equal(engine_server._pipelines[0].gains[:, pol], gains)
-            sensor_value = await get_sensor(engine_client, f"input{pol}.eq")
+            sensor_value = await get_sensor(engine_client, f"wideband.input{pol}.eq")
             assert_valid_complex_list(sensor_value)
             np.testing.assert_equal(np.array(safe_eval(sensor_value)), gains)
 
@@ -161,7 +161,7 @@ class TestKatcpRequests:
         await engine_client.request("gain-all", "2+3j")
         await engine_client.request("gain-all", "default")
         for pol in range(N_POLS):
-            sensor_value = await get_sensor(engine_client, f"input{pol}.eq")
+            sensor_value = await get_sensor(engine_client, f"wideband.input{pol}.eq")
             assert sensor_value == "[0.125+0.0j]"
 
     async def test_gain_all_empty(self, engine_client: aiokatcp.Client) -> None:
@@ -194,7 +194,7 @@ class TestKatcpRequests:
             model(1)
 
         for pol in range(N_POLS):
-            sensor_reading = await get_sensor(engine_client, f"input{pol}.delay")
+            sensor_reading = await get_sensor(engine_client, f"wideband.input{pol}.delay")
             sensor_values = sensor_reading[1:-1].split(",")[1:]  # Drop the timestamp
             sensor_values = (float(field.strip()) for field in sensor_values)
 


### PR DESCRIPTION
Prefix the names of eq, delay, feng-clip-cnt and dig-pwr-dbfs sensors with the output name. The last of these is done for expediency: it ought to be roughly the same for all outputs, but it's calculated per-pipeline, and probably not on the identical set of inputs and at the identical cadence due to the interaction with PFB windows.

See NGC-569.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [ ] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match (PR coming soon)