### PR TITLE
Report dither-seed sensor as a str, not int

### DIFF
--- a/src/katgpucbf/dsim/server.py
+++ b/src/katgpucbf/dsim/server.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2021-2022, National Research Foundation (SARAO)
+# Copyright (c) 2021-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -119,11 +119,11 @@ class DeviceServer(aiokatcp.DeviceServer):
         self.sensors.add(self._steady_state_sensor)
         self.sensors.add(
             aiokatcp.Sensor(
-                int,
+                str,
                 "dither-seed",
                 "Random seed used in dithering for quantisation",
                 initial_status=aiokatcp.Sensor.Status.NOMINAL,
-                default=dither_seed,
+                default=str(dither_seed),
             )
         )
         self.sensors.add(


### PR DESCRIPTION
Apparently some katcp clients have issues with the extremely large int value.

Closes NGC-919.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
