### PR TITLE
Enable engine unit tests for narrowband

### DIFF
--- a/test/fgpu/conftest.py
+++ b/test/fgpu/conftest.py
@@ -108,6 +108,7 @@ async def engine_server(
     # added by less-specific markers.
     for marker in reversed(list(request.node.iter_markers("cmdline_args"))):
         if marker.kwargs.get("remove_outputs"):
+            raise NotImplementedError("remove_outputs needs to be replaced")
             arglist = [arg for arg in arglist if not arg.startswith(("--wideband=", "--narrowband="))]
         arglist.extend(marker.args)
 

--- a/test/fgpu/conftest.py
+++ b/test/fgpu/conftest.py
@@ -95,9 +95,6 @@ async def engine_server(
     tested.
 
     Extra command-line arguments can be added using a ``cmdline_args`` marker.
-    If a keyword-only `remove_outputs` argument is set to true, any existing
-    arguments starting with ``--wideband=`` or ``--narrowband=`` are removed
-    first.
     """
     arglist = list(engine_arglist)  # Copy, to ensure we don't alter original
     if request.node.get_closest_marker("use_vkgdr"):
@@ -107,9 +104,6 @@ async def engine_server(
     # that more specific markers append options to the end, overriding those
     # added by less-specific markers.
     for marker in reversed(list(request.node.iter_markers("cmdline_args"))):
-        if marker.kwargs.get("remove_outputs"):
-            raise NotImplementedError("remove_outputs needs to be replaced")
-            arglist = [arg for arg in arglist if not arg.startswith(("--wideband=", "--narrowband="))]
         arglist.extend(marker.args)
 
     args = parse_args(arglist)

--- a/test/fgpu/conftest.py
+++ b/test/fgpu/conftest.py
@@ -80,7 +80,12 @@ def check_vkgdr(context: AbstractContext) -> None:
 
 @pytest.fixture
 async def engine_server(
-    request, mock_recv_streams, mock_send_stream, recv_max_chunks_one, context: AbstractContext
+    request,
+    engine_arglist: list[str],
+    mock_recv_streams,
+    mock_send_stream,
+    recv_max_chunks_one,
+    context: AbstractContext,
 ) -> AsyncGenerator[Engine, None]:
     """Create a dummy :class:`.fgpu.Engine` for unit testing.
 
@@ -94,7 +99,7 @@ async def engine_server(
     arguments starting with ``--wideband=`` or ``--narrowband=`` are removed
     first.
     """
-    arglist = list(request.cls.engine_arglist)
+    arglist = list(engine_arglist)  # Copy, to ensure we don't alter original
     if request.node.get_closest_marker("use_vkgdr"):
         check_vkgdr(context)
         arglist.append("--use-vkgdr")

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -923,12 +923,17 @@ class TestEngine:
             )
             == 0
         )
+
+        # Compute the expected timestamp. The timestamp is associated with the
+        # output chunk, so we need to round up to output chunk size.
+        last_timestamp = roundup(timestamps[-1] + 1, engine_server.chunk_jones * output.decimation * 2)
+
         sensor = engine_server.sensors[f"test_stream.input{tone_pol}.feng-clip-cnt"]
         assert sensor.value == len(timestamps)
-        assert sensor.timestamp == SYNC_EPOCH + n_samples / ADC_SAMPLE_RATE
+        assert sensor.timestamp == SYNC_EPOCH + last_timestamp / ADC_SAMPLE_RATE
         sensor = engine_server.sensors[f"test_stream.input{1 - tone_pol}.feng-clip-cnt"]
         assert sensor.value == 0
-        assert sensor.timestamp == SYNC_EPOCH + n_samples / ADC_SAMPLE_RATE
+        assert sensor.timestamp == SYNC_EPOCH + last_timestamp / ADC_SAMPLE_RATE
 
     def _patch_fill_in(self, monkeypatch, engine_client: aiokatcp.Client, *request) -> list[int]:
         """Patch Pipeline._fill_in` to make a request partway through the stream.

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -33,7 +33,7 @@ from katgpucbf.fgpu import METRIC_NAMESPACE
 from katgpucbf.fgpu.delay import wrap_angle
 from katgpucbf.fgpu.engine import Engine, InItem, Pipeline
 from katgpucbf.fgpu.main import parse_narrowband, parse_wideband
-from katgpucbf.fgpu.output import Output
+from katgpucbf.fgpu.output import NarrowbandOutput, Output
 from katgpucbf.utils import TimeConverter
 
 from .. import PromDiff, packbits
@@ -533,6 +533,9 @@ class TestEngine:
         dig_sample_bits: int,
     ) -> None:
         """Test that delay rate and phase rate setting works."""
+        # TODO[nb]: Narrowband doesn't support non-default dig_sample_bits yet
+        if isinstance(output, NarrowbandOutput) and dig_sample_bits != DIG_SAMPLE_BITS:
+            pytest.skip(f"narrowband does not support dig_sample_bits={dig_sample_bits}")
         # One tone at centre frequency to test the absolute phase, and one at another
         # frequency to test the slope across the band.
         tone_channels = [CHANNELS // 2, CHANNELS - 123]

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -323,6 +323,7 @@ class TestEngine:
             dst_present_mask = np.ones(dst_present, dtype=bool)
         else:
             dst_present_mask = dst_present
+        assert np.sum(dst_present_mask) > 0
 
         data = np.zeros((channels, len(dst_present_mask) * spectra_per_heap, N_POLS, COMPLEX), np.int8)
         channels_per_substream = channels // n_out_streams

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -415,7 +415,7 @@ class TestEngine:
             tone_data = out_data[tone_channels[pol], :, pol]
             expected_mag = tones[pol].magnitude * COHERENT_SCALE * GAIN
             assert 50 <= expected_mag < 127, "Magnitude is outside of good range for testing"
-            np.testing.assert_equal(np.abs(tone_data), pytest.approx(expected_mag, 2))
+            np.testing.assert_equal(np.abs(tone_data), pytest.approx(expected_mag, abs=3))
             # The frequency corresponds to an integer number of cycles per
             # spectrum, so the phase will be consistent across spectra.
             # The accuracy is limited by the quantisation.

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -360,7 +360,7 @@ class TestEngine:
         # Convert to complex for analysis
         data_cplx = data[..., 0] + 1j * data[..., 1]
         assert expected_first_timestamp is not None
-        timestamps = np.arange(data_cplx.shape[1], dtype=np.int64) * (channels * 2) + expected_first_timestamp
+        timestamps = np.arange(data_cplx.shape[1], dtype=np.int64) * output.spectra_samples + expected_first_timestamp
         return data_cplx, timestamps
 
     # One delay value is tested with vkgdr, another with smaller output chunks

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -868,7 +868,7 @@ class TestEngine:
         monkeypatch,
     ) -> None:
         """Test that the ``steady-state-timestamp`` is updated correctly after ``?gain``."""
-        n_samples = 8 * CHUNK_SAMPLES
+        n_samples = max(8 * CHUNK_SAMPLES, output.spectra_samples * SPECTRA_PER_HEAP * 3)
         rng = np.random.default_rng(1)
         dig_data = rng.integers(-255, 255, size=(2, n_samples), dtype=np.int16)
 
@@ -903,7 +903,7 @@ class TestEngine:
         monkeypatch,
     ) -> None:
         """Test that the ``steady-state-timestamp`` is updated correctly after ``?delays``."""
-        n_samples = 8 * CHUNK_SAMPLES
+        n_samples = max(8 * CHUNK_SAMPLES, output.spectra_samples * SPECTRA_PER_HEAP * 3)
         dig_data = self._make_tone(n_samples, CW(frac_channel=0.5, magnitude=100), 0)
 
         timestamp_list = self._patch_fill_in(

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -707,6 +707,8 @@ class TestEngine:
         mock_send_stream: list[spead2.InprocQueue],
         engine_server: Engine,
         engine_client: aiokatcp.Client,
+        extra_delay_samples: float,
+        extra_phase: float,
         output: Output,
     ) -> None:
         """Test loading several future delay models."""
@@ -716,7 +718,9 @@ class TestEngine:
 
         # To keep things simple, we'll just use phase, not delay.
         tone_channel = CHANNELS // 2
-        tone = CW(frac_channel=0.5, magnitude=110)
+        tone = CW(
+            frac_channel=frac_channel(output, tone_channel), magnitude=110, delay=extra_delay_samples, phase=extra_phase
+        )
         src_layout = engine_server.src_layout
         n_samples = 10 * src_layout.chunk_samples
         dig_data = self._make_tone(n_samples, tone, 0)

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -864,7 +864,7 @@ class TestEngine:
         """Test that the ``dig-clip-cnt`` sensors are set correctly."""
         sensors = [engine_server.sensors[f"input{pol}.dig-clip-cnt"] for pol in range(N_POLS)]
         sensor_update_dict = self._watch_sensors(sensors)
-        n_samples = 3 * CHUNK_SAMPLES
+        n_samples = 9 * CHUNK_SAMPLES
         dig_data = np.zeros((2, n_samples), np.int16)
         saturation_value = 2 ** (engine_server.src_layout.sample_bits - 1) - 1
         dig_data[0, 10000:15000] = saturation_value
@@ -879,10 +879,10 @@ class TestEngine:
         # TODO: turn aiokatcp.Reading into a dataclass (or at least implement
         # __eq__ and __repr__) so that it can be used in comparisons.
         time_converter = TimeConverter(SYNC_EPOCH, ADC_SAMPLE_RATE)
-        expected_timestamps = [time_converter.adc_to_unix(t) for t in [524288, 1048576, 1572864]]
-        assert [r.value for r in sensor_update_dict[sensors[0].name]] == [5000, 5000, 5000]
+        expected_timestamps = [time_converter.adc_to_unix(t * 524288) for t in range(1, 10)]
+        assert [r.value for r in sensor_update_dict[sensors[0].name]] == [5000] * 9
         assert [r.timestamp for r in sensor_update_dict[sensors[0].name]] == expected_timestamps
-        assert [r.value for r in sensor_update_dict[sensors[1].name]] == [0, 0, 10000]
+        assert [r.value for r in sensor_update_dict[sensors[1].name]] == [0, 0] + [10000] * 7
         assert [r.timestamp for r in sensor_update_dict[sensors[1].name]] == expected_timestamps
 
     @pytest.mark.parametrize("tone_pol", [0, 1])

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -98,25 +98,27 @@ class CW:
 class TestEngine:
     r"""Grouping of unit tests for :class:`.Engine`\'s various functionality."""
 
-    engine_arglist = [
-        "--katcp-host=127.0.0.1",
-        "--katcp-port=0",
-        "--src-interface=lo",
-        "--dst-interface=lo",
-        f"--sync-epoch={SYNC_EPOCH}",
-        f"--src-chunk-samples={CHUNK_SAMPLES}",
-        f"--dst-chunk-jones={CHUNK_JONES}",
-        f"--max-delay-diff={MAX_DELAY_DIFF}",
-        f"--spectra-per-heap={SPECTRA_PER_HEAP}",
-        f"--src-packet-samples={PACKET_SAMPLES}",
-        f"--feng-id={FENG_ID}",
-        f"--adc-sample-rate={ADC_SAMPLE_RATE}",
-        f"--gain={GAIN}",
-        "--send-rate-factor=0",  # Infinitely fast
-        f"--wideband=name=wideband,dst=239.10.11.0+15:7149,channels={CHANNELS},taps={TAPS}",
-        "239.10.10.0+7:7149",  # src1
-        "239.10.10.8+7:7149",  # src2
-    ]
+    @pytest.fixture
+    def engine_arglist(self) -> list[str]:
+        return [
+            "--katcp-host=127.0.0.1",
+            "--katcp-port=0",
+            "--src-interface=lo",
+            "--dst-interface=lo",
+            f"--sync-epoch={SYNC_EPOCH}",
+            f"--src-chunk-samples={CHUNK_SAMPLES}",
+            f"--dst-chunk-jones={CHUNK_JONES}",
+            f"--max-delay-diff={MAX_DELAY_DIFF}",
+            f"--spectra-per-heap={SPECTRA_PER_HEAP}",
+            f"--src-packet-samples={PACKET_SAMPLES}",
+            f"--feng-id={FENG_ID}",
+            f"--adc-sample-rate={ADC_SAMPLE_RATE}",
+            f"--gain={GAIN}",
+            "--send-rate-factor=0",  # Infinitely fast
+            f"--wideband=name=wideband,dst=239.10.11.0+15:7149,channels={CHANNELS},taps={TAPS}",
+            "239.10.10.0+7:7149",  # src1
+            "239.10.10.8+7:7149",  # src2
+        ]
 
     def test_engine_required_arguments(self, engine_server: Engine) -> None:
         """Test proper setting of required arguments.

--- a/test/fgpu/test_katcp_interface.py
+++ b/test/fgpu/test_katcp_interface.py
@@ -55,18 +55,20 @@ def assert_valid_complex_list(value: str) -> None:
 class TestKatcpRequests:
     """Unit tests for the Engine's KATCP requests."""
 
-    engine_arglist = [
-        "--katcp-host=127.0.0.1",
-        "--katcp-port=0",
-        "--src-interface=lo",
-        "--dst-interface=lo",
-        f"--sync-epoch={SYNC_EPOCH}",
-        f"--gain={GAIN}",
-        "--adc-sample-rate=1.712e9",
-        f"--wideband=name=wideband,dst=239.10.11.0+15:7149,channels={CHANNELS}",
-        "239.10.10.0+7:7149",  # src1
-        "239.10.10.8+7:7149",  # src2
-    ]
+    @pytest.fixture
+    def engine_arglist(self) -> list[str]:
+        return [
+            "--katcp-host=127.0.0.1",
+            "--katcp-port=0",
+            "--src-interface=lo",
+            "--dst-interface=lo",
+            f"--sync-epoch={SYNC_EPOCH}",
+            f"--gain={GAIN}",
+            "--adc-sample-rate=1.712e9",
+            f"--wideband=name=wideband,dst=239.10.11.0+15:7149,channels={CHANNELS}",
+            "239.10.10.0+7:7149",  # src1
+            "239.10.10.8+7:7149",  # src2
+        ]
 
     @pytest.mark.parametrize("pol", range(N_POLS))
     async def test_initial_gain(self, engine_client: aiokatcp.Client, pol: int) -> None:


### PR DESCRIPTION
There are a few sorts of changes here:

- The way the fixtures are set up (particularly command-line arguments) is changed to allow it to be parametrized over the different stream types. At this point the TestEngine class isn't actually necessary (all the tests could be free functions), but I'm keeping it for now because later we will probably want to add some tests that cover using wideband+narrowband together, and those will need different setup that can probably be put into a separate class.
- Some tests needed to be updated to use `output.spectra_samples` instead of `2 * channels` or `output.window` instead of `2 * channels * pfb_taps`.
- Some tests need to pump more data through to take into account the much larger window/spectra_samples for narrowband.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Mostly addresses NGC-949, but it will still need some tests for combining wide+narrow.
