### PR TITLE
Support ± symbol in qualification report

### DIFF
--- a/qualification/report/preamble.tex
+++ b/qualification/report/preamble.tex
@@ -8,8 +8,8 @@
 % http://www.bollchen.de/blog/2011/04/good-looking-line-breaks-with-the-listings-package/
 \lstset{prebreak=\raisebox{0ex}[0ex][0ex]{\ensuremath{\hookleftarrow}}}
 \lstset{postbreak=\raisebox{0ex}[0ex][0ex]{\ensuremath{\hookrightarrow\space}}}
-% Make degree sign in listings (e.g. from a backtrace) work.
-\lstset{inputencoding=utf8,literate={°}{{\textdegree}}1}
+% Make degree sign and plus-minus sign in listings (e.g. from a backtrace) work.
+\lstset{inputencoding=utf8,literate={°}{{\textdegree}}1{±}{{\ensuremath{\pm}}}1}
 
 % For plotting to work nicely.
 \usepackage{pgfplots}


### PR DESCRIPTION
pytest.approx generates it, and lstlistings needs some help to parse it.

Closes NGC-989
