### PR TITLE
Make dig-rms-dbfs an engine-wide sensor

### DIFF
--- a/src/katgpucbf/fgpu/compute.py
+++ b/src/katgpucbf/fgpu/compute.py
@@ -212,7 +212,6 @@ class Compute(accel.OperationSequence):
             else:
                 compounds[f"in{pol}"] = [f"ddc{pol}:in"]
                 compounds[f"subsampled{pol}"] = [f"ddc{pol}:out", f"pfb_fir{pol}:in"]
-                compounds[f"dig_total_power{pol}"] = [f"ddc{pol}:total_power"]
             # pfb_firN:out is an array of real values (in wideband) while
             # fftN:src reinterprets it as an array of complex values. We thus
             # have to make them aliases to view the memory as different

--- a/src/katgpucbf/fgpu/ddc.py
+++ b/src/katgpucbf/fgpu/ddc.py
@@ -152,10 +152,6 @@ class DDC(accel.Operation):
         Baseband filter coefficients. If the filter is asymmetric, the
         coefficients must be reversed: the first element gets
         multiplied by the oldest sample.
-    **total_power** : uint64
-        Sum of squares of input samples.
-
-        .. todo:: This is not implemented yet (it exists but is not touched).
 
     Raises
     ------
@@ -190,7 +186,6 @@ class DDC(accel.Operation):
         )
         self.slots["out"] = accel.IOSlot((self.out_samples,), np.complex64)
         self.slots["weights"] = accel.IOSlot((template.taps,), np.float32)
-        self.slots["total_power"] = accel.IOSlot((), np.uint64)
         self._mix_lookup = accel.DeviceArray(
             template.context, (template._segments, template._segment_samples), np.complex64
         )


### PR DESCRIPTION
Instead of creating it for every output, just do it for the first (wideband) output.

See NGC-924.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match: https://github.com/ska-sa/katsdpcontroller/pull/686
