### PR TITLE
Fix qualification tests

### DIFF
--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -193,8 +193,8 @@ def pdf_report(request, monkeypatch) -> Reporter:
         data[0]["test_name"] = name_marker.args[0]
     request.node.user_properties.append(("pdf_report_data", data))
     reporter = Reporter(data, raw_data=request.config.getini("raw_data"))
-    orig_log_failure = pytest_check.check_methods.log_failure
-    orig_get_full_context = pytest_check.check_methods.get_full_context
+    orig_log_failure = pytest_check.check_log.log_failure
+    orig_get_full_context = pytest_check.pseudo_traceback.get_full_context
 
     def get_full_context(level):
         # The real log_failure function constructs a backtrace, and inserting
@@ -202,14 +202,21 @@ def pdf_report(request, monkeypatch) -> Reporter:
         # skip an extra level for each wrapper we're injecting.
         return orig_get_full_context(level + 2)
 
-    def log_failure(msg):
-        reporter.failure(f"Failed assertion: {msg}")
-        return orig_log_failure(msg)
+    def log_failure(msg="", check_str=""):
+        __tracebackhide__ = True
+        if check_str:
+            reporter.failure(f"Failed assertion: {msg}: {check_str}")
+        else:
+            reporter.failure(f"Failed assertion: {msg}")
+        return orig_log_failure(msg, check_str)
 
     # Patch the central point where pytest-check logs failures so that we can
     # insert them into the test procedure.
-    monkeypatch.setattr(pytest_check.check_methods, "log_failure", log_failure)
-    monkeypatch.setattr(pytest_check.check_methods, "get_full_context", get_full_context)
+    monkeypatch.setattr(pytest_check.check_log, "log_failure", log_failure)
+    # context_manager uses `from .check_log import log_failure` so we have to
+    # patch it under that name.
+    monkeypatch.setattr(pytest_check.context_manager, "log_failure", log_failure)
+    monkeypatch.setattr(pytest_check.pseudo_traceback, "get_full_context", get_full_context)
     return reporter
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ qualification =
     pylatex
     pytest
     pytest-asyncio
-    pytest-check
+    pytest-check>=1.3
     pytest-custom_exit_code
     pytest-reportlog
 


### PR DESCRIPTION
I'd updated pytest-check in #575, which broke the qualification tests because pytest-check moved around some of the internals that we're monkey-patching.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [ ] If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
