### PR TITLE
Simplify the DDC kernel

### DIFF
--- a/doc/fgpu.design.rst
+++ b/doc/fgpu.design.rst
@@ -734,8 +734,8 @@ produced from the same input, we do not attempt to duplicate this calculation
 for narrowband.
 
 An engine with only narrowband outputs will thus be lacking these statistics.
-Calculating the statistics in that case would be challenging, as it would
-need to be done in the DDC kernel, which is already extremely complex.
+Calculating the statistics in that case would require extending the DDC kernel
+to compute the same statistics.
 
 .. rubric:: Footnotes
 

--- a/doc/fgpu.design.rst
+++ b/doc/fgpu.design.rst
@@ -538,7 +538,7 @@ bandwidth is channelised and output. Typically they have narrower channel
 widths. The overall approach is as follows:
 
 1. The signal is multiplied (:dfn:`mixed`) by a complex tone of the form
-   :math:`e^{2\pi j\omega t}`, to effect a shift in the frequency of the
+   :math:`e^{2\pi jft}`, to effect a shift in the frequency of the
    signal. The centre of the desired band is placed at the DC frequency.
 
 2. The signal is convolved with a low-pass filter. This suppresses most
@@ -614,26 +614,26 @@ concurrently. We can describe the operation with the equation
 
 .. math::
 
-   y_{b+i} = \sum_{k=0}^{T-1} x_{S(b+i)+k} \cdot h_k \cdot e^{2\pi j\omega [S(b+i)+k]}
+   y_{b+i} = \sum_{k=0}^{T-1} x_{S(b+i)+k} \cdot h_k \cdot e^{2\pi jf[S(b+i)+k]}
 
 where
 
 - :math:`x` is the input
 - :math:`y` is the output
-- :math:`h` contains the weights,
+- :math:`h` contains the weights
 - :math:`S` is the subsampling factor
 - :math:`T` is the number of taps
-- :math:`b` is the first of the :math:`C` outputs to produce; and
-- :math:`0 \le i < C` is the index into the :math:`C` outputs to produce.
-- :math:`\omega` is the angular frequency of the mixer signal.
+- :math:`b` is the first of the :math:`C` outputs to produce
+- :math:`0 \le i < C` is the index into the :math:`C` outputs to produce; and
+- :math:`f` is the frequency of the mixer signal, in cycles per digitiser sample.
 
 The first simplification we make is to pre-compute the weights with the mixer
-(on the CPU). Let :math:`z_k = h_k e^{2\pi j\omega k}`. Then the equation
+(on the CPU). Let :math:`z_k = h_k e^{2\pi jfk}`. Then the equation
 becomes
 
 .. math::
 
-   y_{b+i} = e^{2\pi j\omega S(b+i)} \sum_{k=0}^{T-1} x_{S(b+i)+k}\cdot z_k.
+   y_{b+i} = e^{2\pi jfS(b+i)} \sum_{k=0}^{T-1} x_{S(b+i)+k}\cdot z_k.
 
 For now we'll focus on just the summation, and deal with the exponential later.
 For simplicity, assume :math:`T` is a multiple of :math:`S` (although the
@@ -642,7 +642,7 @@ can write :math:`k` as :math:`pS + q` and rewrite this equation as
 
 .. math::
 
-   y_{b+i} = e^{2\pi j\omega S(b+i)} \sum_{p=0}^{W - 1} \sum_{q=0}^{S-1} x_{S(b+i+p) + q} \cdot z_{pS + q}.
+   y_{b+i} = e^{2\pi jfS(b+i)} \sum_{p=0}^{W - 1} \sum_{q=0}^{S-1} x_{S(b+i+p) + q} \cdot z_{pS + q}.
 
 The kernel iterates first over :math:`q`, then :math:`p`, then :math:`i`. A
 separate accumulator variable is kept for each value of :math:`i`.
@@ -675,14 +675,14 @@ logic involved in decoding the samples can be evaluated at compile-time.
 Mixer signal
 ~~~~~~~~~~~~
 Care needs to be taken with the precision of the argument to the mixer signal.
-Simply evaluating the sine and cosine of :math:`2\pi \omega t` when
+Simply evaluating the sine and cosine of :math:`2\pift` when
 :math:`t` is large can lead to a catastrophic loss of precision, as the
-product :math:`\omega t` will have a large integer part and leave few bits for
-the fractional part. Even passing :math:`\omega` in single precision can lead
+product :math:`ft` will have a large integer part and leave few bits for
+the fractional part. Even passing :math:`f` in single precision can lead
 to large errors.
 
-To overcome this, a hybrid approach is used. The factor :math:`e^{2\pi j\omega S(b+i)}`
-is further decomposed as :math:`e^{2\pi j\omega (Sb)} \cdot e^{2\pi j\omega (Si)}`. We
+To overcome this, a hybrid approach is used. The factor :math:`e^{2\pi jfS(b+i)}`
+is further decomposed as :math:`e^{2\pi jf(Sb)} \cdot e^{2\pi jf(Si)}`. We
 compute :math:`Sb` in double precision and subtract out the integer part before
 dropping to single precision to compute the complex exponential. This only
 needs to be done once per work-item. The second factor is stored in a

--- a/doc/fgpu.design.rst
+++ b/doc/fgpu.design.rst
@@ -675,7 +675,7 @@ logic involved in decoding the samples can be evaluated at compile-time.
 Mixer signal
 ~~~~~~~~~~~~
 Care needs to be taken with the precision of the argument to the mixer signal.
-Simply evaluating the sine and cosine of :math:`2\pift` when
+Simply evaluating the sine and cosine of :math:`2\pi ft` when
 :math:`t` is large can lead to a catastrophic loss of precision, as the
 product :math:`ft` will have a large integer part and leave few bits for
 the fractional part. Even passing :math:`f` in single precision can lead

--- a/doc/fgpu.design.rst
+++ b/doc/fgpu.design.rst
@@ -614,13 +614,13 @@ concurrently. We can describe the operation with the equation
 
 .. math::
 
-   y_{b+i} = \sum_{k=0}^{T-1} x_{S(b+i)+k} w_k e^{2\pi j\omega [S(b+i)+k]}
+   y_{b+i} = \sum_{k=0}^{T-1} x_{S(b+i)+k} \cdot h_k \cdot e^{2\pi j\omega [S(b+i)+k]}
 
 where
 
 - :math:`x` is the input
 - :math:`y` is the output
-- :math:`w` contains the weights,
+- :math:`h` contains the weights,
 - :math:`S` is the subsampling factor
 - :math:`T` is the number of taps
 - :math:`b` is the first of the :math:`C` outputs to produce; and
@@ -628,21 +628,21 @@ where
 - :math:`\omega` is the angular frequency of the mixer signal.
 
 The first simplification we make is to pre-compute the weights with the mixer
-(on the CPU). Let :math:`z_k = w_k e^{2\pi j\omega k}`. Then the equation
+(on the CPU). Let :math:`z_k = h_k e^{2\pi j\omega k}`. Then the equation
 becomes
 
 .. math::
 
-   y_{b+i} = e^{2\pi j\omega S(b+i)} \sum_{k=0}^{T-1} x_{S(b+i)+k} z_k.
+   y_{b+i} = e^{2\pi j\omega S(b+i)} \sum_{k=0}^{T-1} x_{S(b+i)+k}\cdot z_k.
 
 For now we'll focus on just the summation, and deal with the exponential later.
 For simplicity, assume :math:`T` is a multiple of :math:`S` (although the
 implementation does not require it) and let :math:`W = \frac{T}{S}`. Then we
-can write :math:`j` as :math:`pS + q` and rewrite this equation as
+can write :math:`k` as :math:`pS + q` and rewrite this equation as
 
 .. math::
 
-   y_{b+i} = e^{2\pi j\omega S(b+i)} \sum_{p=0}^{W - 1} \sum_{q=0}^{S-1} x_{S(b+i+p) + q} z_{pS + q}.
+   y_{b+i} = e^{2\pi j\omega S(b+i)} \sum_{p=0}^{W - 1} \sum_{q=0}^{S-1} x_{S(b+i+p) + q} \cdot z_{pS + q}.
 
 The kernel iterates first over :math:`q`, then :math:`p`, then :math:`i`. A
 separate accumulator variable is kept for each value of :math:`i`.
@@ -682,7 +682,7 @@ the fractional part. Even passing :math:`\omega` in single precision can lead
 to large errors.
 
 To overcome this, a hybrid approach is used. The factor :math:`e^{2\pi j\omega S(b+i)}`
-is further decomposed as :math:`e^{2\pi j\omega (Sb)} e^{2\pi j\omega (Si)}`. We
+is further decomposed as :math:`e^{2\pi j\omega (Sb)} \cdot e^{2\pi j\omega (Si)}`. We
 compute :math:`Sb` in double precision and subtract out the integer part before
 dropping to single precision to compute the complex exponential. This only
 needs to be done once per work-item. The second factor is stored in a

--- a/scratch/fgpu/benchmarks/compute_bench.py
+++ b/scratch/fgpu/benchmarks/compute_bench.py
@@ -57,7 +57,10 @@ def main():  # noqa: C901
     with context:
         if args.narrowband:
             narrowband_config = NarrowbandConfig(
-                decimation=args.narrowband_decimation, taps=args.ddc_taps, mix_frequency=0.25
+                decimation=args.narrowband_decimation,
+                taps=args.ddc_taps,
+                mix_frequency=0.25,
+                weights=generate_ddc_weights(args.ddc_taps, args.narrowband_decimation, 0.005),
             )
             spectra_samples = 2 * args.channels * args.narrowband_decimation
             window = args.taps * spectra_samples + args.ddc_taps - args.narrowband_decimation
@@ -83,11 +86,6 @@ def main():  # noqa: C901
         h_weights = fn.buffer("weights").empty_like()
         h_weights[:] = generate_pfb_weights(2 * args.channels, args.taps, 1.0)
         fn.buffer("weights").set(command_queue, h_weights)
-
-        if args.narrowband:
-            h_ddc_weights = fn.buffer("ddc_weights").empty_like()
-            h_ddc_weights[:] = generate_ddc_weights(args.ddc_taps, args.narrowband_decimation, 0.005)
-            fn.buffer("ddc_weights").set(command_queue, h_ddc_weights)
 
         h_gains = fn.buffer("gains").empty_like()
         h_gains[:] = 1

--- a/scratch/fgpu/benchmarks/compute_bench.py
+++ b/scratch/fgpu/benchmarks/compute_bench.py
@@ -58,7 +58,6 @@ def main():  # noqa: C901
         if args.narrowband:
             narrowband_config = NarrowbandConfig(
                 decimation=args.narrowband_decimation,
-                taps=args.ddc_taps,
                 mix_frequency=0.25,
                 weights=generate_ddc_weights(args.ddc_taps, args.narrowband_decimation, 0.005),
             )

--- a/scratch/fgpu/benchmarks/ddc_bench.py
+++ b/scratch/fgpu/benchmarks/ddc_bench.py
@@ -20,6 +20,7 @@ import argparse
 
 from katsdpsigproc import accel
 
+from katgpucbf import DIG_SAMPLE_BITS
 from katgpucbf.fgpu.ddc import DDCTemplate
 
 
@@ -28,13 +29,16 @@ def main():
     parser.add_argument("--taps", type=int, default=128)
     parser.add_argument("--subsampling", type=int, default=8)
     parser.add_argument("--samples", type=int, default=16 * 1024 * 1024)
+    parser.add_argument("--input-sample-bits", type=int, default=DIG_SAMPLE_BITS)
     parser.add_argument("--passes", type=int, default=10)
     args = parser.parse_args()
 
     context = accel.create_some_context(device_filter=lambda device: device.is_cuda)
     with context:
         command_queue = context.create_tuning_command_queue()
-        template = DDCTemplate(context, taps=args.taps, subsampling=args.subsampling)
+        template = DDCTemplate(
+            context, taps=args.taps, subsampling=args.subsampling, input_sample_bits=args.input_sample_bits
+        )
         fn = template.instantiate(command_queue, samples=args.samples)
         fn.ensure_all_bound()
         fn.buffer("in").zero(command_queue)

--- a/scratch/fgpu/benchmarks/ddc_bench.py
+++ b/scratch/fgpu/benchmarks/ddc_bench.py
@@ -25,8 +25,8 @@ from katgpucbf.fgpu.ddc import DDCTemplate
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--taps", type=int, default=256)
-    parser.add_argument("--subsampling", type=int, default=16)
+    parser.add_argument("--taps", type=int, default=128)
+    parser.add_argument("--subsampling", type=int, default=8)
     parser.add_argument("--samples", type=int, default=16 * 1024 * 1024)
     parser.add_argument("--passes", type=int, default=10)
     args = parser.parse_args()

--- a/src/katgpucbf/fgpu/compute.py
+++ b/src/katgpucbf/fgpu/compute.py
@@ -41,6 +41,8 @@ class NarrowbandConfig:
     taps: int
     #: Mixer frequency, in cycles per ADC sample
     mix_frequency: float
+    #: Downconversion filter weights (float)
+    weights: np.ndarray
 
 
 class ComputeTemplate:
@@ -171,7 +173,7 @@ class Compute(accel.OperationSequence):
                 raise ValueError(f"samples ({samples}) must be a multiple of subsampling ({template.ddc.subsampling})")
             self.ddc = [template.ddc.instantiate(command_queue, samples) for _ in range(N_POLS)]
             for pol in range(N_POLS):
-                self.ddc[pol].mix_frequency = template.narrowband.mix_frequency
+                self.ddc[pol].configure(template.narrowband.mix_frequency, template.narrowband.weights)
                 operations.append((f"ddc{pol}", self.ddc[pol]))
             samples = self.ddc[0].out_samples  # Number of samples available to remainder of pipeline
         self.pfb_fir = [template.pfb_fir.instantiate(command_queue, samples, spectra) for _ in range(N_POLS)]

--- a/src/katgpucbf/fgpu/compute.py
+++ b/src/katgpucbf/fgpu/compute.py
@@ -37,8 +37,6 @@ class NarrowbandConfig:
 
     #: Factor by which bandwidth is reduced
     decimation: int
-    #: Taps in low-pass filter
-    taps: int
     #: Mixer frequency, in cycles per ADC sample
     mix_frequency: float
     #: Downconversion filter weights (float)
@@ -97,7 +95,7 @@ class ComputeTemplate:
             self.pfb_fir = pfb.PFBFIRTemplate(
                 context, taps, self.internal_channels, 32, self.unzip_factor, complex_input=True
             )
-            self.ddc = ddc.DDCTemplate(context, narrowband.taps, narrowband.decimation, dig_sample_bits)
+            self.ddc = ddc.DDCTemplate(context, len(narrowband.weights), narrowband.decimation, dig_sample_bits)
 
     def instantiate(
         self,

--- a/src/katgpucbf/fgpu/compute.py
+++ b/src/katgpucbf/fgpu/compute.py
@@ -97,7 +97,7 @@ class ComputeTemplate:
             self.pfb_fir = pfb.PFBFIRTemplate(
                 context, taps, self.internal_channels, 32, self.unzip_factor, complex_input=True
             )
-            self.ddc = ddc.DDCTemplate(context, narrowband.taps, narrowband.decimation)
+            self.ddc = ddc.DDCTemplate(context, narrowband.taps, narrowband.decimation, dig_sample_bits)
 
     def instantiate(
         self,

--- a/src/katgpucbf/fgpu/ddc.py
+++ b/src/katgpucbf/fgpu/ddc.py
@@ -46,11 +46,6 @@ class DDCTemplate:
         Number of taps in the FIR filter
     subsampling
         Fraction of samples to retain after filtering
-
-    Raises
-    ------
-    ValueError
-        If `taps` is not a multiple of `subsampling`
     """
 
     def __init__(
@@ -60,8 +55,6 @@ class DDCTemplate:
             raise ValueError("taps must be positive")
         if subsampling <= 0:
             raise ValueError("subsampling must be positive")
-        if taps % subsampling != 0:
-            raise ValueError("taps must be a multiple of subsampling")
         if tuning is None:
             tuning = self.autotune(context, taps, subsampling)
         self.context = context

--- a/src/katgpucbf/fgpu/ddc.py
+++ b/src/katgpucbf/fgpu/ddc.py
@@ -72,6 +72,7 @@ class DDCTemplate:
 
         # Sanity check the tuning parameters
         # TODO: re-do for NGC-980
+        assert self.subsampling * self.unroll * self.input_sample_bits % 32 == 0
 
         with resources.as_file(resources.files(__package__)) as resource_dir:
             program = accel.build(
@@ -95,8 +96,10 @@ class DDCTemplate:
 
            Actually do autotuning instead of using fixed logic.
         """
-        wgs = 128
-        unroll = 4
+        wgs = 32
+        unroll = 8
+        while unroll * subsampling * DIG_SAMPLE_BITS % 32:
+            unroll *= 2
         return {"wgs": wgs, "unroll": unroll}
 
     def instantiate(self, command_queue: AbstractCommandQueue, samples: int) -> "DDC":

--- a/src/katgpucbf/fgpu/ddc.py
+++ b/src/katgpucbf/fgpu/ddc.py
@@ -97,7 +97,7 @@ class DDCTemplate:
            Actually do autotuning instead of using fixed logic.
         """
         wgs = 32
-        unroll = 8
+        unroll = 7
         while unroll * subsampling * DIG_SAMPLE_BITS % 32:
             unroll *= 2
         return {"wgs": wgs, "unroll": unroll}

--- a/src/katgpucbf/fgpu/ddc.py
+++ b/src/katgpucbf/fgpu/ddc.py
@@ -89,7 +89,7 @@ class DDCTemplate:
                     "unroll": self.unroll,
                     "taps": taps,
                     "subsampling": subsampling,
-                    "sample_bits": input_sample_bits,
+                    "input_sample_bits": input_sample_bits,
                 },
                 extra_dirs=[str(resource_dir)],
             )

--- a/src/katgpucbf/fgpu/ddc.py
+++ b/src/katgpucbf/fgpu/ddc.py
@@ -95,8 +95,8 @@ class DDCTemplate:
 
            Actually do autotuning instead of using fixed logic.
         """
-        wgs = 256
-        unroll = 8
+        wgs = 128
+        unroll = 4
         return {"wgs": wgs, "unroll": unroll}
 
     def instantiate(self, command_queue: AbstractCommandQueue, samples: int) -> "DDC":

--- a/src/katgpucbf/fgpu/ddc.py
+++ b/src/katgpucbf/fgpu/ddc.py
@@ -134,10 +134,9 @@ class DDC(accel.Operation):
     Element j of the output contains the dot product of **weights** with
     elements :math:`dj, d(j+1), \ldots, d(j+taps-1)` of the mixed signal. The
     mixed signal is the product of sample :math:`j` of the input with
-    :math:`e^{2\pi i (aj + b)}`, where :math:`a` and :math:`b` are set with
-    the :attr:`mix_frequency` and :attr:`mix_phase` properties. Note that
-    setting :attr:`mix_frequency` is somewhat expensive as it has to update an
-    array on the device.
+    :math:`e^{2\pi i (aj + b)}`, where :math:`a` is the `mix_frequency`
+    argument to :meth:`configure` and :math:`b` is the (settable)
+    :attr:`mix_phase` property.
 
     .. rubric:: Slots
 
@@ -186,7 +185,12 @@ class DDC(accel.Operation):
         self.mix_phase = 0.0  # Specify in fractions of a cycle (0-1)
 
     def configure(self, mix_frequency: float, weights: np.ndarray) -> None:
-        """Set the mixer frequency and filter weights."""
+        """Set the mixer frequency and filter weights.
+
+        This is a somewhat expensive operation, as it computes lookup tables
+        and transfers them to the device synchronously. It is only intended
+        to be used at startup rather than continuously.
+        """
         assert weights.shape == self._weights_host.shape
         self._mix_frequency = mix_frequency
         self._weights_host[:] = weights * np.exp(2j * np.pi * mix_frequency * np.arange(len(weights)))

--- a/src/katgpucbf/fgpu/ddc.py
+++ b/src/katgpucbf/fgpu/ddc.py
@@ -116,7 +116,7 @@ class DDCTemplate:
             return tune.make_measure(queue, fn)
 
         ua = cls.unroll_align(subsampling)
-        return cast(_TuningDict, tune.autotune(generate, wgs=[32, 64, 96, 128], unroll=range(ua, 17, ua)))
+        return cast(_TuningDict, tune.autotune(generate, wgs=[32, 64], unroll=range(max(8, ua), 17, ua)))
 
     def instantiate(self, command_queue: AbstractCommandQueue, samples: int) -> "DDC":
         """Generate a :class:`DDC` object based on the template."""

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -503,7 +503,6 @@ class Pipeline:
         if isinstance(output, NarrowbandOutput):
             narrowband_config = NarrowbandConfig(
                 decimation=output.decimation,
-                taps=output.ddc_taps,
                 mix_frequency=-output.centre_frequency / engine.adc_sample_rate,
                 weights=generate_ddc_weights(output.ddc_taps, output.subsampling, output.weight_pass),
             )

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -505,6 +505,7 @@ class Pipeline:
                 decimation=output.decimation,
                 taps=output.ddc_taps,
                 mix_frequency=-output.centre_frequency / engine.adc_sample_rate,
+                weights=generate_ddc_weights(output.ddc_taps, output.subsampling, output.weight_pass),
             )
         else:
             narrowband_config = None
@@ -517,12 +518,6 @@ class Pipeline:
             compute_queue,
             generate_pfb_weights(output.spectra_samples // output.subsampling, output.taps, output.w_cutoff),
         )
-        if isinstance(output, NarrowbandOutput):
-            device_ddc_weights = self._compute.slots["ddc_weights"].allocate(accel.DeviceAllocator(context))
-            device_ddc_weights.set(
-                compute_queue,
-                generate_ddc_weights(output.ddc_taps, output.subsampling, output.weight_pass),
-            )
 
         # Initialize sending
         self._init_send(engine.use_peerdirect)

--- a/src/katgpucbf/fgpu/kernels/ddc.mako
+++ b/src/katgpucbf/fgpu/kernels/ddc.mako
@@ -100,7 +100,7 @@ void ddc(
             float2 weights[TAPS];
             float2 mix_lookup[C];
         };
-        float out[2][C * WGS];
+        float out[2][C * WGS];  // Logically float2, but split to reduce bank conflicts
     } local;
 
     unsigned int lid = get_local_id(0);

--- a/src/katgpucbf/fgpu/kernels/ddc.mako
+++ b/src/katgpucbf/fgpu/kernels/ddc.mako
@@ -46,7 +46,7 @@ DEVICE_FN static unsigned int reverse_endian(unsigned int v)
  * buffer (or after a discontiguous change in @a idx), set @a start to false.
  *
  * @param in      Array with all the raw (but native-endian) sample words for the workgroup
- * @param buffer  Sample word that help the LSBs of the previous sample if any (updated on return)
+ * @param buffer  Sample word that holds the LSBs of the previous sample if any (updated on return)
  * @param idx     Index of the sample to retrieve, relative to @a in
  * @param start   If true, @a buffer is ignored
  */

--- a/src/katgpucbf/fgpu/kernels/ddc.mako
+++ b/src/katgpucbf/fgpu/kernels/ddc.mako
@@ -185,8 +185,6 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void ddc(
 
     BARRIER();
 
-    // TODO: transpose writeback through local mem?
-
     unsigned int first_out_idx = get_group_id(0) * (WGS * C);
     for (int i = 0; i < C; i++)
     {

--- a/src/katgpucbf/fgpu/kernels/ddc.mako
+++ b/src/katgpucbf/fgpu/kernels/ddc.mako
@@ -118,9 +118,7 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void ddc(
 
     unsigned int lid = get_local_id(0);
     /* Copy workgroup's sample data to local memory */
-    unsigned int group_first_in_idx = get_group_id(0) * (WGS * C * SUBSAMPLING);
-    // TODO: risk of integer overflow:
-    unsigned int group_first_in_word = group_first_in_idx * SAMPLE_BITS / SAMPLE_WORD_BITS;
+    unsigned int group_first_in_word = get_group_id(0) * (WGS * C * SUBSAMPLING * SAMPLE_BITS / SAMPLE_WORD_BITS);
     for (int i = lid; i < group_in_words; i += WGS)
     {
         unsigned int idx = group_first_in_word + i;
@@ -162,7 +160,7 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void ddc(
         }
     }
 
-    mix_bias += (group_first_in_idx + first_in_idx) * mix_scale;
+    mix_bias += get_global_id(0) * (C * SUBSAMPLING) * mix_scale;
     mix_bias -= rint(mix_bias);
     float2 mix_base;
     sincospif(2 * (float) mix_bias, &mix_base.y, &mix_base.x);

--- a/src/katgpucbf/fgpu/kernels/ddc.mako
+++ b/src/katgpucbf/fgpu/kernels/ddc.mako
@@ -107,6 +107,7 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void ddc(
     const int group_in_words = (group_in_size * SAMPLE_BITS + SAMPLE_WORD_BITS - 1) / SAMPLE_WORD_BITS;
     LOCAL_DECL sample_word l_in[group_in_words];
     LOCAL_DECL float2 l_weights[TAPS];
+    LOCAL_DECL float2 l_mix_lookup[C];
 
     unsigned int lid = get_local_id(0);
     /* Copy workgroup's sample data to local memory */
@@ -119,9 +120,11 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void ddc(
         l_in[i] = (idx < in_size_words) ? in[group_first_in_word + i] : 0;
     }
 
-    /* Copy weights to local memory */
+    /* Copy weights and mix_lookup to local memory (TODO: bank conflicts?) */
     for (int i = lid; i < TAPS; i += WGS)
         l_weights[i] = weights[i];
+    for (int i = lid; i < C; i += WGS)
+        l_mix_lookup[i] = mix_lookup[i];
 
     BARRIER();
 
@@ -160,9 +163,8 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void ddc(
     for (int i = 0; i < C; i++)
     {
         accum[i] = cmul(accum[i], mix_base);
-        // TODO: copy mix_lookup to shared mem?
         if (i > 0)
-            accum[i] = cmul(accum[i], mix_lookup[i]);
+            accum[i] = cmul(accum[i], l_mix_lookup[i]);
     }
 
     // TODO: transpose writeback through local mem?

--- a/src/katgpucbf/fgpu/kernels/ddc.mako
+++ b/src/katgpucbf/fgpu/kernels/ddc.mako
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022-2023, National Research Foundation (SARAO)
+ * Copyright (c) 2023, National Research Foundation (SARAO)
  *
  * Licensed under the BSD 3-Clause License (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy
@@ -15,85 +15,71 @@
  ******************************************************************************/
 
 <%include file="/port.mako"/>
-<%namespace name="wg_reduce" file="/wg_reduce.mako"/>
-
-/* TODO:
- * - test reading via shared memory with memcpy_async
- * - test writing via shared memory
- * - test putting constants into shared memory
- * - look into __constant memory type
- * - Try packing multiple logical workgroups into one physical one e.g. to
- *   enable warp-synchronous operation without harming occupancy
- * - Check if it could be more efficient to load SG_SIZE strided values per
- *   tile, instead of contiguous
- */
-
-/* Alignment requirements:
- * - in_offset must be a multiple of SEGMENT_SAMPLES
- * - GROUP_IN_SIZE must be a multiple of SEGMENT_SAMPLES
- * - SEGMENT_SAMPLES * SAMPLE_BITS must be a multiple of 32
- * - WGS must be a multiple of SG_SIZE
- * - TAPS must be a multiple of SUBSAMPLING
- * - SEGMENT_SAMPLES must be a multiple of SG_SIZE
- * - SUBSAMPLING must be a multiple of SG_SIZE
- * - COARSEN should be odd for best performance
- * - SG_SIZE should be a power of two for best performance
- */
 
 #define WGS ${wgs}
 #define TAPS ${taps}
 #define SUBSAMPLING ${subsampling}
-#define COARSEN ${coarsen}
-#define SG_SIZE ${sg_size}
 #define SAMPLE_BITS ${sample_bits}
-#define SEGMENT_SAMPLES ${segment_samples}
+#define C ${unroll}
+#define W ${taps // subsampling}
 
-// Number of contiguous 32-bit words to store in each segment
-#define SEGMENT_WORDS (SEGMENT_SAMPLES * SAMPLE_BITS / 32)
-// Number of output samples
-#define GROUP_OUT_SIZE (COARSEN * (WGS / SG_SIZE))
-// Stride of input samples between workgroups
-#define GROUP_IN_SIZE (GROUP_OUT_SIZE * SUBSAMPLING)
-// Number of input samples to load in this workgroup
-#define LOAD_SIZE (GROUP_IN_SIZE + TAPS - SUBSAMPLING)
-// Load-size expressed in 32-bit words (rounding up)
-#define LOAD_WORDS ((LOAD_SIZE - 1) * SAMPLE_BITS / 32 + 1)
-// Number of segments to load per work-item
-#define SEGMENTS ((LOAD_SIZE - 1) / (SEGMENT_SAMPLES * WGS) + 1)
-/* Number of contiguous samples that take turns occupying a tile
- * (must divide both SEGMENT_SAMPLES and SUBSAMPLING, and be a multiple
- * of SG_SIZE). This implementation is pessimistic when SUBSAMPLING is
- * neither a factor nor multiple of SEGMENT_SAMPLES, but that's not expected to
- * be a common case.
+/// Raw storage type for sample data
+typedef unsigned int sample_word;
+/// Signed version of sample_word
+typedef int ssample_word;
+#define SAMPLE_WORD_BITS 32
+
+/**
+ *  Read a contiguous sequence of packed samples
+ *
+ * The implementation is optimised to work with loop unrolling, such that
+ * buffer_bits should always be a compile-time constant and branches should
+ * vanish.
  */
-#if SUBSAMPLING % SEGMENT_SAMPLES == 0
-# define TILE_SAMPLES SEGMENT_SAMPLES
-#elif SEGMENT_SAMPLES % SUBSAMPLING == 0
-# define TILE_SAMPLES SUBSAMPLING
-#else
-# define TILE_SAMPLES SG_SIZE
-#endif
-// Number of tiles to store in local memory
-#define TILES (LOAD_SIZE / TILE_SAMPLES)
-#define TILES_PER_SEGMENT (SEGMENT_SAMPLES / TILE_SAMPLES)
-#define TILES_PER_SUBSAMPLING (SUBSAMPLING / TILE_SAMPLES)
-
-${wg_reduce.define_scratch('float', sg_size, 'scratch_t', allow_shuffle=True)}
-${wg_reduce.define_function('float', sg_size, 'reduce', 'scratch_t', wg_reduce.op_plus, allow_shuffle=True, broadcast=False)}
-
-DEVICE_FN void sync()
+struct decoder
 {
-    // When only a single warp is in use, we can use a cheaper barrier
-#if defined(__CUDA_ARCH__)
-    if (WGS == warpSize)
+    const LOCAL sample_word *next_raw;
+    sample_word buffer;
+    int buffer_bits;
+};
+
+DEVICE_FN static unsigned int reverse_endian(unsigned int v)
+{
+    return __byte_perm(v, v, 0x0123);
+}
+
+/// Initialise a decoder.
+DEVICE_FN static void decoder_init(decoder *dec, const LOCAL sample_word *base, unsigned int offset)
+{
+    // Compute how much to skip
+    unsigned int bits = offset * SAMPLE_BITS;
+    unsigned int full_words = bits / SAMPLE_WORD_BITS;
+    dec->buffer = reverse_endian(base[full_words]);
+    dec->buffer_bits = SAMPLE_WORD_BITS - bits % SAMPLE_WORD_BITS;
+    dec->next_raw = base + (full_words + 1);
+}
+
+DEVICE_FN static int decoder_next(decoder *dec)
+{
+    // Desired value in the top SAMPLE_BITS bits
+    sample_word shifted;
+    if (dec->buffer_bits >= SAMPLE_BITS)
     {
-        __syncwarp();
+        shifted = dec->buffer << (SAMPLE_WORD_BITS - dec->buffer_bits);
+        dec->buffer_bits -= SAMPLE_BITS;
     }
     else
-#endif
     {
-        BARRIER();
+        sample_word next = *dec->next_raw++;
+        // CUDA is little-endian, but the packing uses big endian
+        next = reverse_endian(next);
+        shifted = __funnelshift_lc(next, dec->buffer, SAMPLE_WORD_BITS - dec->buffer_bits);
+        dec->buffer = next;
+        dec->buffer_bits += SAMPLE_WORD_BITS - SAMPLE_BITS;
     }
+    // Rely on nvcc to do sign extension when right-shifting a negative
+    // value (it's undefined behaviour in C).
+    return ((ssample_word) shifted) >> (SAMPLE_WORD_BITS - SAMPLE_BITS);
 }
 
 DEVICE_FN static float2 cmul(float2 a, float2 b)
@@ -101,220 +87,68 @@ DEVICE_FN static float2 cmul(float2 a, float2 b)
     return make_float2(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);
 }
 
-DEVICE_FN static unsigned int reverse_endian(unsigned int v)
-{
-    return __byte_perm(v, v, 0x0123);
-}
-
-/* A segment consists of SEGMENT_SAMPLES contiguous samples, still in 10-bit
- * packing and so occupying SEGMENT_WORDS uint32's. Each uint32 is loaded from
- * memory as big-endian.
- */
-struct segment
-{
-    unsigned int raw[SEGMENT_WORDS];
-};
-
-/* A tile represents a contiguous group of TILE_SAMPLES samples, of which
- * only SG_SIZE (contiguous) are loaded in memory at a time.
- */
-struct tile
-{
-    float2 samples[SG_SIZE];
-};
-
-/* Retrieve a sample from a segment. */
-DEVICE_FN static int segment_get(const segment *seg, int idx)
-{
-    int word0 = idx * SAMPLE_BITS / 32;
-    int shift = idx * SAMPLE_BITS % 32;
-    int top;  // packed value shifted to the top of a 32-bit word
-    if (shift + SAMPLE_BITS <= 32)
-        top = seg->raw[word0] << shift;
-    else
-        top = __funnelshift_l(seg->raw[word0 + 1], seg->raw[word0], shift);
-    return top >>= 32 - SAMPLE_BITS;  // trusts nvcc to sign extend - undefined in C++
-}
-
-/* Retrieve the data for all segments from global memory into registers. */
-DEVICE_FN static void load_segments(
-    const GLOBAL unsigned int * RESTRICT in,
-    segment segs[SEGMENTS],
-    int lid,
-    int in_size_words)
-{
-    for (int i = 0; i < SEGMENTS; i++)
-        for (int j = 0; j < SEGMENT_WORDS; j++)
-        {
-            int addr = i * WGS * SEGMENT_WORDS + lid * SEGMENT_WORDS + j;
-            segs[i].raw[j] = (addr < in_size_words) ? in[addr] : 0;
-        }
-
-    /* First schedule all the loads so that they can happen asynchronously,
-     * and only then do endian swapping.
-     *
-     * Note: this will do some unnecessary work (some of the values are
-     * outside LOAD_SAMPLES) but it's cheaper to just do it than to check.
-     */
-    for (int i = 0; i < SEGMENTS; i++)
-        for (int j = 0; j < SEGMENT_WORDS; j++)
-            segs[i].raw[j] = reverse_endian(segs[i].raw[j]);
-}
-
-/* Decode and mix the samples for the phase. Specifically, each tile is
- * populated with the samples with positions in the range
- * [phase, phase + SG_SIZE).
- */
-DEVICE_FN static void mix(
-    const segment segs[SEGMENTS],
-    LOCAL tile tiles[TILES],
-    float2 mix_base,
-    const GLOBAL float2 (* RESTRICT mix_lookup)[SEGMENT_SAMPLES],
-    int phase,
-    int lid)
-{
-#pragma unroll
-    for (int i = 0; i < SEGMENTS; i++)
-        for (int j = 0; j < TILES_PER_SEGMENT; j++)
-        {
-            int tile_id = i * WGS * TILES_PER_SEGMENT + lid * TILES_PER_SEGMENT + j;
-            if (tile_id < TILES)
-            {
-#pragma unroll
-                for (int k = 0; k < SG_SIZE; k++)
-                {
-                    int seg_idx = j * TILE_SAMPLES + phase + k;
-                    float sample = segment_get(&segs[i], seg_idx);
-                    float2 mixed = cmul(mix_base, mix_lookup[i][seg_idx]);
-                    mixed.x *= sample;
-                    mixed.y *= sample;
-                    tiles[tile_id].samples[k] = mixed;
-                }
-            }
-        }
-}
-
-/* Multiply samples in `tiles` with `weights` and accumulate in `sums`.
- */
-DEVICE_FN static void filter(
-    const GLOBAL float * RESTRICT weights,
-    const LOCAL tile tiles[TILES],
-    float2 sums[COARSEN],
-    int phase, int sg_group, int sg_rank)
-{
-#pragma unroll
-    for (int dphase = 0; dphase < SUBSAMPLING; dphase += TILE_SAMPLES)
-    {
-        // Sample within the SUBSAMPLING group for the first work item in
-        // the subgroup
-        int total_phase = phase + dphase;
-        // Holds a sliding window of samples which get multiplied by the
-        // sample weights.
-        float2 samples[COARSEN];
-        int tile_index_base = total_phase / TILE_SAMPLES + sg_group * (COARSEN * TILES_PER_SUBSAMPLING);
-#pragma unroll
-        for (int j = 0; j < COARSEN - 1; j++)
-        {
-            // Prime the pipeline
-            samples[j] = tiles[tile_index_base + j * TILES_PER_SUBSAMPLING].samples[sg_rank];
-        }
-#pragma unroll
-        for (int i = 0; i < TAPS / SUBSAMPLING; i++)
-        {
-            int tap = i * SUBSAMPLING + total_phase + sg_rank;
-            float w = weights[tap];
-            samples[COARSEN - 1] = tiles[tile_index_base + (i + COARSEN - 1) * TILES_PER_SUBSAMPLING].samples[sg_rank];
-            for (int j = 0; j < COARSEN; j++)
-            {
-                sums[j].x += w * samples[j].x;
-                sums[j].y += w * samples[j].y;
-            }
-            /* Shift down all the samples. The compiler should make
-             * these free by the magic of loop unrolling.
-             */
-            for (int j = 0; j < COARSEN - 1; j++)
-                samples[j] = samples[j + 1];
-        }
-    }
-}
-
 KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void ddc(
     GLOBAL float2 * RESTRICT out,
-    const GLOBAL unsigned int * RESTRICT in,
-    const GLOBAL float * RESTRICT weights,
-    int out_size,
-    int in_size_words,
+    const GLOBAL sample_word * RESTRICT in,
+    const GLOBAL float2 * RESTRICT weights,
+    unsigned int out_size,
+    unsigned int in_size_words,
     double mix_scale,  // Mixer frequency in cycles per sample
     double mix_bias,   // Mixer phase in cycles at the first sample
-    const GLOBAL float2 (* RESTRICT mix_lookup)[SEGMENT_SAMPLES])
+    const GLOBAL float2 * RESTRICT mix_lookup  // Mixer phase rotations
+)
 {
-    LOCAL_DECL tile tiles[TILES];
-    segment segs[SEGMENTS];
-    float2 sums[COARSEN];
+    unsigned int gid = get_global_id(0);
+    unsigned int first_in_idx = gid * (C * SUBSAMPLING);
 
-    /* Note: unsigned is important here as it allows the compiler to turn
-     * div/mod into shift/mask when SG_SIZE is a power of 2.
-     */
-    unsigned int lid = get_local_id(0);
-    unsigned int group = get_group_id(0);
-    unsigned int sg_rank = lid % SG_SIZE;   // Position within subgroup
-    unsigned int sg_group = lid / SG_SIZE;  // Subgroup number
+    // TODO: copy input to shared memory
+    // TODO: copy weights to shared memory
 
-    unsigned int in_offset_group = group * (GROUP_IN_SIZE * SEGMENT_WORDS / SEGMENT_SAMPLES);
-    in += in_offset_group;
-    in_size_words -= in_offset_group;
-    /* Note: could also limit in_size_words to LOAD_WORDS to avoid loading
-     * unwanted data. But that data will be needed by another workgroup and
-     * it seems beneficial to load it into L2 cache.
-     */
+    float2 accum[C];
+    decoder decoders[C + W - 1];
+    float samples[C + W - 1];
 
-    out += group * GROUP_OUT_SIZE;
-    out_size -= group * GROUP_OUT_SIZE;
+    for (int i = 0; i < C + W - 1; i++)
+        decoder_init(&decoders[i], in, first_in_idx + i * SUBSAMPLING);
+    for (int i = 0; i < C; i++)
+        accum[i] = make_float2(0.0f, 0.0f);
 
-    // Complex mixer value at first sample mixed by this work item
-    float2 mix_base;
-    /* mix_bias needs to be computed at double precision because there are many
-     * bits to the left of the decimal point. After we've gotten rid of those
-     * we can go back to single precision.
-     */
-    mix_bias += (group * GROUP_IN_SIZE + lid * SEGMENT_SAMPLES) * mix_scale;
-    mix_bias -= rint(mix_bias);
-    sincospif(2 * (float) mix_bias, &mix_base.y, &mix_base.x);
-
-    load_segments(in, segs, lid, in_size_words);
-
-    for (int i = 0; i < COARSEN; i++)
-        sums[i] = make_float2(0.0f, 0.0f);
-
-    /* This loop determines which mixed samples are kept in `tiles`, namely
-     * those in positions [phase, phase + SG_SIZE) within each tile.
-     */
-#pragma unroll
-    for (int phase = 0; phase < TILE_SAMPLES; phase += SG_SIZE)
+    for (int i = 0; i < SUBSAMPLING; i++)
     {
-        mix(segs, tiles, mix_base, mix_lookup, phase, lid);
-
-        // tiles is written above and read below
-        sync();
-
-        filter(weights, tiles, sums, phase, sg_group, sg_rank);
-
-        // tiles is read above and written by the next loop iteration
-        // (could possibly be eliminated on the final loop pass)
-        sync();
+        for (int j = 0; j < C + W - 1; j++)
+        {
+            samples[j] = (float) decoder_next(&decoders[j]);
+        }
+        for (int j = 0; j < W; j++)
+        {
+            float2 w = weights[j * SUBSAMPLING + i];
+            for (int k = 0; k < C; k++)
+            {
+                accum[k].x += samples[j + k] * w.x;
+                accum[k].y += samples[j + k] * w.y;
+            }
+        }
     }
 
-    // Reduce the result across work items that are contributing to the same sum.
-    for (int j = 0; j < COARSEN; j++)
+    mix_bias += first_in_idx * mix_scale;
+    mix_bias -= rint(mix_bias);
+    float2 mix_base;
+    sincospif(2 * (float) mix_bias, &mix_base.y, &mix_base.x);
+
+    for (int i = 0; i < C; i++)
     {
-        LOCAL_DECL scratch_t scratch;
-        sums[j].x = reduce(sums[j].x, sg_rank, &scratch);
-        sums[j].y = reduce(sums[j].y, sg_rank, &scratch);
-        if (sg_rank == 0)
-        {
-            int addr = sg_group * COARSEN + j;
-            if (addr < out_size)
-                out[addr] = sums[j];
-        }
+        accum[i] = cmul(accum[i], mix_base);
+        // TODO: copy mix_lookup to shared mem?
+        if (i > 0)
+            accum[i] = cmul(accum[i], mix_lookup[i]);
+    }
+
+    // TODO: transpose writeback through local mem?
+    unsigned int first_out_idx = gid * C;
+    for (int i = 0; i < C; i++)
+    {
+        unsigned int idx = first_out_idx + i;
+        if (idx < out_size)
+            out[idx] = accum[i];
     }
 }

--- a/src/katgpucbf/fgpu/kernels/ddc.mako
+++ b/src/katgpucbf/fgpu/kernels/ddc.mako
@@ -150,11 +150,6 @@ void ddc(
                 accum[k].y += samples[j + k] * w.y;
             }
         }
-
-        /* This is not necessary for correctness, but prevents the compiler
-         * going nuts on register allocation and improves performance.
-         */
-        __syncwarp();
     }
 
     mix_bias += get_global_id(0) * (C * SUBSAMPLING) * mix_scale;

--- a/src/katgpucbf/fgpu/kernels/ddc.mako
+++ b/src/katgpucbf/fgpu/kernels/ddc.mako
@@ -77,7 +77,7 @@ DEVICE_FN static float2 cmul(float2 a, float2 b)
     return make_float2(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);
 }
 
-DEVICE_FN static void copy_to_local_f32(LOCAL float *out, const GLOBAL float * RESTRICT in, unsigned int n)
+DEVICE_FN static void copy_to_local_float(LOCAL float *out, const GLOBAL float * RESTRICT in, unsigned int n)
 {
     // This implementation is optimised for 'items' being a compile-time constant,
     // and also for when it is a multiple of WGS.
@@ -96,7 +96,7 @@ DEVICE_FN static void copy_to_local_f32(LOCAL float *out, const GLOBAL float * R
     }
 }
 
-DEVICE_FN static void copy_to_local(LOCAL float2 *out, const GLOBAL float2 * RESTRICT in, unsigned int n)
+DEVICE_FN static void copy_to_local_float2(LOCAL float2 *out, const GLOBAL float2 * RESTRICT in, unsigned int n)
 {
     /* This relies on some behaviour that's not totally defined (aliasing
      * float2 as float[2] but which nvcc seems to handle sanely.
@@ -104,7 +104,7 @@ DEVICE_FN static void copy_to_local(LOCAL float2 *out, const GLOBAL float2 * RES
      * This approach does perform marginally better than copying a float2
      * at a time, presumably due to bank conflicts.
      */
-    copy_to_local_f32((LOCAL float *) out, (const GLOBAL float *) in, n * 2);
+    copy_to_local_float((LOCAL float *) out, (const GLOBAL float *) in, n * 2);
 }
 
 KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1)
@@ -147,8 +147,8 @@ void ddc(
     }
 
     /* Copy weights and mix_lookup to local memory */
-    copy_to_local(local.weights, weights, TAPS);
-    copy_to_local(local.mix_lookup, mix_lookup, C);
+    copy_to_local_float2(local.weights, weights, TAPS);
+    copy_to_local_float2(local.mix_lookup, mix_lookup, C);
 
     BARRIER();
 

--- a/test/fgpu/test_compute.py
+++ b/test/fgpu/test_compute.py
@@ -19,6 +19,7 @@ import pytest
 from katsdpsigproc.abc import AbstractCommandQueue, AbstractContext
 
 from katgpucbf.fgpu import compute
+from katgpucbf.fgpu.engine import generate_ddc_weights
 
 pytestmark = [pytest.mark.cuda_only]
 
@@ -32,7 +33,7 @@ def test_compute(context: AbstractContext, command_queue: AbstractCommandQueue, 
     channels = 32768
     dig_sample_bits = 10
     decimation = 8
-    ddc_taps = 256
+    ddc_taps = 128
     pfb_taps = 4
     spectra_per_heap = 256
     subsampling = decimation
@@ -43,7 +44,12 @@ def test_compute(context: AbstractContext, command_queue: AbstractCommandQueue, 
         spectra = 1280
         internal_channels = channels
     else:
-        narrowband = compute.NarrowbandConfig(decimation=decimation, taps=ddc_taps, mix_frequency=0.2)
+        narrowband = compute.NarrowbandConfig(
+            decimation=decimation,
+            taps=ddc_taps,
+            mix_frequency=0.2,
+            weights=generate_ddc_weights(ddc_taps, decimation, 0.1),
+        )
         spectra = nb_spectra
         internal_channels = 2 * channels
     template = compute.ComputeTemplate(context, pfb_taps, channels, dig_sample_bits, narrowband)

--- a/test/fgpu/test_compute.py
+++ b/test/fgpu/test_compute.py
@@ -46,7 +46,6 @@ def test_compute(context: AbstractContext, command_queue: AbstractCommandQueue, 
     else:
         narrowband = compute.NarrowbandConfig(
             decimation=decimation,
-            taps=ddc_taps,
             mix_frequency=0.2,
             weights=generate_ddc_weights(ddc_taps, decimation, 0.1),
         )

--- a/test/fgpu/test_ddc.py
+++ b/test/fgpu/test_ddc.py
@@ -78,6 +78,7 @@ def test_ddc(
     h_out = fn.buffer("out").get(command_queue)
     # atol has to be quite large because the calculation is fundamentally
     # numerically unstable.
+    print(np.nonzero(np.abs(h_out - expected) > 2e-2))
     np.testing.assert_allclose(h_out, expected, atol=2e-2)
     # RMS error should be an order of magnitude lower
     err = h_out - expected

--- a/test/fgpu/test_ddc.py
+++ b/test/fgpu/test_ddc.py
@@ -46,8 +46,8 @@ def ddc_host(samples: np.ndarray, weights: np.ndarray, subsampling: int, mix_fre
         (256, 16, 1024 * 1024, None),
         (256, 16, 1234568, None),
         (256, 8, 1234568, None),
-        (256, 4, 1234568, None),
-        (256, 32, 1234568, None),
+        (255, 4, 1234568, None),
+        (257, 32, 1234568, None),
         (256, 64, 1234568, None),
         (32, 32, 1234568, None),
         (55, 5, 123464, None),
@@ -88,7 +88,6 @@ def test_ddc(
 @pytest.mark.parametrize(
     "taps,subsampling",
     [
-        (123, 12),  # Not a multiple
         (0, 64),  # <= 0
         (8, -1),  # <= 0
     ],

--- a/test/fgpu/test_ddc.py
+++ b/test/fgpu/test_ddc.py
@@ -99,8 +99,19 @@ def test_bad_template_parameters(context: AbstractContext, taps: int, subsamplin
         DDCTemplate(context, taps=taps, subsampling=subsampling)
 
 
+def test_bad_tuning(context: AbstractContext) -> None:
+    with pytest.raises(ValueError, match="unroll must be a multiple of 16"):
+        DDCTemplate(context, taps=255, subsampling=5, tuning={"wgs": 32, "unroll": 5})
+
+
 def test_too_few_samples(context: AbstractContext, command_queue: AbstractCommandQueue) -> None:
     """Test that :class:`DDC` raises ValueError when `samples` is too small."""
     template = DDCTemplate(context, taps=256, subsampling=16)
     with pytest.raises(ValueError):
         template.instantiate(command_queue, 255)
+
+
+@pytest.mark.force_autotune
+def test_autotune(context: AbstractContext) -> None:
+    """Test that autotuner runs successfully."""
+    DDCTemplate(context, taps=128, subsampling=8)

--- a/test/fgpu/test_ddc.py
+++ b/test/fgpu/test_ddc.py
@@ -51,7 +51,7 @@ def ddc_host(samples: np.ndarray, weights: np.ndarray, subsampling: int, mix_fre
         (256, 64, 1234568, None),
         (32, 32, 1234568, None),
         (55, 5, 123464, None),
-        (256, 16, 256 * 1024, {"wgs": 96, "coarsen": 3, "sg_size": 8, "segment_samples": 32}),
+        (256, 16, 256 * 1024, {"wgs": 96, "unroll": 4}),
     ],
 )
 def test_ddc(

--- a/test/fgpu/test_ddc.py
+++ b/test/fgpu/test_ddc.py
@@ -78,7 +78,6 @@ def test_ddc(
     h_out = fn.buffer("out").get(command_queue)
     # atol has to be quite large because the calculation is fundamentally
     # numerically unstable.
-    print(np.nonzero(np.abs(h_out - expected) > 2e-2))
     np.testing.assert_allclose(h_out, expected, atol=2e-2)
     # RMS error should be an order of magnitude lower
     err = h_out - expected

--- a/test/fgpu/test_ddc.py
+++ b/test/fgpu/test_ddc.py
@@ -71,10 +71,9 @@ def test_ddc(
 
     template = DDCTemplate(context, taps=taps, subsampling=subsampling, tuning=tuning)
     fn = template.instantiate(command_queue, samples)
-    fn.mix_frequency = mix_frequency
+    fn.configure(mix_frequency, weights)
     fn.ensure_all_bound()
     fn.buffer("in").set(command_queue, h_in)
-    fn.buffer("weights").set(command_queue, weights)
     fn()
     h_out = fn.buffer("out").get(command_queue)
     # atol has to be quite large because the calculation is fundamentally

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -635,9 +635,6 @@ class TestEngine:
         dig_sample_bits: int,
     ) -> None:
         """Test that delay rate and phase rate setting works."""
-        # TODO[nb]: Narrowband doesn't support non-default dig_sample_bits yet
-        if isinstance(output, NarrowbandOutput) and dig_sample_bits != DIG_SAMPLE_BITS:
-            pytest.skip(f"narrowband does not support dig_sample_bits={dig_sample_bits}")
         # One tone at centre frequency to test the absolute phase, and one at another
         # frequency to test the slope across the band.
         tone_channels = [CHANNELS // 2, CHANNELS - 123]


### PR DESCRIPTION
Replace the DDC kernel with a new version that is simpler, faster, more flexible and supports arbitrary input_sample_bits.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-980 and NGC-926.
