### PR TITLE
Fix the seed for test_missing_heaps

### DIFF
--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -802,7 +802,7 @@ class TestEngine:
             (117, 133),
             (6 * chunk_samples // PACKET_SAMPLES, 7 * chunk_samples // PACKET_SAMPLES),
         ]
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(seed=1)
         dig_data = np.tile(rng.integers(-255, 255, size=(2, n_samples // 2), dtype=np.int16), 2)
         src_present = np.ones((2, n_samples // PACKET_SAMPLES), bool)
         for a, b in missing_ranges:
@@ -844,6 +844,12 @@ class TestEngine:
             if p and i + middle < len(dst_present):
                 x = out_data[:, i * spectra_per_heap : (i + 1) * spectra_per_heap]
                 y = out_data[:, (i + middle) * spectra_per_heap : (i + middle + 1) * spectra_per_heap]
+                # For narrowband they're not guaranteed to be equal, as the mixer
+                # phase varies over time. For this test the time difference is a
+                # multiple of the mixer wavelength, but there can still be
+                # numerical rounding differences. For the fixed seed chosen
+                # above, we get exact equality, but this test may need to be
+                # related slightly in future.
                 np.testing.assert_equal(x, y)
 
         for pol in range(N_POLS):

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -849,7 +849,7 @@ class TestEngine:
                 # multiple of the mixer wavelength, but there can still be
                 # numerical rounding differences. For the fixed seed chosen
                 # above, we get exact equality, but this test may need to be
-                # related slightly in future.
+                # relaxed slightly in future.
                 np.testing.assert_equal(x, y)
 
         for pol in range(N_POLS):


### PR DESCRIPTION
The exact equality comparison isn't guaranteed to always be exact due to numerical rounding issues in computing the mixer. Fixing the seed lets the exact test work without occasionally failing randomly.

Closes NGC-976.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match