### PR TITLE
Rename "decimation" to "subsampling" in DDC kernel

### DIFF
--- a/doc/fgpu.design.rst
+++ b/doc/fgpu.design.rst
@@ -544,12 +544,19 @@ performed:
 2. The signal is convolved with a low-pass filter. This eliminates the
    unwanted parts of the band, to the extent possible with a FIR filter.
 
-3. The signal is decimated (every Nth sample is retained), reducing the data
+3. The signal is subsampled (every Nth sample is retained), reducing the data
    rate. The low-pass filter above limits aliasing.
 
 For efficiency, all three operations are implemented in the same kernel. In
-particular, the filtered samples that would be removed by decimation are never
+particular, the filtered samples that would be removed by subsampling are never
 actually computed.
+
+.. note::
+   To avoid confusion, the "subsampling factor" is the ratio of original to
+   retained samples in the subsampling step, while the "decimation factor" is
+   the factor by which the bandwidth is reduced. Because the mixing turns a
+   real signal into a complex signal, the subsampling factor is twice the
+   decimation factor.
 
 The kernel is one of the more complex in katgpucbf. Simpler implementations
 tend to have low performance because the target GPUs (NVIDIA Ampere

--- a/src/katgpucbf/fgpu/ddc.py
+++ b/src/katgpucbf/fgpu/ddc.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2022, National Research Foundation (SARAO)
+# Copyright (c) 2022-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katgpucbf/fgpu/ddc.py
+++ b/src/katgpucbf/fgpu/ddc.py
@@ -44,42 +44,44 @@ class DDCTemplate:
         The GPU context that we'll operate in
     taps
         Number of taps in the FIR filter
-    decimation
+    subsampling
         Fraction of samples to retain after filtering
 
     Raises
     ------
     ValueError
-        If `taps` is not a multiple of `decimation`
+        If `taps` is not a multiple of `subsampling`
     """
 
-    def __init__(self, context: AbstractContext, taps: int, decimation: int, tuning: _TuningDict | None = None) -> None:
+    def __init__(
+        self, context: AbstractContext, taps: int, subsampling: int, tuning: _TuningDict | None = None
+    ) -> None:
         if taps <= 0:
             raise ValueError("taps must be positive")
-        if decimation <= 0:
-            raise ValueError("decimation must be positive")
-        if taps % decimation != 0:
-            raise ValueError("taps must be a multiple of decimation")
+        if subsampling <= 0:
+            raise ValueError("subsampling must be positive")
+        if taps % subsampling != 0:
+            raise ValueError("taps must be a multiple of subsampling")
         if tuning is None:
-            tuning = self.autotune(context, taps, decimation)
+            tuning = self.autotune(context, taps, subsampling)
         self.context = context
         self.wgs = tuning["wgs"]
         self._sg_size = tuning["sg_size"]
         self._coarsen = tuning["coarsen"]
         self._segment_samples = tuning["segment_samples"]
         self.taps = taps
-        self.decimation = decimation
+        self.subsampling = subsampling
 
         self._group_out_size = self.wgs // self._sg_size * self._coarsen
-        self._group_in_size = self._group_out_size * decimation
-        self._load_size = self._group_in_size + taps - decimation
+        self._group_in_size = self._group_out_size * subsampling
+        self._load_size = self._group_in_size + taps - subsampling
         self._segments = (self._load_size - 1) // (self._segment_samples * self.wgs) + 1
 
         # Sanity check the tuning parameters
         if self.wgs % self._sg_size:
             raise ValueError("wgs must be a multiple of sg_size")
-        if self.decimation % self._sg_size:
-            raise ValueError("decimation must be a multiple of sg_size")
+        if self.subsampling % self._sg_size:
+            raise ValueError("subsampling must be a multiple of sg_size")
         if self._group_in_size % self._segment_samples:
             raise ValueError("group_in_size must be a multiple of segment_samples (fix sg_size)")
         if self._segment_samples * DIG_SAMPLE_BITS % 32:
@@ -92,7 +94,7 @@ class DDCTemplate:
                 {
                     "wgs": self.wgs,
                     "taps": taps,
-                    "decimation": decimation,
+                    "subsampling": subsampling,
                     "coarsen": self._coarsen,
                     "sg_size": self._sg_size,
                     "sample_bits": DIG_SAMPLE_BITS,
@@ -102,7 +104,7 @@ class DDCTemplate:
             )
         self.kernel = program.get_kernel("ddc")
 
-    def autotune(self, context: AbstractContext, taps: int, decimation: int) -> _TuningDict:
+    def autotune(self, context: AbstractContext, taps: int, subsampling: int) -> _TuningDict:
         """Determine tuning parameters.
 
         .. todo::
@@ -113,7 +115,7 @@ class DDCTemplate:
         coarsen = 9
         sg_size = 2
         segment_samples = 16
-        while sg_size > 1 and decimation % sg_size != 0:
+        while sg_size > 1 and subsampling % sg_size != 0:
             sg_size //= 2
         return {"wgs": wgs, "coarsen": coarsen, "sg_size": sg_size, "segment_samples": segment_samples}
 
@@ -143,7 +145,7 @@ class DDC(accel.Operation):
     **in** : samples * DIG_SAMPLE_BITS // BYTE_BITS, uint8
         Input digitiser samples in a big chunk.
     **out** : out_samples, complex64
-        Filtered and decimated output data
+        Filtered and subsampled output data
     **weights** : taps, float32
         Baseband filter coefficients. If the filter is asymmetric, the
         coefficients must be reversed: the first element gets
@@ -172,7 +174,7 @@ class DDC(accel.Operation):
             raise ValueError("samples must be at least the number of filter taps")
         self.template = template
         self.samples = samples
-        self.out_samples = accel.divup(samples - template.taps + 1, template.decimation)
+        self.out_samples = accel.divup(samples - template.taps + 1, template.subsampling)
         self.slots["in"] = accel.IOSlot(
             (
                 accel.Dimension(

--- a/test/fgpu/test_ddc.py
+++ b/test/fgpu/test_ddc.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2022, National Research Foundation (SARAO)
+# Copyright (c) 2022-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy


### PR DESCRIPTION
The term "decimation" is used elsewhere in CBF to mean the factor by which bandwidth is reduced, rather than the factor by which the sample rate is reduced. The mixing+filtering removes the symmetry properties of the original real-valued signal, so they differ by a factor of 2.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-925.
