### PR TITLE
Increase the default src-chunk-samples

### DIFF
--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -383,7 +383,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--src-chunk-samples",
         type=int,
-        default=2**24,
+        default=2**25,
         metavar="SAMPLES",
         help="Number of digitiser samples to process at a time (per pol). [%(default)s]",
     )


### PR DESCRIPTION
This improves performance of 1/8 narrowband, and makes 1/16 narrowband function.

Closes NGC-953.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
