### PR TITLE
Remove built docker image from host after push

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -163,8 +163,8 @@ pipeline {
           docker.withRegistry("https://harbor.sdp.kat.ac.za/", "harbor-cbf") {
             dockerImage.push()
           }
-        // Remove the built and pushed Docker image from host
-        sh "docker rmi ${dockerImage.id}"
+          // Remove the built and pushed Docker image from host
+          sh "docker rmi ${dockerImage.id}"
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -163,9 +163,9 @@ pipeline {
           docker.withRegistry("https://harbor.sdp.kat.ac.za/", "harbor-cbf") {
             dockerImage.push()
           }
-        }
         // Remove the built and pushed Docker image from host
-        sh "docker rmi \$(docker images --quiet --filter label=org.opencontainers.image.revision=${env.GIT_COMMIT})"
+        sh "docker rmi ${dockerImage.id}"
+        }
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -164,6 +164,8 @@ pipeline {
             dockerImage.push()
           }
         }
+        // Remove the built and pushed Docker image from host
+        sh "docker rmi \$(docker images --quiet --filter label=org.opencontainers.image.revision=${env.GIT_COMMIT})"
       }
     }
   }
@@ -187,7 +189,6 @@ pipeline {
       recipientProviders: [developers(), requestor(), culprits()],
       subject: '$PROJECT_NAME - $BUILD_STATUS!',
       to: '$DEFAULT_RECIPIENTS'
-
 
       cleanWs()
     }


### PR DESCRIPTION
This change removes the test image from the host machine, after it has been built and pushed to harbor. This prevents the disk on the host machine from filling up with images after many builds.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-934.
