### PR TITLE
Report: Fix test names shown in "Requirements Verified"

### DIFF
--- a/qualification/report/generate_pdf.py
+++ b/qualification/report/generate_pdf.py
@@ -509,9 +509,7 @@ def extract_requirements_verified(results: Iterable[Result]) -> dict[str, list[s
     requirements_verified = defaultdict(list)
     for result in results:
         for requirement in result.requirements:
-            # TODO: This will need to be adapted once NGC-656 is merged.
-            test_name = fix_test_name(result.name).split("[")[0]  # Remove the param list at the back.
-            requirements_verified[requirement].append(test_name)
+            requirements_verified[requirement].append(result.text_name)
     # Remove duplicates from the lists.
     for key in requirements_verified.keys():
         requirements_verified[key] = sorted(set(requirements_verified[key]))


### PR DESCRIPTION
It was still directly coding the logic of title-casing the Python function name, ignoring the more recent support for the test name to be specified via decorator.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Example: [test-report.pdf](https://github.com/ska-sa/katgpucbf/files/11250246/test-report.pdf)
