### PR TITLE
Make output Prom counters exist from the start

### DIFF
--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1340,6 +1340,7 @@ class Engine(aiokatcp.DeviceServer):
         This method should only be called by :class:`Pipeline`.
         """
         return send.make_streams(
+            output_name=output.name,
             thread_pool=self._send_thread_pool,
             endpoints=output.dst,
             interfaces=self._dst_interface,

--- a/src/katgpucbf/fgpu/send.py
+++ b/src/katgpucbf/fgpu/send.py
@@ -212,6 +212,7 @@ class Chunk:
 
 def make_streams(
     *,
+    output_name: str,
     thread_pool: spead2.ThreadPool,
     endpoints: list[Endpoint],
     interfaces: list[str],
@@ -268,6 +269,14 @@ def make_streams(
         # interfaces. IDs may get reused after 2^40/num_ants heaps, which should
         # be much larger than a receiver's window.
         stream.set_cnt_sequence((i << 40) + feng_id, num_ants)
+    # Referencing the labels causes them to be created, in advance of data
+    # actually being transmitted.
+    output_heaps_counter.labels(output_name)
+    output_bytes_counter.labels(output_name)
+    output_samples_counter.labels(output_name)
+    skipped_heaps_counter.labels(output_name)
+    for pol in range(N_POLS):
+        output_clip_counter.labels(output_name, pol)
     return streams
 
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -47,7 +47,7 @@ class PromDiff:
         self,
         *,
         registry: prometheus_client.CollectorRegistry = prometheus_client.REGISTRY,
-        namespace: str | None = None
+        namespace: str | None = None,
     ) -> None:
         self._registry = registry
         self._before: list[prometheus_client.samples.Sample] = []
@@ -82,7 +82,7 @@ class PromDiff:
         """Return the increase in the metric during the context manager protocol.
 
         If it is not found, returns ``None``. If it was not found on entry,
-        returns the value on exit.
+        raises an exception.
         """
         if labels is None:
             labels = {}
@@ -90,6 +90,8 @@ class PromDiff:
         after = self._get_value(self._after, name, labels)
         if before is not None and after is not None:
             return after - before
+        elif after is not None:
+            raise ValueError(f"Metric {name}{labels} did not exist at start")
         else:
             return after
 


### PR DESCRIPTION
Because narrowband support changes made them labelled by the output stream, they didn't exist at all until the first time they were referenced for a specific stream. Ensure that they get referenced (and hence made to exist) before any data is transmitted.

Closes NGC-956.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
