### PR TITLE
Fix phase offset for narrowband delays

### DIFF
--- a/src/katgpucbf/fgpu/compute.py
+++ b/src/katgpucbf/fgpu/compute.py
@@ -21,7 +21,6 @@ Allocations of memory for input, intermediate and output are also handled here.
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from fractions import Fraction
 
 import numpy as np
 from katsdpsigproc import accel, fft
@@ -243,14 +242,8 @@ class Compute(accel.OperationSequence):
             self.bind(**{f"in{pol}": samples[pol]})
             self.ensure_bound(f"subsampled{pol}")
         for pol in range(N_POLS):
-            # TODO: could run these in parallel, but that would require two
-            # command queues.
-            # Compute the fractional part of first_sample * mix_frequency.
-            # Using Fraction avoids the serious rounding errors that would
-            # occur using floating point.
-            phase = Fraction(self.ddc[pol].mix_frequency) * first_sample
-            phase -= round(phase)
-            self.ddc[pol].mix_phase = float(phase)
+            # TODO: eliminate this property entirely
+            self.ddc[pol].mix_phase = 0.0
             self.ddc[pol]()
 
     def _run_frontend_common(

--- a/src/katgpucbf/fgpu/compute.py
+++ b/src/katgpucbf/fgpu/compute.py
@@ -242,8 +242,6 @@ class Compute(accel.OperationSequence):
             self.bind(**{f"in{pol}": samples[pol]})
             self.ensure_bound(f"subsampled{pol}")
         for pol in range(N_POLS):
-            # TODO: eliminate this property entirely
-            self.ddc[pol].mix_phase = 0.0
             self.ddc[pol]()
 
     def _run_frontend_common(

--- a/src/katgpucbf/fgpu/ddc.py
+++ b/src/katgpucbf/fgpu/ddc.py
@@ -137,12 +137,11 @@ class DDC(accel.Operation):
     baseband filter and a mixer frequency for translating the signal from
     the desired band to baseband.
 
-    Element j of the output contains the dot product of **weights** with
-    elements :math:`dj, d(j+1), \ldots, d(j+taps-1)` of the mixed signal. The
-    mixed signal is the product of sample :math:`j` of the input with
-    :math:`e^{2\pi i (aj + b)}`, where :math:`a` is the `mix_frequency`
-    argument to :meth:`configure` and :math:`b` is the (settable)
-    :attr:`mix_phase` property.
+    Element i of the output contains the dot product of **weights** with
+    elements :math:`dj, d(i+1), \ldots, d(i+taps-1)` of the mixed signal. The
+    mixed signal is the product of sample :math:`i` of the input with
+    :math:`e^{2\pi j (ai)}`, where :math:`a` is the `mix_frequency`
+    argument to :meth:`configure`.
 
     .. rubric:: Slots
 
@@ -188,7 +187,6 @@ class DDC(accel.Operation):
         self._mix_lookup = accel.DeviceArray(template.context, (template.unroll,), np.complex64)
         self._mix_lookup_host = self._mix_lookup.empty_like()
         self._mix_frequency = 0.0  # Specify in cycles per sample
-        self.mix_phase = 0.0  # Specify in fractions of a cycle (0-1)
 
     def configure(self, mix_frequency: float, weights: np.ndarray) -> None:
         """Set the mixer frequency and filter weights.
@@ -226,7 +224,6 @@ class DDC(accel.Operation):
                 np.int32(out_buffer.shape[0]),  # out_size
                 np.int32(accel.divup(in_buffer.shape[0], 4)),  # in_size_words
                 np.float64(self.mix_frequency),  # mix_scale
-                np.float64(self.mix_phase),  # mix_bias
                 self._mix_lookup.buffer,
             ],
             global_size=(groups * self.template.wgs, 1, 1),

--- a/src/katgpucbf/fgpu/kernels/ddc.mako
+++ b/src/katgpucbf/fgpu/kernels/ddc.mako
@@ -131,7 +131,6 @@ void ddc(
     unsigned int out_size,
     unsigned int in_size_words,
     double mix_scale,  // Mixer frequency in cycles per sample
-    double mix_bias,   // Mixer phase in cycles at the first sample
     const GLOBAL float2 * RESTRICT mix_lookup  // Mixer phase rotations
 )
 {
@@ -203,7 +202,7 @@ void ddc(
     }
 
     // Compute the mixer for the first sample output by this workitem
-    mix_bias += get_global_id(0) * (C * SUBSAMPLING) * mix_scale;
+    double mix_bias = get_global_id(0) * (C * SUBSAMPLING) * mix_scale;
     mix_bias -= rint(mix_bias);
     float2 mix_base;
     sincospif(2 * (float) mix_bias, &mix_base.y, &mix_base.x);

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -288,7 +288,7 @@ class TestEngine:
         Parameters
         ----------
         timestamps
-            Timestamps to generate
+            Timestamps for the samples to generate
         tone
             The cosine wave to synthesize
         pol


### PR DESCRIPTION
It was failing to account for the phase shift caused by the mixer.

The mixer is now initially referenced to the start of the input chunk, rather than timestamp 0, which simplifies some calculations. When applying phase correction, the reference point is shifted to the start of the PFB window. Thus, the output phase is determined by the set of samples in the PFB window and the delay, but it is not affected by the absolute timestamp.

Some unit tests were adjusted to properly test this (when the centre frequency is not a multiple of the channel width), and a new test was added to help check my sanity.

This doesn't actually matter for baseline-correlation-products output, as the error will cancel out between the two antennas, but it will affect antenna-channelised-voltage and tied-array-channelised-voltage streams.

Qualification tests are still a work in progress.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-928.
