### PR TITLE
Fix up initial binding of Compute slots

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         additional_dependencies: [
             'aiokatcp==1.7.0',
             'dask==2023.5.0',
-            'katsdpsigproc==1.6.1',
+            'katsdpsigproc==1.7.0',
             'katsdptelstate==0.13',
             'numpy==1.23.4',
             'pyparsing==3.0.9',

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -132,7 +132,7 @@ katsdpservices==1.2
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   katgpucbf (setup.cfg)
-katsdpsigproc==1.6.1
+katsdpsigproc==1.7.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -136,7 +136,7 @@ katsdpservices==1.2
     # via
     #   -c requirements.txt
     #   katgpucbf (setup.cfg)
-katsdpsigproc==1.6.1
+katsdpsigproc==1.7.0
     # via
     #   -c requirements.txt
     #   katgpucbf (setup.cfg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ importlib-metadata==6.6.0
     # via dask
 katsdpservices==1.2
     # via katgpucbf (setup.cfg)
-katsdpsigproc==1.6.1
+katsdpsigproc==1.7.0
     # via katgpucbf (setup.cfg)
 katsdptelstate==0.13
     # via katgpucbf (setup.cfg)

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ install_requires =
     aiokatcp>=1.6.0
     dask
     katsdpservices[aiomonitor]
-    katsdpsigproc>=1.6.1
+    katsdpsigproc>=1.7.0
     katsdptelstate
     numba
     numpy


### PR DESCRIPTION
There are two issues fixed:
- Some slots had memory allocated to them before it was needed, and those slots were later re-bound, making the initial allocation unnecessary and a waste of memory (NGC-978).
- Some slots were only bound once the data arrived, slowing down the startup and possibly leading to more lost heaps than necessary.

These changes don't seem to affect the achievable throughput, but should reduce memory usage, and might reduce startup losses.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-978 (although I might still need to reduce the memory allocation in katsdpcontroller).
