### PR TITLE
Add complex version of PFB filter

### DIFF
--- a/src/katgpucbf/fgpu/compute.py
+++ b/src/katgpucbf/fgpu/compute.py
@@ -116,7 +116,7 @@ class Compute(accel.OperationSequence):
         spectra: int,
         spectra_per_heap: int,
     ) -> None:
-        self.dig_sample_bits = template.pfb_fir.dig_sample_bits
+        self.dig_sample_bits = template.pfb_fir.input_sample_bits
         self.template = template
         self.samples = samples
         self.spectra = spectra

--- a/src/katgpucbf/fgpu/kernels/unpack_float.mako
+++ b/src/katgpucbf/fgpu/kernels/unpack_float.mako
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2023, National Research Foundation (SARAO)
+ *
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+/* Provide a similar interface to unpack.mako, but for input that is already
+ * in float32.
+ */
+
+typedef float sample_t;  // type returned by unpack_read
+
+/* An "address" for a sample. */
+struct unpack_t
+{
+    const GLOBAL sample_t *ptr;
+};
+
+/* Initialise an unpack_t, given the pointer to the base of the array and
+ * the sample index.
+ */
+DEVICE_FN void unpack_init(unpack_t *unpack, const GLOBAL sample_t *in, unsigned int idx)
+{
+    unpack->ptr = in + idx;
+}
+
+// Dereference an unpack_t to get the sample value
+DEVICE_FN sample_t unpack_read(const unpack_t *unpack)
+{
+    return *unpack->ptr;
+}
+
+// Increment an unpack_t by a given number of samples.
+DEVICE_FN void unpack_advance(unpack_t *unpack, unsigned int dist)
+{
+    unpack->ptr += dist;
+}


### PR DESCRIPTION
With narrowband, the PFB will take its input from the DDC filter output i.e. complex64 rather than packed real values. Add support for that mode of operation.

The complex version also does not emit digitiser total power, since it is not the first step in the pipeline.

There are probably going to need to be some updates to the design documentation, but I'll rather do a separate update to bring that up to date once I've got everything implemented.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [ ] If design has changed: ensure documentation is up to date
- [x] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-925.
