### PR TITLE
Test narrowband modes in qualification testing

### DIFF
--- a/qualification/__init__.py
+++ b/qualification/__init__.py
@@ -192,10 +192,15 @@ class BaselineCorrelationProductsReceiver:
     ) -> None:
         # Some metadata we know already from the config.
         acv_name = correlator.config["outputs"][stream_name]["src_streams"][0]
-        self.n_inputs = len(correlator.config["outputs"][acv_name]["src_streams"])
+        acv_config = correlator.config["outputs"][acv_name]
+        self.n_inputs = len(acv_config["src_streams"])
         self.n_ants = self.n_inputs // 2
-        self.n_chans = correlator.config["outputs"][acv_name]["n_chans"]
-        self.input_labels = correlator.config["outputs"][acv_name]["input_labels"]
+        self.n_chans = acv_config["n_chans"]
+        self.input_labels = acv_config["input_labels"]
+        if "narrowband" in acv_config:
+            self.decimation_factor = acv_config["narrowband"]["decimation_factor"]
+        else:
+            self.decimation_factor = 1
 
         # But some we don't. Note: these could be properties. But copying them up
         # front ensures we get an exception early if the sensor is missing.
@@ -210,6 +215,7 @@ class BaselineCorrelationProductsReceiver:
         self.sync_time = correlator.sensors[f"{acv_name}.sync-time"].value
         self.scale_factor_timestamp = correlator.sensors[f"{acv_name}.scale-factor-timestamp"].value
         self.bandwidth = correlator.sensors[f"{acv_name}.bandwidth"].value
+        self.center_freq = correlator.sensors[f"{acv_name}.center-freq"].value
         self.multicast_endpoints = [
             (endpoint.host, endpoint.port)
             for endpoint in endpoint_list_parser(DEFAULT_PORT)(

--- a/qualification/antenna_channelised_voltage/__init__.py
+++ b/qualification/antenna_channelised_voltage/__init__.py
@@ -123,10 +123,10 @@ def compute_tone_gain(
     # well (2e9 is comfortably less than 2^31).
     # The PFB is scaled for fixed incoherent gain, but we need to be concerned
     # about coherent gain to avoid overflowing the F-engine output. Coherent gain
-    # scales approximately with np.sqrt(correlator.n_chans / 2).
+    # scales approximately with sqrt(bw / chan_bw / 2).
     target_voltage = min(target_voltage, np.sqrt(2e9 / receiver.n_spectra_per_acc))
     dig_max = 2 ** (DIG_SAMPLE_BITS - 1) - 1
-    return target_voltage / (amplitude * dig_max * np.sqrt(receiver.n_chans / 2))
+    return target_voltage / (amplitude * dig_max * np.sqrt(receiver.n_chans * receiver.decimation_factor / 2))
 
 
 async def sample_tone_response(

--- a/qualification/antenna_channelised_voltage/__init__.py
+++ b/qualification/antenna_channelised_voltage/__init__.py
@@ -157,7 +157,7 @@ async def sample_tone_response(
         corrs.append(receiver.bls_ordering.index((receiver.input_labels[i], receiver.input_labels[i + 1])))
 
     channel_width = receiver.bandwidth / receiver.n_chans
-    freqs = np.asarray(rel_freqs) * channel_width  # Baseband, which is what dsims work on
+    freqs = receiver.center_freq + (np.asarray(rel_freqs) - receiver.n_chans / 2) * channel_width
     amplitude = np.asarray(amplitude)
     out_shape = np.broadcast_shapes(freqs.shape, amplitude.shape) + (receiver.n_chans,)
     out = np.empty(out_shape, np.int32)

--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -189,7 +189,7 @@ async def test_delay_enable_disable(
 
 @pytest.mark.requirements("CBF-REQ-0187,CBF-REQ-0188")
 @pytest.mark.xfail(
-    reason="requirement cannot be met for all mdoes as delays cannot be updated more than once per spectrum"
+    reason="requirement cannot be met for all modes as delays cannot be updated more than once per spectrum"
 )
 async def test_delay_application_rate(correlator: CorrelatorRemoteControl, pdf_report: Reporter) -> None:
     """Test that delay and phase polynomials are applied at the required rate.

--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -143,7 +143,7 @@ async def test_delay_enable_disable(
 
     receiver = receive_baseline_correlation_products
     channel = 3 * receiver.n_chans // 4
-    freq = 3 * receiver.bandwidth / 4
+    freq = receiver.center_freq + receiver.bandwidth / 4
     signal = f"cw(0.1, {freq})"
     gain = compute_tone_gain(receiver, 0.1, 100)
     bl_idx = receiver.bls_ordering.index((receiver.input_labels[0], receiver.input_labels[1]))
@@ -171,7 +171,7 @@ async def test_delay_enable_disable(
     # One might expect it to be pi radians, but that ignores the implicit
     # phase adjustment that ensures the centre channel has zero phase.
     with check:
-        assert phase == pytest.approx(math.pi / 3, abs=np.deg2rad(1))
+        assert phase == pytest.approx(math.pi * (freq - receiver.center_freq) / freq, abs=np.deg2rad(1))
 
     pdf_report.step("Check that compensation can be disabled.")
     await set_delays(["0,0:0,0"] * (2 * receiver.n_ants))
@@ -300,14 +300,15 @@ def check_phases(
     pdf_report.figure(fig)
 
 
-def delay_phase(n_chans: int, delay_samples: float) -> np.ndarray:
+def delay_phase(receiver: BaselineCorrelationProductsReceiver, delay_samples: float) -> np.ndarray:
     """Calculate expected phase for a given delay.
 
     The return value is appropriate if the sample signal is provided on both
     inputs, but the first input in the correlation is configured with a delay
     of `delay_samples` samples, and no phase compensation.
     """
-    return np.arange(-n_chans // 2, n_chans // 2) / n_chans * np.pi * -delay_samples
+    n_chans = receiver.n_chans
+    return np.arange(-n_chans // 2, n_chans // 2) / n_chans / receiver.decimation_factor * np.pi * -delay_samples
 
 
 async def _test_delay_phase_fixed(
@@ -381,7 +382,7 @@ async def _test_delay_phase_fixed(
         input1 = receiver.input_labels[i]
         input2 = receiver.input_labels[-1]
         bl_idx = receiver.bls_ordering.index((input1, input2))
-        expected = delay_phase(receiver.n_chans, residual) + phase
+        expected = delay_phase(receiver, residual) + phase
         check_phases(pdf_report, actual[:, bl_idx], expected, caption)
 
 
@@ -445,7 +446,7 @@ async def _test_delay_phase_rate(
         input2 = receiver.input_labels[-1]
         bl_idx = receiver.bls_ordering.index((input1, input2))
         actual = phases[1][:, bl_idx] - phases[0][:, bl_idx]
-        expected = delay_phase(receiver.n_chans, delay_rate * elapsed) + phase_rate * elapsed_s
+        expected = delay_phase(receiver, delay_rate * elapsed) + phase_rate * elapsed_s
         # Allow 2° rather than 1° because we're taking the difference between
         # two phases which each have a 1° tolerance.
         check_phases(pdf_report, actual, expected, caption, tolerance_deg=2)

--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -188,6 +188,9 @@ async def test_delay_enable_disable(
 
 
 @pytest.mark.requirements("CBF-REQ-0187,CBF-REQ-0188")
+@pytest.mark.xfail(
+    reason="requirement cannot be met for all mdoes as delays cannot be updated more than once per spectrum"
+)
 async def test_delay_application_rate(correlator: CorrelatorRemoteControl, pdf_report: Reporter) -> None:
     """Test that delay and phase polynomials are applied at the required rate.
 

--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -383,6 +383,9 @@ async def _test_delay_phase_fixed(
         input2 = receiver.input_labels[-1]
         bl_idx = receiver.bls_ordering.index((input1, input2))
         expected = delay_phase(receiver, residual) + phase
+        # The delay in the dsim will affect the phase of the centre frequency,
+        # which the delay compensation won't correct.
+        expected += 2 * np.pi * delay_samples[i] / receiver.scale_factor_timestamp * receiver.center_freq
         check_phases(pdf_report, actual[:, bl_idx], expected, caption)
 
 

--- a/qualification/baseline_correlation_products/test_accum_length.py
+++ b/qualification/baseline_correlation_products/test_accum_length.py
@@ -25,6 +25,7 @@ from ..reporter import Reporter
 
 
 @pytest.mark.requirements("CBF-REQ-0096")
+@pytest.mark.xfail(reason="requirement needs to be updated")
 async def test_accum_length(
     correlator: CorrelatorRemoteControl,
     receive_baseline_correlation_products: BaselineCorrelationProductsReceiver,
@@ -35,8 +36,7 @@ async def test_accum_length(
     Verification method
     -------------------
     Verify by testing that the accumulation interval is within specification
-    when set to 500ms. Inject a noise signal and check that the measured
-    signal has the expected power.
+    when set to 500ms.
     """
     receiver = receive_baseline_correlation_products
     pdf_report.step("Retrieve the reported accumulation time and check it.")
@@ -45,6 +45,22 @@ async def test_accum_length(
     with check:
         assert 0.48 <= receiver.int_time <= 0.52
 
+
+@pytest.mark.requirements("CBF-REQ-0096")
+async def test_accum_power(
+    correlator: CorrelatorRemoteControl,
+    receive_baseline_correlation_products: BaselineCorrelationProductsReceiver,
+    pdf_report: Reporter,
+) -> None:
+    """
+    Test that the actual accumulation length matches the reported length.
+
+    Verification method
+    -------------------
+    Inject a noise signal and check that the measured signal has the expected
+    power for the number of accumulations.
+    """
+    receiver = receive_baseline_correlation_products
     pdf_report.step("Inject a white noise signal.")
     level = 32  # Expected magnitude of F-engine outputs
     input_std = level / 511  # dsim will scale up by 511 to fill [-511, 511] range

--- a/qualification/baseline_correlation_products/test_accum_length.py
+++ b/qualification/baseline_correlation_products/test_accum_length.py
@@ -65,7 +65,9 @@ async def test_accum_length(
     # the input signals are the same for all antennas.
     assert isinstance(chunks[1][1].data, np.ndarray)
     total_power = np.sum(chunks[1][1].data[:, 0, 0], dtype=np.int64)
-    acc_len = round(receiver.int_time * receiver.scale_factor_timestamp / (2 * receiver.n_chans))
+    acc_len = round(
+        receiver.int_time * receiver.scale_factor_timestamp / (2 * receiver.n_chans * receiver.decimation_factor)
+    )
     expected_power = acc_len * receiver.n_chans * (level * level)
     pdf_report.detail(f"Total power: {total_power}; expected: {expected_power}.")
     # Statistical analysis of total_power is quite tricky because there is

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -321,9 +321,14 @@ async def _correlator_config_and_description(
         "n_chans": n_channels,
     }
     if narrowband_decimation > 1:
+        # Pick a centre frequency that is not going to be a multiple of the
+        # channel width (to test the most general case), but which is a
+        # multiple of the dsim frequency resolution (to avoid rounding the
+        # frequency of injected tones).
+        centre_frequency = adc_sample_rate * (23456789 / 2**27)
         config["outputs"]["antenna-channelised-voltage"]["narrowband"] = {
             "decimation_factor": narrowband_decimation,
-            "centre_frequency": adc_sample_rate / 4,
+            "centre_frequency": centre_frequency,
         }
     config["outputs"]["baseline-correlation-products"] = {
         "type": "gpucbf.baseline_correlation_products",

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -62,7 +62,24 @@ ini_options = [
     IniOption(name="product_name", help="Name of subarray product", type="string", default="qualification_correlator"),
     IniOption(name="tester", help="Name of person executing this qualification run", type="string", default="Unknown"),
     IniOption(name="max_antennas", help="Maximum number of antennas to test", type="string", default="8"),
-    IniOption(name="channels", help="Space-separated list of channel counts to test", type="args", default=["8192"]),
+    IniOption(
+        name="wideband_channels",
+        help="Space-separated list of channel counts to test in wideband",
+        type="args",
+        default=["8192"],
+    ),
+    IniOption(
+        name="narrowband_channels",
+        help="Space-separated list of channel counts to test in narrowband",
+        type="args",
+        default=["32768"],
+    ),
+    IniOption(
+        name="narrowband_decimation",
+        help="Space-separated list of narrowband decimation factors to test",
+        type="args",
+        default=["8"],
+    ),
     IniOption(name="bands", help="Space-separated list of bands to test", type="args", default=["l"]),
     IniOption(name="raw_data", help="Include raw data for figures", type="bool", default=False),
 ]
@@ -130,11 +147,17 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
         metafunc.parametrize("n_antennas", values, indirect=True)
     if "band" in metafunc.fixturenames:
         metafunc.parametrize("band", metafunc.config.getini("bands"), indirect=True)
-    if "n_channels" in metafunc.fixturenames:
+    if "n_channels" in metafunc.fixturenames or "narrowband_decimation" in metafunc.fixturenames:
         # NB: don't try to convert the string-typed values to integers here.
         # It will generate new int objects each time, causing pytest to treat
         # them as different and hence it won't reuse the fixture between tests.
-        metafunc.parametrize("n_channels", metafunc.config.getini("channels"), indirect=True)
+        configs = [(n_channels, "1") for n_channels in metafunc.config.getini("wideband_channels")]
+        configs.extend(
+            (n_channels, decimation)
+            for decimation in metafunc.config.getini("narrowband_decimation")
+            for n_channels in metafunc.config.getini("narrowband_channels")
+        )
+        metafunc.parametrize("n_channels, narrowband_decimation", configs, indirect=True)
 
 
 # Need to redefine this from pytest-asyncio to have it at package scope
@@ -160,6 +183,12 @@ def n_dsims() -> int:  # noqa: D401
 @pytest.fixture(scope="package")
 def n_channels(request: pytest.FixtureRequest) -> int:  # noqa: D401
     """Number of channels for the channeliser."""
+    return int(request.param)
+
+
+@pytest.fixture(scope="package")
+def narrowband_decimation(request: pytest.FixtureRequest) -> int:  # noqa: D401
+    """Narrowband decimation factor, or 1 for wideband."""
     return int(request.param)
 
 
@@ -246,7 +275,13 @@ def matplotlib_report_style() -> Generator[None, None, None]:
 
 @pytest.fixture(scope="package")
 async def _correlator_config_and_description(
-    pytestconfig, n_antennas: int, n_channels: int, n_dsims: int, band: str, int_time: float
+    pytestconfig,
+    n_antennas: int,
+    n_channels: int,
+    n_dsims: int,
+    band: str,
+    int_time: float,
+    narrowband_decimation: int,
 ) -> tuple[dict, dict]:
     config: dict = {
         "version": "3.4",
@@ -285,6 +320,11 @@ async def _correlator_config_and_description(
         "input_labels": [f"m{800 + i}{pol}" for i in range(n_antennas) for pol in ["v", "h"]],
         "n_chans": n_channels,
     }
+    if narrowband_decimation > 1:
+        config["outputs"]["antenna-channelised-voltage"]["narrowband"] = {
+            "decimation": narrowband_decimation,
+            "centre_frequency": adc_sample_rate / 4,
+        }
     config["outputs"]["baseline-correlation-products"] = {
         "type": "gpucbf.baseline_correlation_products",
         "src_streams": ["antenna-channelised-voltage"],
@@ -292,15 +332,16 @@ async def _correlator_config_and_description(
     }
 
     # The first three key/values are used for the traditional MeerKAT
-    # correlator mode string, the second three are used for a more complete
+    # correlator mode string, while the rest are used for a more complete
     # correlator description in the final report.
     # TODO: Update the key to be the actual parameter/fixture name
     correlator_mode_config: dict[str, str] = {
         "antennas": str(n_antennas),
         "channels": str(n_channels),
-        "bandwidth": f"{int(adc_sample_rate//1e6//2)}",
+        "bandwidth": f"{round(adc_sample_rate / 1e6 / 2 / narrowband_decimation)}",
         "band": f"{BANDS[band].long_name}",
         "integration_time": str(int_time),
+        "narrowband_decimation": str(narrowband_decimation),
         "dsims": str(n_dsims),
     }
     long_description = (

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -322,7 +322,7 @@ async def _correlator_config_and_description(
     }
     if narrowband_decimation > 1:
         config["outputs"]["antenna-channelised-voltage"]["narrowband"] = {
-            "decimation": narrowband_decimation,
+            "decimation_factor": narrowband_decimation,
             "centre_frequency": adc_sample_rate / 4,
         }
     config["outputs"]["baseline-correlation-products"] = {

--- a/qualification/pytest-jenkins.ini
+++ b/qualification/pytest-jenkins.ini
@@ -11,5 +11,7 @@ log_cli = true
 log_cli_level = info
 addopts = --report-log=report.json
 max_antennas = 10
-channels = 1024 4096 8192 32768
+wideband_channels = 1024 4096 8192 32768
+narrowband_channels = 32768
+narrowband_decimation = 8 16
 bands = u l s0


### PR DESCRIPTION
Add narrowband support to existing qualification tests (no narrowband-specific tests).

The config can control which narrowband modes to test via the inifile (`narrowband_decimation`); Jenkins is set up to test 1/8 and 1/16, with 32768 channels. The changes are mostly to account for either the bandwidth being different to the wideband bandwidth, the centre frequency not being the middle of the digitised band, or the centre frequency not being a multiple of the channel width.
<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report: [report-full.pdf](https://github.com/ska-sa/katgpucbf/files/11677244/report-full.pdf)
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-984.
