### PR TITLE
Rework fgpu/Engine's unhandled async tasks

### DIFF
--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -724,10 +724,22 @@ class Pipeline:
     async def _chunk_send_and_cleanup(
         self, streams: list["spead2.send.asyncio.AsyncStream"], n_frames: int, chunk: send.Chunk
     ) -> None:
-        """Return a chunk to the free queue after it has completed transmission."""
+        """Transmit a chunk's data and return it to the free queue.
+
+        The returning of the chunk to the free queue happens whether the data
+        transmission was successful or not.
+
+        Parameters
+        ----------
+        streams
+            The streams transmitting data.
+        n_frames
+            Number of frames of data to be transmitted.
+        chunk
+            :class:`~send.Chunk` used to facilitate data transmission.
+        """
         try:
-            task = asyncio.create_task(chunk.send(streams, n_frames, self.engine.time_converter, self.engine.sensors))
-            await task
+            await chunk.send(streams, n_frames, self.engine.time_converter, self.engine.sensors)
         except asyncio.CancelledError:
             pass
         except Exception:

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -841,7 +841,7 @@ class Pipeline:
             try:
                 await task
             except Exception:
-                pass  # It's already logged by chunk_send_and_cleanup
+                pass  # It's already logged by _chunk_send_and_cleanup
         stop_heap = spead2.send.Heap(send.FLAVOUR)
         stop_heap.add_end()
         for substream_index in self.substreams:


### PR DESCRIPTION
Two points to consider when reviewing:
1. As you can see, I went for the **literal** option in renaming `Pipeline::_chunk_finished` - happy to change as requested.
2. I decided not to roll the _send and cleanup_ functionality/chain of events into `Chunk.send` because it needed the `logger` to log the unexpected `Exception` - and the params list was busy enough anyway.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml` (N/A)
- [x] If modules are added/removed: use sphinx-apidoc to update files in `doc/` (N/A)
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report (N/A)
- [x] If design has changed: ensure documentation is up to date (N/A)
- [x] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match (N/A)

Closes NGC-899.
