### PR TITLE
Improve narrowband channel response

### DIFF
--- a/doc/fgpu.design.rst
+++ b/doc/fgpu.design.rst
@@ -749,6 +749,11 @@ filter that is as close as possible to 1 in the passband and 0 in the
 stopband. A weighting factor (which the user can override) balances the
 priority of the passband (ripple) and stopband (alias suppression).
 
+The filter performance is slightly improved by noting that the discarded
+channels have multiple aliases, and the filter response in those aliases is
+also irrelevant. We thus use :func:`scipy.signal.remez` to only optimise the
+response to those channels that alias into the output.
+
 Delays
 ^^^^^^
 Coarse delay is (as for wideband) implemented using an input offset to the PFB

--- a/doc/fgpu.design.rst
+++ b/doc/fgpu.design.rst
@@ -568,7 +568,7 @@ The decimation is thus achieved by a combination of time-domain (steps 2 and
 3) and frequency domain (step 5) techniques. This has better computational
 efficiency than a purely frequency-domain approach (which would require the
 PFB to be run on the full bandwidth), while mitigating many of the filter
-design problems inherent in a purely time-domain approach (the rolloff of the
+design problems inherent in a purely time-domain approach (the roll-off of the
 FIR filter can be hidden in the discarded outer channels).
 
 The first three steps are implemented by a "digital down-conversion"

--- a/doc/fgpu.design.rst
+++ b/doc/fgpu.design.rst
@@ -541,22 +541,35 @@ widths. The overall approach is as follows:
    :math:`e^{2\pi jft}`, to effect a shift in the frequency of the
    signal. The centre of the desired band is placed at the DC frequency.
 
-2. The signal is convolved with a low-pass filter. This eliminates the
-   unwanted parts of the band, to the extent possible with a FIR filter.
+2. The signal is convolved with a low-pass filter. This suppresses most
+   of the unwanted parts of the band, to the extent possible with a FIR
+   filter.
 
 3. The signal is subsampled (every Nth sample is retained), reducing the data
-   rate. The low-pass filter above limits aliasing.
+   rate. The low-pass filter above limits aliasing. At this stage, twice as
+   much bandwidth as desired is retained.
 
-4. The rest of the pipeline proceeds largely as before. However, the input is
-   now complex rather than real, so the Fourier transform is a
-   complex-to-complex rather than real-to-complex transform.
+4. The rest of the pipeline proceeds largely as before, but using double the
+   final channel count (since the bandwidth is also doubled, the channel width
+   is as desired). The input is now complex rather than real, so the Fourier
+   transform is a complex-to-complex rather than real-to-complex transform.
+
+5. Half the channels (the outer half) are discarded.
 
 .. note::
    To avoid confusion, the "subsampling factor" is the ratio of original to
    retained samples in the subsampling step, while the "decimation factor" is
    the factor by which the bandwidth is reduced. Because the mixing turns a
    real signal into a complex signal, the subsampling factor is twice the
-   decimation factor.
+   decimation factor in step 3 (but equal to the overall decimation
+   factor).
+
+The decimation is thus achieved by a combination of time-domain (steps 2 and
+3) and frequency domain (step 5) techniques. This has better computational
+efficiency than a purely frequency-domain approach (which would require the
+PFB to be run on the full bandwidth), while mitigating many of the filter
+design problems inherent in a purely time-domain approach (the rolloff of the
+FIR filter can be hidden in the discarded outer channels).
 
 The first three steps are implemented by a "digital down-conversion"
 ("DDC") kernel. This is applied to each input chunk, after copying the head of
@@ -567,8 +580,9 @@ The PFB FIR kernel has alternations because it needs to consume
 single-precision complex inputs rather than packed integers. However, the real
 and imaginary components are independent, and so the input is treated
 internally as if it contained just real values, with an adjustment to correctly
-index the weights. The postprocessing kernel also has minor adjustments, as the
-corrections for a real-to-complex Fourier transform are no longer required.
+index the weights. The postprocessing kernel also has adjustments, as the
+corrections for a real-to-complex Fourier transform are no longer required, and
+the outer channels must be discarded.
 
 An incidental difference between the wideband and narrowband modes is that in
 wideband, the DC frequency of the Fourier transform corresponds to the lowest
@@ -576,7 +590,8 @@ on-sky frequency, while for wideband it corresponds to the centre on-sky
 frequency. This difference is also handled in the postprocessing kernel.
 Internally, channels are numbered according to the Fourier transform (0 being
 the DC channel), but different calculations are used in wideband versus
-narrowband mode to swap the two halves of the band when
+narrowband mode to swap the two halves of the band (and to discard half the
+channels) when
 
 - indexing the gains array;
 - indexing the output array;
@@ -723,6 +738,16 @@ The work group size, subgroup size and coarsening factor can all affect
 performance significantly, and not always in obvious ways. It will likely be
 necessary to implement autotuning to get optimal results across a range of
 problem parameters and hardware devices, but this has not yet been done.
+
+Filter design
+^^^^^^^^^^^^^
+Discarding half the channels after channelisation allows for a lot of freedom
+in the design of the DDC FIR filter: the discarded channels, as well as their
+aliases, can have an arbitrary response. This allows for a gradual transition
+from passband to stopband. We use :func:`scipy.signal.remez` to produce a
+filter that is as close as possible to 1 in the passband and 0 in the
+stopband. A weighting factor (which the user can override) balances the
+priority of the passband (ripple) and stopband (alias suppression).
 
 Delays
 ^^^^^^

--- a/test/fgpu/test_compute.py
+++ b/test/fgpu/test_compute.py
@@ -35,21 +35,25 @@ def test_compute(context: AbstractContext, command_queue: AbstractCommandQueue, 
     ddc_taps = 256
     pfb_taps = 4
     spectra_per_heap = 256
-    subsampling = 2 * decimation
+    subsampling = decimation
     nb_spectra = 256
 
     if mode == "wide":
         narrowband: compute.NarrowbandConfig | None = None
         spectra = 1280
+        internal_channels = channels
     else:
         narrowband = compute.NarrowbandConfig(decimation=decimation, taps=ddc_taps, mix_frequency=0.2)
         spectra = nb_spectra
+        internal_channels = 2 * channels
     template = compute.ComputeTemplate(context, pfb_taps, channels, dig_sample_bits, narrowband)
     # The sample count is the minimum that will produce the required number of
     # output spectra for narrowband mode. For wideband there is more headroom.
     fn = template.instantiate(
         command_queue,
-        nb_spectra * channels * subsampling + ddc_taps + ((pfb_taps - 1) * channels - 1) * subsampling,
+        nb_spectra * internal_channels * subsampling
+        + ddc_taps
+        + ((pfb_taps - 1) * internal_channels - 1) * subsampling,
         spectra,
         spectra_per_heap,
     )

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -148,9 +148,7 @@ class TestEngine:
         pfb = generate_pfb_weights(output.spectra_samples // output.subsampling, output.taps, output.w_cutoff)
         gain = np.repeat(np.sum(pfb), output.channels)
         if isinstance(output, NarrowbandOutput):
-            ddc = generate_ddc_weights(
-                output.ddc_taps, 0.25 / output.subsampling, 0.75 / output.subsampling, output.weight_pass
-            )
+            ddc = generate_ddc_weights(output.ddc_taps, output.subsampling, output.weight_pass)
             response = np.fft.fftshift(scipy.signal.freqz(ddc, worN=output.spectra_samples, whole=True)[1])
             # Discard higher frequencies
             response = response[

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -148,7 +148,9 @@ class TestEngine:
         pfb = generate_pfb_weights(output.spectra_samples // output.subsampling, output.taps, output.w_cutoff)
         gain = np.repeat(np.sum(pfb), output.channels)
         if isinstance(output, NarrowbandOutput):
-            ddc = generate_ddc_weights(output.ddc_taps, output.w_pass, output.w_stop, output.weight_pass)
+            ddc = generate_ddc_weights(
+                output.ddc_taps, 0.25 / output.subsampling, 0.75 / output.subsampling, output.weight_pass
+            )
             response = np.fft.fftshift(scipy.signal.freqz(ddc, worN=output.spectra_samples, whole=True)[1])
             # Discard higher frequencies
             response = response[
@@ -230,7 +232,7 @@ class TestEngine:
         assert engine_server._port == 0
         assert engine_server._src_interface == ["127.0.0.1"] * N_POLS
         # TODO: `dst_interface` goes to the _sender member, which doesn't have anything we can query.
-        assert engine_server._pipelines[0].channels == CHANNELS
+        assert engine_server._pipelines[0].output.channels == CHANNELS
         assert engine_server.time_converter.sync_epoch == SYNC_EPOCH
         assert engine_server._srcs == [
             [

--- a/test/fgpu/test_main.py
+++ b/test/fgpu/test_main.py
@@ -23,6 +23,7 @@ from katgpucbf.fgpu.main import (
     DEFAULT_DDC_TAPS,
     DEFAULT_TAPS,
     DEFAULT_W_CUTOFF,
+    DEFAULT_WEIGHT_PASS,
     comma_split,
     parse_args,
     parse_narrowband,
@@ -75,9 +76,7 @@ class TestParseNarrowband:
             centre_frequency=400e6,
             decimation=8,
             dst=[Endpoint("239.1.2.3", 7148), Endpoint("239.1.2.4", 7148)],
-            w_pass=0.02175,
-            w_stop=0.035875,
-            weight_pass=0.015,
+            weight_pass=DEFAULT_WEIGHT_PASS,
             taps=DEFAULT_TAPS,
             ddc_taps=DEFAULT_DDC_TAPS,
             w_cutoff=DEFAULT_W_CUTOFF,
@@ -87,7 +86,7 @@ class TestParseNarrowband:
         """Test with all valid arguments."""
         assert parse_narrowband(
             "name=foo,channels=1024,centre_frequency=400e6,decimation=8,taps=8,"
-            "w_cutoff=0.5,dst=239.1.2.3+1:7148,ddc_taps=128,w_pass=0.1,w_stop=0.2,weight_pass=0.3"
+            "w_cutoff=0.5,dst=239.1.2.3+1:7148,ddc_taps=128,weight_pass=0.3"
         ) == NarrowbandOutput(
             name="foo",
             channels=1024,
@@ -97,8 +96,6 @@ class TestParseNarrowband:
             w_cutoff=0.5,
             dst=[Endpoint("239.1.2.3", 7148), Endpoint("239.1.2.4", 7148)],
             ddc_taps=128,
-            w_pass=0.1,
-            w_stop=0.2,
             weight_pass=0.3,
         )
 
@@ -137,7 +134,7 @@ class TestParseArgs:
             (
                 "--narrowband=name=nb0,dst=239.1.0.0+1,channels=32768,"
                 "centre_frequency=400e6,decimation=8,taps=4,w_cutoff=0.8,"
-                "ddc_taps=128,w_pass=0.1,w_stop=0.2,weight_pass=0.3"
+                "ddc_taps=64,weight_pass=0.3"
             ),
             "--narrowband=name=nb1,dst=239.2.0.0+0:7149,channels=8192,centre_frequency=300e6,decimation=16",
             "239.0.1.0+7:7148",
@@ -160,9 +157,7 @@ class TestParseArgs:
                 decimation=8,
                 taps=4,
                 w_cutoff=0.8,
-                ddc_taps=128,
-                w_pass=0.1,
-                w_stop=0.2,
+                ddc_taps=64,
                 weight_pass=0.3,
             ),
             NarrowbandOutput(
@@ -171,11 +166,9 @@ class TestParseArgs:
                 channels=8192,
                 centre_frequency=300e6,
                 decimation=16,
-                taps=16,
-                w_cutoff=1.0,
-                ddc_taps=256,
-                w_pass=0.00671875,
-                w_stop=0.01965625,
-                weight_pass=0.033,
+                taps=DEFAULT_TAPS,
+                w_cutoff=DEFAULT_W_CUTOFF,
+                ddc_taps=DEFAULT_DDC_TAPS,
+                weight_pass=DEFAULT_WEIGHT_PASS,
             ),
         ]


### PR DESCRIPTION
Split the bandwidth decimation between the time domain and frequency domain (factor decimation/2 in time domain, factor 2 in the frequency domain). This allows for a much better response, even when reducing the number of taps.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-939.
