### PR TITLE
Prevent docutils deprecation warnings in generate_pdf

### DIFF
--- a/qualification/report/generate_pdf.py
+++ b/qualification/report/generate_pdf.py
@@ -166,7 +166,14 @@ def rst2latex(text: str) -> str:
     """Turn a section of ReStructured Text (like a docstring) into LaTeX."""
     writer = docutils.writers.latex2e.Writer()
     writer.translator_class = Translator
-    return publish_parts(source=text, writer=writer)["body"]
+    # If these are not specifically set, docutils issues deprecation warnings
+    # indicating that the defaults will change. These settings are the values
+    # that will become the default in future.
+    overrides = {
+        "use_latex_citations": True,
+        "legacy_column_widths": False,
+    }
+    return publish_parts(source=text, writer=writer, settings_overrides=overrides)["body"]
 
 
 @dataclass

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ test =
 
 qualification =
     async-timeout
-    docutils
+    docutils>=0.18
     matplotlib
     prometheus-api-client
     pylatex


### PR DESCRIPTION
This changes the docutils settings (to match what will become default in docutils 1.0), but the report appears visually unchanged.

Closes NGC-960.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match