### PR TITLE
Fix rounding of frequency in dsim

### DIFF
--- a/src/katgpucbf/dsim/signal.py
+++ b/src/katgpucbf/dsim/signal.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2021-2022, National Research Foundation (SARAO)
+# Copyright (c) 2021-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -237,7 +237,7 @@ class CW(Signal):
         waves = max(1, round(n * self.frequency / sample_rate))
         frequency = waves * sample_rate / n
         logger.info(f"Rounded tone frequency to {frequency} Hz")
-        scale = self.frequency / sample_rate * 2 * np.pi
+        scale = waves / n * 2 * np.pi
 
         # Index of the first element of each chunk
         offsets = da.arange(0, n, CHUNK_SIZE, chunks=1, dtype=np.int64)

--- a/test/dsim/test_signal.py
+++ b/test/dsim/test_signal.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2021-2022, National Research Foundation (SARAO)
+# Copyright (c) 2021-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -66,6 +66,9 @@ class TestCW:
         cw = CW(amplitude, frequency)
         out = cw.sample(n, adc_sample_rate)
         timestamps = np.arange(0, n)
+        # Round frequency to match the rounding in CW
+        waves = max(1, round(n * frequency / adc_sample_rate))
+        frequency = waves * adc_sample_rate / n
         expected = np.cos(timestamps * (frequency / adc_sample_rate * 2 * np.pi)) * amplitude
         np.testing.assert_allclose(out, expected, atol=1e-6 * amplitude)
 


### PR DESCRIPTION
It was supposed to round to the nearest frequency that could be supported with repeating output, but the original rather than the rounded value was used. This could lead to a discontinuity every time the sampled data wrapped.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Relates to NGC-984.
