### PR TITLE
Use fixed-point arithmic for DDC mixer phase

### DIFF
--- a/doc/fgpu.design.rst
+++ b/doc/fgpu.design.rst
@@ -681,12 +681,11 @@ product :math:`ft` will have a large integer part and leave few bits for
 the fractional part. Even passing :math:`f` in single precision can lead
 to large errors.
 
-To overcome this, a hybrid approach is used. The factor :math:`e^{2\pi jfS(b+i)}`
-is further decomposed as :math:`e^{2\pi jf(Sb)} \cdot e^{2\pi jf(Si)}`. We
-compute :math:`Sb` in double precision and subtract out the integer part before
-dropping to single precision to compute the complex exponential. This only
-needs to be done once per work-item. The second factor is stored in a
-single-precision lookup table, indexed by :math:`i`.
+To avoid these problems, fixed-point computations are used. Phase is
+represented as a fractional number of cycles, scaled by :math:`2^{32}` and
+stored in a 32-bit integer. When performing arithmetic on values encoded this
+way, the values may overflow and wrap. The high bits that are lost represent
+complete cycles, and so have no effect on phase.
 
 Filter design
 ^^^^^^^^^^^^^

--- a/src/katgpucbf/fgpu/kernels/ddc.mako
+++ b/src/katgpucbf/fgpu/kernels/ddc.mako
@@ -204,7 +204,9 @@ void ddc(
     for (int i = 0; i < C; i++)
     {
         float2 mix;
-        // Casting from unsigned int to int changes the range from [0, 2pi) to [-pi, pi).
+        // Casting from unsigned int to int changes the range from [0, 2pi) to
+        // [-pi, pi). The magic number is 2^32, used to convert fixed-point
+        // representation to real.
         __sincosf(2 * (float) M_PI / 4294967296.0f * (int) mix_cycles, &mix.y, &mix.x);
         accum[i] = cmul(accum[i], mix);
         mix_cycles += mix_scale;

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -849,12 +849,8 @@ class TestEngine:
             if p and i + middle < len(dst_present):
                 x = out_data[:, i * spectra_per_heap : (i + 1) * spectra_per_heap]
                 y = out_data[:, (i + middle) * spectra_per_heap : (i + middle + 1) * spectra_per_heap]
-                # For narrowband they're not guaranteed to be equal, as the mixer
-                # phase varies over time. For this test the time difference is a
-                # multiple of the mixer wavelength, but there can still be
-                # numerical rounding differences. For the fixed seed chosen
-                # above, we get exact equality, but this test may need to be
-                # relaxed slightly in future.
+                # For narrowband they're only guaranteed to be equal because
+                # the time difference is a multiple of the mixer wavelength.
                 np.testing.assert_equal(x, y)
 
         for pol in range(N_POLS):


### PR DESCRIPTION
This eliminates some floating-point consistency issues, where results would change slightly if the tuning parameters (specifically unrolling) changed. This approach is also a few percent cheaper as it does not require double-precision arithmetic in the kernel.

The downside is that the requested centre frequency is quantised slightly, and this will require changed to katsdpcontroller to report the actual frequency used. The quantisation is to a multiple of output-bw/2**32, which is far below the channel width.

Closes NGC-991.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
