### PR TITLE
Correct the narrowband gain

### DIFF
--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -108,7 +108,8 @@ def generate_ddc_weights(taps: int, subsampling: int, weight_pass: float) -> np.
     band will be retained. The response in the outer 50% (and aliases
     thereof) are thus irrelevant.
 
-    The resulting weights are normalised such that the sum of squares is 1.
+    The resulting weights are normalised such that the gain (after subsampling)
+    is 1.
 
     Parameters
     ----------
@@ -128,7 +129,7 @@ def generate_ddc_weights(taps: int, subsampling: int, weight_pass: float) -> np.
         desired.append(0.0)
         weights.append(1.0)
     coeff = scipy.signal.remez(taps, edges, desired, weights, fs=subsampling, maxiter=1000)
-    coeff /= np.sqrt(np.sum(np.square(coeff)))
+    coeff *= np.sqrt(subsampling)
     return coeff.astype(np.float32)
 
 


### PR DESCRIPTION
This gives the same incoherent gain as wideband (i.e. 1), which should make the test_accum_length test of total power pass.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Relates to NGC-984.
