### PR TITLE
xbgpu: add command-line arguments for beamformer

### DIFF
--- a/doc/katgpucbf.xbgpu.output.rst
+++ b/doc/katgpucbf.xbgpu.output.rst
@@ -1,0 +1,7 @@
+katgpucbf.xbgpu.output module
+=============================
+
+.. automodule:: katgpucbf.xbgpu.output
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/katgpucbf.xbgpu.rst
+++ b/doc/katgpucbf.xbgpu.rst
@@ -10,6 +10,7 @@ Submodules
    katgpucbf.xbgpu.correlation
    katgpucbf.xbgpu.engine
    katgpucbf.xbgpu.main
+   katgpucbf.xbgpu.output
    katgpucbf.xbgpu.recv
    katgpucbf.xbgpu.xsend
 

--- a/scratch/xbgpu/run-xbgpu.sh
+++ b/scratch/xbgpu/run-xbgpu.sh
@@ -46,6 +46,7 @@ exec spead2_net_raw numactl -C $other_affinity xbgpu \
     --src-interface $iface \
     --dst-interface $iface \
     --src-ibv --dst-ibv \
+    --corrprod=name=bcp1,dst=$dst_mcast \
     --adc-sample-rate ${adc_sample_rate:-1712000000} \
     --array-size ${array_size:-64} \
     --spectra-per-heap ${spectra_per_heap:-256} \
@@ -57,4 +58,4 @@ exec spead2_net_raw numactl -C $other_affinity xbgpu \
     --sync-epoch 0 \
     --katcp-port $port \
     --tx-enabled \
-    $src_mcast $dst_mcast
+    $src_mcast

--- a/scratch/xbgpu/run-xbgpu.sh
+++ b/scratch/xbgpu/run-xbgpu.sh
@@ -46,7 +46,7 @@ exec spead2_net_raw numactl -C $other_affinity xbgpu \
     --src-interface $iface \
     --dst-interface $iface \
     --src-ibv --dst-ibv \
-    --corrprod=name=bcp1,dst=$dst_mcast \
+    --corrprod=name=bcp1,heap_accumulation_threshold=${heap_accumulation_threshold:-52},samples_between_spectra=${samples_between_spectra:-$((channels*2))},spectra_per_heap=${spectra_per_heap:-256},dst=$dst_mcast \
     --adc-sample-rate ${adc_sample_rate:-1712000000} \
     --array-size ${array_size:-64} \
     --spectra-per-heap ${spectra_per_heap:-256} \

--- a/scratch/xbgpu/run-xbgpu.sh
+++ b/scratch/xbgpu/run-xbgpu.sh
@@ -54,7 +54,6 @@ exec spead2_net_raw numactl -C $other_affinity xbgpu \
     --channels-per-substream $channels_per_substream \
     --samples-between-spectra ${samples_between_spectra:-$((channels*2))} \
     --channel-offset-value $channel_offset \
-    --heap-accumulation-threshold ${heap_accumulation_threshold:-52} \
     --sync-epoch 0 \
     --katcp-port $port \
     --tx-enabled \

--- a/scratch/xbgpu/run-xbgpu.sh
+++ b/scratch/xbgpu/run-xbgpu.sh
@@ -46,7 +46,7 @@ exec spead2_net_raw numactl -C $other_affinity xbgpu \
     --src-interface $iface \
     --dst-interface $iface \
     --src-ibv --dst-ibv \
-    --corrprod=name=bcp1,heap_accumulation_threshold=${heap_accumulation_threshold:-52},samples_between_spectra=${samples_between_spectra:-$((channels*2))},spectra_per_heap=${spectra_per_heap:-256},dst=$dst_mcast \
+    --corrprod=name=bcp1,heap_accumulation_threshold=${heap_accumulation_threshold:-52},dst=$dst_mcast \
     --adc-sample-rate ${adc_sample_rate:-1712000000} \
     --array-size ${array_size:-64} \
     --spectra-per-heap ${spectra_per_heap:-256} \

--- a/src/katgpucbf/fgpu/compute.py
+++ b/src/katgpucbf/fgpu/compute.py
@@ -115,7 +115,7 @@ class Compute(accel.OperationSequence):
     - spectra_per_heap <= spectra - i.e. a chunk of data must be enough to send out at
       least one heap.
     - spectra % spectra_per_heap == 0
-    - samples >= output.window (see :class:`.Output`). An input chunk requires
+    - samples >= output.window (see :class:`.fgpu.output.Output`). An input chunk requires
       at least enough samples to output a single spectrum.
     - samples % 8 == 0
 

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -42,7 +42,6 @@ import numpy as np
 import spead2.recv
 from aiokatcp import DeviceServer
 from katsdpsigproc import accel
-from katsdptelstate.endpoint import Endpoint
 
 from .. import (
     DESCRIPTOR_TASK_NAME,
@@ -61,7 +60,7 @@ from ..send import DescriptorSender
 from ..utils import DeviceStatusSensor, TimeConverter, add_time_sync_sensors
 from . import recv
 from .correlation import Correlation, CorrelationTemplate
-from .output import Output, XengineOutput
+from .output import Output, XOutput
 from .xsend import XSend, incomplete_accum_counter, make_stream
 
 logger = logging.getLogger(__name__)
@@ -197,7 +196,7 @@ class XBEngine(DeviceServer):
         spectrum reassembly by the downstream receiver.
     outputs
         Output streams to generate. Currently this must be a single
-        XengineOutput.
+        XOutput.
     src
         Endpoint for the incoming data.
     src_interface
@@ -267,7 +266,6 @@ class XBEngine(DeviceServer):
         src_affinity: int,
         src_comp_vector: int,
         src_buffer: int,
-        dst: Endpoint,
         dst_interface: str,
         dst_ttl: int,
         dst_ibv: bool,
@@ -285,7 +283,7 @@ class XBEngine(DeviceServer):
 
         # B-engine doesn't work yet
         assert len(outputs) == 1
-        assert isinstance(outputs[0], XengineOutput)
+        assert isinstance(outputs[0], XOutput)
 
         if sample_bits != 8:
             raise ValueError("sample_bits must equal 8 - no other values supported at the moment.")
@@ -443,8 +441,8 @@ class XBEngine(DeviceServer):
             context=self.context,
             packet_payload=dst_packet_payload,
             stream_factory=lambda stream_config, buffers: make_stream(
-                dest_ip=dst.host,
-                dest_port=dst.port,
+                dest_ip=outputs[0].dst[0].host,
+                dest_port=outputs[0].dst[0].port,
                 interface_ip=dst_interface,
                 ttl=dst_ttl,
                 use_ibv=dst_ibv,

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -305,6 +305,7 @@ class XBEngine(DeviceServer):
         self.heap_accumulation_threshold = heap_accumulation_threshold
         self.time_converter = TimeConverter(sync_epoch, adc_sample_rate_hz)
         self.n_ants = n_ants
+        self.n_channels_per_stream = n_channels_per_stream
         self.sample_bits = sample_bits
         self.channel_offset_value = channel_offset_value
 
@@ -346,7 +347,6 @@ class XBEngine(DeviceServer):
                 * self.rx_heap_timestamp_step
                 / adc_sample_rate_hz,
             ),
-            (channel_offset_value, channel_offset_value + n_channels_per_stream),
         )
 
         self.timestamp_increment_per_accumulation = self.heap_accumulation_threshold * self.rx_heap_timestamp_step
@@ -467,7 +467,6 @@ class XBEngine(DeviceServer):
         self,
         sensors: aiokatcp.SensorSet,
         rx_sensor_timeout: float,
-        chan_range: tuple[int, int],
     ) -> None:
         """Define the sensors for an XBEngine.
 
@@ -485,7 +484,7 @@ class XBEngine(DeviceServer):
                 str,
                 "chan-range",
                 "The range of channels processed by this XB-engine, inclusive",
-                default=f"({chan_range[0]},{chan_range[1] - 1})",
+                default=f"({self.channel_offset_value},{self.channel_offset_value + self.n_channels_per_stream - 1})",
                 initial_status=aiokatcp.Sensor.Status.NOMINAL,
             )
         )

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -468,16 +468,7 @@ class XBEngine(DeviceServer):
         sensors: aiokatcp.SensorSet,
         rx_sensor_timeout: float,
     ) -> None:
-        """Define the sensors for an XBEngine.
-
-        Parameters
-        ----------
-        rx_sensor_timeout
-            See :meth:`.recv.make_sensors` for more information.
-        chan_range
-            Tuple of integers showing the two values of the chan-range sensor
-            - (channel_offset, channel_offset + channels_per_substream)
-        """
+        """Define the sensors for an XBEngine."""
         # Static sensors
         sensors.add(
             aiokatcp.Sensor(

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -217,8 +217,6 @@ class XBEngine(DeviceServer):
     rx_reorder_tol
         Maximum tolerance for jitter between received packets, as a time
         expressed in ADC sample ticks.
-    dst
-        Destination endpoint for the outgoing data.
     dst_interface
         IP address of the network device to use for output.
     dst_ttl
@@ -253,6 +251,7 @@ class XBEngine(DeviceServer):
         katcp_host: str,
         katcp_port: int,
         adc_sample_rate_hz: float,
+        send_rate_factor: float,
         n_samples_between_spectra: int,
         n_spectra_per_heap: int,
         sample_bits: int,
@@ -288,8 +287,9 @@ class XBEngine(DeviceServer):
         if sample_bits != 8:
             raise ValueError("sample_bits must equal 8 - no other values supported at the moment.")
 
-        if channel_offset_value % outputs[0].channels_per_substream != 0:
-            raise ValueError("channel_offset must be an integer multiple of channels_per_substream")
+        for output in outputs:
+            if channel_offset_value % output.channels_per_substream != 0:
+                raise ValueError(f"{output.name}: channel_offset must be an integer multiple of channels_per_substream")
 
         # Array configuration parameters
         self.adc_sample_rate_hz = adc_sample_rate_hz
@@ -436,7 +436,7 @@ class XBEngine(DeviceServer):
             n_channels=outputs[0].channels,
             n_channels_per_stream=outputs[0].channels_per_substream,
             dump_interval_s=self.dump_interval_s,
-            send_rate_factor=outputs[0].send_rate_factor,
+            send_rate_factor=send_rate_factor,
             channel_offset=self.channel_offset_value,  # Arbitrary for now - depends on F-Engine stream
             context=self.context,
             packet_payload=dst_packet_payload,

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -298,13 +298,13 @@ class XBEngine(DeviceServer):
                     f"{output.name} has {output.channels_per_substream} channels-per-substream, \
                                  which is not compatible with the global value ({n_channels_per_stream})"
                 )
+            # TODO: Do we need to ensure all output.dst addresses do not overlap?
 
         # Array configuration parameters
         self.adc_sample_rate_hz = adc_sample_rate_hz
         self.heap_accumulation_threshold = heap_accumulation_threshold
         self.time_converter = TimeConverter(sync_epoch, adc_sample_rate_hz)
         self.n_ants = n_ants
-
         self.sample_bits = sample_bits
         self.channel_offset_value = channel_offset_value
 

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -185,9 +185,6 @@ class XBEngine(DeviceServer):
         The number of time samples received per frequency channel.
     sample_bits
         The number of bits per sample. Only 8 bits is supported at the moment.
-    heap_accumulation_threshold
-        The number of consecutive heaps to accumulate. This value is used to
-        determine the dump rate.
     sync_epoch
         UNIX time corresponding to timestamp zero
     channel_offset_value
@@ -258,7 +255,6 @@ class XBEngine(DeviceServer):
         n_samples_between_spectra: int,
         n_spectra_per_heap: int,
         sample_bits: int,
-        heap_accumulation_threshold: int,
         sync_epoch: float,
         channel_offset_value: int,
         outputs: list[Output],
@@ -296,7 +292,7 @@ class XBEngine(DeviceServer):
 
         # Array configuration parameters
         self.adc_sample_rate_hz = adc_sample_rate_hz
-        self.heap_accumulation_threshold = heap_accumulation_threshold
+        self.heap_accumulation_threshold = outputs[0].heap_accumulation_threshold
         self.time_converter = TimeConverter(sync_epoch, adc_sample_rate_hz)
         self.n_ants = n_ants
         self.n_channels_per_stream = n_channels_per_stream
@@ -343,7 +339,7 @@ class XBEngine(DeviceServer):
             ),
         )
 
-        self.timestamp_increment_per_accumulation = outputs[0].timestamp_increment_per_accumulation
+        self.timestamp_increment_per_accumulation = self.heap_accumulation_threshold * self.rx_heap_timestamp_step
 
         # Sets the number of batches of heaps to store per chunk
         self.heaps_per_fengine_per_chunk = heaps_per_fengine_per_chunk

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -343,7 +343,7 @@ class XBEngine(DeviceServer):
             ),
         )
 
-        self.timestamp_increment_per_accumulation = self.heap_accumulation_threshold * self.rx_heap_timestamp_step
+        self.timestamp_increment_per_accumulation = outputs[0].timestamp_increment_per_accumulation
 
         # Sets the number of batches of heaps to store per chunk
         self.heaps_per_fengine_per_chunk = heaps_per_fengine_per_chunk

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -291,14 +291,8 @@ class XBEngine(DeviceServer):
             raise ValueError("sample_bits must equal 8 - no other values supported at the moment.")
 
         for output in outputs:
-            if channel_offset_value % output.channels_per_substream != 0:
+            if channel_offset_value % n_channels_per_stream != 0:
                 raise ValueError(f"{output.name}: channel_offset must be an integer multiple of channels_per_substream")
-            if output.channels_per_substream != n_channels_per_stream:
-                raise ValueError(
-                    f"{output.name} has {output.channels_per_substream} channels-per-substream, \
-                                 which is not compatible with the global value ({n_channels_per_stream})"
-                )
-            # TODO: Do we need to ensure all output.dst addresses do not overlap?
 
         # Array configuration parameters
         self.adc_sample_rate_hz = adc_sample_rate_hz
@@ -463,11 +457,7 @@ class XBEngine(DeviceServer):
             tx_enabled=self._init_tx_enabled,
         )
 
-    def populate_sensors(
-        self,
-        sensors: aiokatcp.SensorSet,
-        rx_sensor_timeout: float,
-    ) -> None:
+    def populate_sensors(self, sensors: aiokatcp.SensorSet, rx_sensor_timeout: float) -> None:
         """Define the sensors for an XBEngine."""
         # Static sensors
         sensors.add(

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -65,7 +65,6 @@ class BOutputDict(TypedDict, total=False):
     name: str
     dst: Endpoint
     channels_per_substream: int
-    spectra_per_heap: int
 
 
 def parse_beam(value: str) -> BOutputDict:
@@ -284,6 +283,8 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         if name in used_names:
             parser.error(f"output name {name} already used.")
         used_names.add(name)
+        if "channels_per_substream" not in output:
+            output["channels_per_substream"] = args.channels_per_substream
 
     args.beam = [BOutput(**output) for output in args.beam]
     return args

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -53,7 +53,6 @@ from .output import BOutput, XOutput
 
 _OD = TypeVar("_OD", bound="OutputDict")
 logger = logging.getLogger(__name__)
-DEFAULT_HEAP_ACCUMULATION_THRESHOLD = 52
 
 
 class OutputDict(TypedDict, total=False):
@@ -158,9 +157,8 @@ def parse_corrprod(value: str) -> XOutput:
     try:
         kws: XOutputDict = {}
         _parse_stream(value, kws, _field_callback)
-        # TODO: Perhaps do something clever/neat and only pass XOutput the complete
-        #       timestamp_increment_per_accumulation (and not each component)
-        kws = {"heap_accumulation_threshold": DEFAULT_HEAP_ACCUMULATION_THRESHOLD, **kws}  # type: ignore
+        if "heap_accumulation_threshold" not in kws:
+            raise ValueError("heap_accumulation_threshold is missing")
         return XOutput(**kws)
     except ValueError as exc:
         raise ValueError(f"--corrprod: {exc}") from exc
@@ -183,7 +181,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         default=[],
         action="append",
         metavar="KEY=VALUE[,KEY=VALUE...]",
-        help="Add a baseline-correlation-product output (may be repeated). The required keys are: name, dst.",
+        help="Add a baseline-correlation-products output (may be repeated). The required keys are: name, dst.",
     )
     parser.add_argument(
         "--katcp-host",

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -181,7 +181,8 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         default=[],
         action="append",
         metavar="KEY=VALUE[,KEY=VALUE...]",
-        help="Add a baseline-correlation-products output (may be repeated). The required keys are: name, dst.",
+        help="Add a baseline-correlation-products output (may be repeated). The required keys are: "
+        "name, dst, heap_accumulation_threshold.",
     )
     parser.add_argument(
         "--katcp-host",

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -99,7 +99,7 @@ def _parse_stream(value: str, kws: _OD, field_callback: Callable[[_OD, str, str]
             case [key, data]:
                 match key:
                     case _ if key in kws:
-                        raise ValueError(f"{key} specified twice")
+                        raise ValueError(f"{key} already specified")
                     case "name":
                         kws[key] = data
                     case "dst":
@@ -349,7 +349,6 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
             used_names.add(name)
             args.outputs.append(output)
 
-    args.beam = [BOutput(**output) for output in args.beam]
     return args
 
 

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -87,7 +87,7 @@ def parse_beam(value: str) -> BOutputDict:
                         raise ValueError(f"--beam: {key} specified twice")
                     case "name":
                         kws[key] = data
-                    case "channels_per_substream" | "spectra_per_heap":
+                    case "channels_per_substream":
                         kws[key] = int(data)
                     case "dst":
                         kws[key] = endpoint_parser(DEFAULT_PORT)(data)
@@ -284,10 +284,6 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         if name in used_names:
             parser.error(f"output name {name} already used.")
         used_names.add(name)
-        if "channels_per_substream" not in output:
-            output["channels_per_substream"] = args.channels_per_substream
-        if "spectra_per_heap" not in output:
-            output["spectra_per_heap"] = args.spectra_per_heap
 
     args.beam = [BOutput(**output) for output in args.beam]
     return args
@@ -312,16 +308,17 @@ def make_engine(context: AbstractContext, args: argparse.Namespace) -> tuple[XBE
     logger.info("Initialising XB-Engine on %s", context.device.name)
     xengine = XOutput(
         name="xengine",
-        antennas=args.array_size,
-        channels=args.channels,
-        channels_per_substream=args.channels_per_substream,
         dst=args.dst,
+        channels_per_substream=args.channels_per_substream,
     )
     xbengine = XBEngine(
         katcp_host=args.katcp_host,
         katcp_port=args.katcp_port,
         adc_sample_rate_hz=args.adc_sample_rate,
         send_rate_factor=args.send_rate_factor,
+        n_ants=args.array_size,
+        n_channels_total=args.channels,
+        n_channels_per_stream=args.channels_per_substream,
         n_samples_between_spectra=args.samples_between_spectra,
         n_spectra_per_heap=args.spectra_per_heap,
         sample_bits=args.sample_bits,

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -84,8 +84,6 @@ class XOutputDict(OutputDict, total=False):
     """
 
     heap_accumulation_threshold: int
-    samples_between_spectra: int
-    spectra_per_heap: int
 
 
 def _parse_stream(value: str, kws: _OD, field_callback: Callable[[_OD, str, str], None]) -> None:
@@ -148,13 +146,11 @@ def parse_corrprod(value: str) -> XOutput:
     - name
     - dst
     - heap_accumulation_threshold
-    - samples_between_spectra
-    - spectra_per_heap
     """
 
     def _field_callback(kws: XOutputDict, key: str, data: str) -> None:
         match key:
-            case "heap_accumulation_threshold" | "samples_between_spectra" | "spectra_per_heap":
+            case "heap_accumulation_threshold":
                 kws[key] = int(data)
             case _:
                 raise ValueError(f"unknown key {key}")
@@ -165,9 +161,6 @@ def parse_corrprod(value: str) -> XOutput:
         # TODO: Perhaps do something clever/neat and only pass XOutput the complete
         #       timestamp_increment_per_accumulation (and not each component)
         kws = {"heap_accumulation_threshold": DEFAULT_HEAP_ACCUMULATION_THRESHOLD, **kws}  # type: ignore
-        for key in ["samples_between_spectra", "spectra_per_heap"]:
-            if key not in kws:
-                raise ValueError(f"{key} is missing")
         return XOutput(**kws)
     except ValueError as exc:
         raise ValueError(f"--corrprod: {exc}") from exc
@@ -282,12 +275,6 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         "and still be accepted. [%(default)s]",
     )
     parser.add_argument(
-        "--heap-accumulation-threshold",
-        type=int,
-        default=DEFAULT_HEAP_ACCUMULATION_THRESHOLD,
-        help="Number of batches of heaps to accumulate in a single dump. [%(default)s]",
-    )
-    parser.add_argument(
         "--sync-epoch",
         type=float,
         required=True,
@@ -395,7 +382,6 @@ def make_engine(context: AbstractContext, args: argparse.Namespace) -> tuple[XBE
         n_samples_between_spectra=args.samples_between_spectra,
         n_spectra_per_heap=args.spectra_per_heap,
         sample_bits=args.sample_bits,
-        heap_accumulation_threshold=args.heap_accumulation_threshold,
         sync_epoch=args.sync_epoch,
         channel_offset_value=args.channel_offset_value,
         outputs=args.outputs,

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -88,7 +88,7 @@ def parse_bengine(value: str) -> BengineOutputDict:
             case [key, data]:
                 match key:
                     case _ if key in kws:
-                        raise ValueError(f"{key} specified twice")
+                        raise ValueError(f"--beamformer: {key} specified twice")
                     case "beams" | "channels_per_substream" | "spectra_per_heap":
                         kws[key] = int(data)
                     case "send_rate_factor":
@@ -98,19 +98,16 @@ def parse_bengine(value: str) -> BengineOutputDict:
                     case _:
                         raise ValueError(f"--beamformer: unknown key {key}")
             case _:
-                raise ValueError(f"missing '=' in {part}")
+                raise ValueError(f"--beamformer: missing '=' in {part}")
     for key in ["beams", "dst"]:
         # These are the bare minimum needed for a B-engine,
         # the rest can be taken from X-engine cmd-line args.
         if key not in kws:
-            raise ValueError(f"{key} is missing")
+            raise ValueError(f"--beamformer: {key} is missing")
 
     # Check if we have enough dest addresses for each beam
     if len(kws["dst"]) != kws["beams"]:
-        raise ValueError(
-            "Mismatch in number of beams and \
-            output multicast address range."
-        )
+        raise ValueError("--beamformer: Mismatch in number of beams and dest multicast address range.")
     return kws
 
 

--- a/src/katgpucbf/xbgpu/output.py
+++ b/src/katgpucbf/xbgpu/output.py
@@ -35,13 +35,6 @@ class XOutput(Output):
     """Static configuration for an output baseline-correlation-products stream."""
 
     heap_accumulation_threshold: int
-    samples_between_spectra: int
-    spectra_per_heap: int
-
-    @property
-    def timestamp_increment_per_accumulation(self) -> int:  # noqa: D102
-        """Timestamp increment (in samples) per accumulation interval."""
-        return self.heap_accumulation_threshold * self.samples_between_spectra * self.spectra_per_heap
 
 
 @dataclass

--- a/src/katgpucbf/xbgpu/output.py
+++ b/src/katgpucbf/xbgpu/output.py
@@ -26,14 +26,14 @@ from katsdptelstate.endpoint import Endpoint
 class Output(ABC):
     """Static configuration for an output stream."""
 
+    name: str
     channels_per_substream: int
     dst: list[Endpoint]
-    send_rate_factor: float
 
 
 @dataclass
 class XOutput(Output):
-    """Static configuration for an X-engine output stream."""
+    """Static configuration for an output X-engine stream."""
 
     antennas: int
     channels: int
@@ -46,7 +46,6 @@ class XOutput(Output):
 
 @dataclass
 class BOutput(Output):
-    """Static configuration for a Beamformer stream."""
+    """Static configuration for an output Beam stream."""
 
-    beams: int
     spectra_per_heap: int

--- a/src/katgpucbf/xbgpu/output.py
+++ b/src/katgpucbf/xbgpu/output.py
@@ -1,0 +1,52 @@
+################################################################################
+# Copyright (c) 2023, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Data structures capturing static configuration of a single output stream."""
+
+from abc import ABC
+from dataclasses import dataclass
+
+from katsdptelstate.endpoint import Endpoint
+
+
+@dataclass
+class Output(ABC):
+    """Static configuration for an output stream."""
+
+    channels_per_substream: int
+    dst: list[Endpoint]
+    send_rate_factor: float
+
+
+@dataclass
+class XengineOutput(Output):
+    """Static configuration for an X-engine output stream."""
+
+    antennas: int
+    channels: int
+
+    @property
+    def baselines(self) -> int:
+        """Number of baselines for this array configuration."""
+        return (self.antennas + 1) * (self.antennas) * 2
+
+
+@dataclass
+class BengineOutput(Output):
+    """Static configuration for a Beamformer stream."""
+
+    beams: int
+    spectra_per_heap: int

--- a/src/katgpucbf/xbgpu/output.py
+++ b/src/katgpucbf/xbgpu/output.py
@@ -34,8 +34,14 @@ class Output(ABC):
 class XOutput(Output):
     """Static configuration for an output baseline-correlation-products stream."""
 
-    # TODO: Make timestamp_increment_per_accumulation a property here
-    pass
+    heap_accumulation_threshold: int
+    samples_between_spectra: int
+    spectra_per_heap: int
+
+    @property
+    def timestamp_increment_per_accumulation(self) -> int:  # noqa: D102
+        """Timestamp increment (in samples) per accumulation interval."""
+        return self.heap_accumulation_threshold * self.samples_between_spectra * self.spectra_per_heap
 
 
 @dataclass

--- a/src/katgpucbf/xbgpu/output.py
+++ b/src/katgpucbf/xbgpu/output.py
@@ -32,7 +32,7 @@ class Output(ABC):
 
 
 @dataclass
-class XengineOutput(Output):
+class XOutput(Output):
     """Static configuration for an X-engine output stream."""
 
     antennas: int
@@ -45,7 +45,7 @@ class XengineOutput(Output):
 
 
 @dataclass
-class BengineOutput(Output):
+class BOutput(Output):
     """Static configuration for a Beamformer stream."""
 
     beams: int

--- a/src/katgpucbf/xbgpu/output.py
+++ b/src/katgpucbf/xbgpu/output.py
@@ -28,18 +28,18 @@ class Output(ABC):
 
     name: str
     dst: Endpoint
-    channels_per_substream: int
 
 
 @dataclass
 class XOutput(Output):
-    """Static configuration for an output X-engine stream."""
+    """Static configuration for an output baseline-correlation-products stream."""
 
+    # TODO: Make timestamp_increment_per_accumulation a property here
     pass
 
 
 @dataclass
 class BOutput(Output):
-    """Static configuration for an output Beam stream."""
+    """Static configuration for an output beam stream."""
 
     pass

--- a/src/katgpucbf/xbgpu/output.py
+++ b/src/katgpucbf/xbgpu/output.py
@@ -27,25 +27,19 @@ class Output(ABC):
     """Static configuration for an output stream."""
 
     name: str
+    dst: Endpoint
     channels_per_substream: int
-    dst: list[Endpoint]
 
 
 @dataclass
 class XOutput(Output):
     """Static configuration for an output X-engine stream."""
 
-    antennas: int
-    channels: int
-
-    @property
-    def baselines(self) -> int:
-        """Number of baselines for this array configuration."""
-        return (self.antennas + 1) * (self.antennas) * 2
+    pass
 
 
 @dataclass
 class BOutput(Output):
     """Static configuration for an output Beam stream."""
 
-    spectra_per_heap: int
+    pass

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -387,6 +387,9 @@ class TestEngine:
         arglist = [
             "--katcp-host=127.0.0.1",
             "--katcp-port=0",
+            "--corrprod=name=bcp1,"
+            f"heap_accumulation_threshold={heap_accumulation_threshold},"
+            "dst=239.21.11.4:7149",
             f"--adc-sample-rate={ADC_SAMPLE_RATE}",
             f"--array-size={n_ants}",
             f"--channels={n_channels_total}",
@@ -395,13 +398,11 @@ class TestEngine:
             f"--channel-offset-value={n_channels_per_stream * CHANNEL_OFFSET}",
             f"--spectra-per-heap={n_spectra_per_heap}",
             f"--heaps-per-fengine-per-chunk={HEAPS_PER_FENGINE_PER_CHUNK}",
-            f"--heap-accumulation-threshold={heap_accumulation_threshold}",
             "--sync-epoch=1234567890",
             "--src-interface=lo",
             "--dst-interface=lo",
             "--tx-enabled",
             "239.10.11.4:7149",  # src
-            "239.21.11.4:7149",  # dst
         ]
         args = parse_args(arglist)
         xbengine, _ = make_engine(context, args)

--- a/test/xbgpu/test_main.py
+++ b/test/xbgpu/test_main.py
@@ -57,3 +57,8 @@ class TestParseBeam:
         """Test with a key specified twice."""
         with pytest.raises(ValueError, match="--beam: channels_per_substream specified twice"):
             parse_beam("name=food,channels_per_substream=8,channels_per_substream=9,dst=239.1.2.3:7148")
+
+    def test_invalid_key(self) -> None:
+        """Test with an unknown key/value pair."""
+        with pytest.raises(ValueError, match="--beam: unknown key fizz"):
+            parse_beam("fizz=buzz,name=food,channels_per_substream=8,channels_per_substream=9,dst=239.1.2.3:7148")

--- a/test/xbgpu/test_main.py
+++ b/test/xbgpu/test_main.py
@@ -61,36 +61,25 @@ class TestParseCorrprod:
 
     def test_minimal(self) -> None:
         """Test with the minimum required arguments."""
-        assert parse_corrprod(
-            "name=foo,samples_between_spectra=2048,spectra_per_heap=256,dst=239.2.3.4:7148"
-        ) == XOutput(
+        assert parse_corrprod("name=foo,dst=239.2.3.4:7148") == XOutput(
             name="foo",
-            dst=Endpoint("239.2.3.4", 7148),
             heap_accumulation_threshold=DEFAULT_HEAP_ACCUMULATION_THRESHOLD,
-            samples_between_spectra=2048,
-            spectra_per_heap=256,
+            dst=Endpoint("239.2.3.4", 7148),
         )
 
     def test_maximal(self) -> None:
         """Test with all valid arguments."""
-        assert parse_corrprod(
-            "name=foo,heap_accumulation_threshold=99,samples_between_spectra=2048,"
-            "spectra_per_heap=256,dst=239.2.3.4:7148"
-        ) == XOutput(
+        assert parse_corrprod("name=foo,heap_accumulation_threshold=99,dst=239.2.3.4:7148") == XOutput(
             name="foo",
-            dst=Endpoint("239.2.3.4", 7148),
             heap_accumulation_threshold=99,
-            samples_between_spectra=2048,
-            spectra_per_heap=256,
+            dst=Endpoint("239.2.3.4", 7148),
         )
 
     @pytest.mark.parametrize(
         "missing,value",
         [
-            ("name", "samples_between_spectra=2048,spectra_per_heap=256,dst=239.2.3.4:7148"),
-            ("samples_between_spectra", "name=bcp1,spectra_per_heap=256,dst=239.2.3.4:7148"),
-            ("spectra_per_heap", "name=bcp1,samples_between_spectra=2048,dst=239.2.3.4:7148"),
-            ("dst", "name=foo,samples_between_spectra=2048,spectra_per_heap=256"),
+            ("name", "dst=239.2.3.4:7148"),
+            ("dst", "name=foo"),
         ],
     )
     def test_missing_key(self, missing: str, value: str) -> None:
@@ -101,9 +90,9 @@ class TestParseCorrprod:
     def test_duplicate_key(self) -> None:
         """Test with a key specified twice."""
         with pytest.raises(ValueError, match="--corrprod: name specified twice"):
-            parse_corrprod("name=foo,name=bar,samples_between_spectra=2048,spectra_per_heap=256,dst=239.2.3.4:7148")
+            parse_corrprod("name=foo,name=bar,dst=239.2.3.4:7148")
 
     def test_invalid_key(self) -> None:
         """Test with an unknown key/value pair."""
         with pytest.raises(ValueError, match="--corrprod: unknown key fizz"):
-            parse_corrprod("fizz=buzz,name=foo,samples_between_spectra=2048,spectra_per_heap=256,dst=239.2.3.4:7148")
+            parse_corrprod("fizz=buzz,name=foo,dst=239.2.3.4:7148")

--- a/test/xbgpu/test_main.py
+++ b/test/xbgpu/test_main.py
@@ -34,18 +34,17 @@ class TestParseBeam:
 
     def test_maximal(self) -> None:
         """Test with all valid arguments."""
-        assert parse_beam("name=beam1,channels_per_substream=512,spectra_per_heap=256,dst=239.1.2.3:7148") == {
+        assert parse_beam("name=beam1,channels_per_substream=512,dst=239.1.2.3:7148") == {
             "name": "beam1",
             "channels_per_substream": 512,
             "dst": Endpoint("239.1.2.3", 7148),
-            "spectra_per_heap": 256,
         }
 
     @pytest.mark.parametrize(
         "missing,value",
         [
-            ("dst", "name=foo,channels_per_substream=512,spectra_per_heap=256"),
-            ("name", "channels_per_substream=512,spectra_per_heap=256,dst=239.1.2.3:7148"),
+            ("dst", "name=foo,channels_per_substream=512"),
+            ("name", "channels_per_substream=512,dst=239.1.2.3:7148"),
         ],
     )
     def test_missing_key(self, missing: str, value: str) -> None:

--- a/test/xbgpu/test_main.py
+++ b/test/xbgpu/test_main.py
@@ -19,7 +19,7 @@
 import pytest
 from katsdptelstate.endpoint import Endpoint
 
-from katgpucbf.xbgpu.main import DEFAULT_HEAP_ACCUMULATION_THRESHOLD, parse_beam, parse_corrprod
+from katgpucbf.xbgpu.main import parse_beam, parse_corrprod
 from katgpucbf.xbgpu.output import BOutput, XOutput
 
 
@@ -59,27 +59,20 @@ class TestParseBeam:
 class TestParseCorrprod:
     """Test :func:`.parse_corrprod`."""
 
-    def test_minimal(self) -> None:
-        """Test with the minimum required arguments."""
-        assert parse_corrprod("name=foo,dst=239.2.3.4:7148") == XOutput(
-            name="foo",
-            heap_accumulation_threshold=DEFAULT_HEAP_ACCUMULATION_THRESHOLD,
-            dst=Endpoint("239.2.3.4", 7148),
-        )
-
     def test_maximal(self) -> None:
         """Test with all valid arguments."""
-        assert parse_corrprod("name=foo,heap_accumulation_threshold=99,dst=239.2.3.4:7148") == XOutput(
+        assert parse_corrprod("name=foo,heap_accumulation_threshold=52,dst=239.2.3.4:7148") == XOutput(
             name="foo",
-            heap_accumulation_threshold=99,
+            heap_accumulation_threshold=52,
             dst=Endpoint("239.2.3.4", 7148),
         )
 
     @pytest.mark.parametrize(
         "missing,value",
         [
-            ("name", "dst=239.2.3.4:7148"),
-            ("dst", "name=foo"),
+            ("name", "heap_accumulation_threshold=52,dst=239.2.3.4:7148"),
+            ("heap_accumulation_threshold", "name=foo,dst=239.2.3.4:7148"),
+            ("dst", "name=foo,heap_accumulation_threshold=52"),
         ],
     )
     def test_missing_key(self, missing: str, value: str) -> None:
@@ -90,9 +83,9 @@ class TestParseCorrprod:
     def test_duplicate_key(self) -> None:
         """Test with a key specified twice."""
         with pytest.raises(ValueError, match="--corrprod: name specified twice"):
-            parse_corrprod("name=foo,name=bar,dst=239.2.3.4:7148")
+            parse_corrprod("name=foo,name=bar,heap_accumulation_threshold=52,dst=239.2.3.4:7148")
 
     def test_invalid_key(self) -> None:
         """Test with an unknown key/value pair."""
         with pytest.raises(ValueError, match="--corrprod: unknown key fizz"):
-            parse_corrprod("fizz=buzz,name=foo,dst=239.2.3.4:7148")
+            parse_corrprod("fizz=buzz,name=foo,heap_accumulation_threshold=52,dst=239.2.3.4:7148")

--- a/test/xbgpu/test_main.py
+++ b/test/xbgpu/test_main.py
@@ -47,7 +47,7 @@ class TestParseBeam:
 
     def test_duplicate_key(self) -> None:
         """Test with a key specified twice."""
-        with pytest.raises(ValueError, match="--beam: name specified twice"):
+        with pytest.raises(ValueError, match="--beam: name already specified"):
             parse_beam("name=foo,name=bar,dst=239.1.2.3:7148")
 
     def test_invalid_key(self) -> None:
@@ -82,7 +82,7 @@ class TestParseCorrprod:
 
     def test_duplicate_key(self) -> None:
         """Test with a key specified twice."""
-        with pytest.raises(ValueError, match="--corrprod: name specified twice"):
+        with pytest.raises(ValueError, match="--corrprod: name already specified"):
             parse_corrprod("name=foo,name=bar,heap_accumulation_threshold=52,dst=239.2.3.4:7148")
 
     def test_invalid_key(self) -> None:

--- a/test/xbgpu/test_main.py
+++ b/test/xbgpu/test_main.py
@@ -1,0 +1,64 @@
+################################################################################
+# Copyright (c) 2023, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Unit tests for argument parsing."""
+
+import pytest
+from katsdptelstate.endpoint import Endpoint
+
+from katgpucbf.xbgpu.main import parse_bengine
+
+
+class TestParseBengine:
+    """Test :func:`.parse_bengine`."""
+
+    def test_maximal(self) -> None:
+        """Test with the required arguments."""
+        assert parse_bengine(
+            "beams=2,channels_per_substream=512,send_rate_factor=1.0,spectra_per_heap=256,dst=239.1.2.3+1:7148"
+        ) == {
+            "beams": 2,
+            "channels_per_substream": 512,
+            "dst": [Endpoint("239.1.2.3", 7148), Endpoint("239.1.2.4", 7148)],
+            "send_rate_factor": 1.0,
+            "spectra_per_heap": 256,
+        }
+
+    def test_beamcount_mismatch(self) -> None:
+        """Test where number of beams does not match dst addresses."""
+        with pytest.raises(
+            ValueError, match="--beamformer: Mismatch in number of beams and dest multicast address range."
+        ):
+            parse_bengine(
+                "beams=2,channels_per_substream=512,send_rate_factor=1.0,spectra_per_heap=256,dst=239.1.2.3+7:7148"
+            )
+
+    @pytest.mark.parametrize(
+        "missing,value",
+        [
+            ("dst", "beams=8,channels_per_substream=512,send_rate_factor=1.0,spectra_per_heap=256"),
+            ("beams", "channels_per_substream=512,spectra_per_heap=256,dst=239.1.2.3+7:7148"),
+        ],
+    )
+    def test_missing_key(self, missing: str, value: str) -> None:
+        """Test without one of the required keys."""
+        with pytest.raises(ValueError, match=f"--beamformer: {missing} is missing"):
+            parse_bengine(value)
+
+    def test_duplicate_key(self) -> None:
+        """Test with a key specified twice."""
+        with pytest.raises(ValueError, match="--beamformer: channels_per_substream specified twice"):
+            parse_bengine("beams=8,channels_per_substream=8,channels_per_substream=9,dst=239.1.2.3+7:7148")


### PR DESCRIPTION
Much like #535, this adds a `--beamformer` command-line argument, taking properties to set via comma-separate key=value pairs.

I may have overstepped the boundaries of the PR in some way as I have an eye on NGC-929 (a la PR #537 )
* I purposefully left a `self.n_ants` attribute in `XBEngine` (used in the `_sender_loop`), and
* I updated `populate_sensors` to take the `chan-range` sensor default values as an arg.

It's a conundrum I regularly dance around (do the straightforward thing or be less abrupt with the change), please share your grievances accordingly.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-905.
