### PR TITLE
Include narrowband decimation factor in correlator descriptions

### DIFF
--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -353,6 +353,8 @@ async def _correlator_config_and_description(
         f"{n_antennas} antennas, {n_channels} channels, "
         f"{BANDS[band].long_name}-band, {int_time}s integrations, {n_dsims} dsims"
     )
+    if narrowband_decimation > 1:
+        long_description += f", 1/{narrowband_decimation} narrowband"
     logger.info("Config for correlator generation: %s.", long_description)
 
     return config, correlator_mode_config

--- a/qualification/report/generate_pdf.py
+++ b/qualification/report/generate_pdf.py
@@ -98,13 +98,16 @@ def make_correlator_mode_str(config: dict, *, expand: bool = False) -> str:
 
     if expand:
         # Long description required
-        config_mode = (
-            f'{config["antennas"]} antennas, '
-            f'{config["channels"]} channels, '
-            f'{config["band"]}-band, '
-            f'{config["integration_time"]}s integrations, '
-            f'{config["dsims"]} dsims.'
-        )
+        parts = [
+            f'{config["antennas"]} antennas',
+            f'{config["channels"]} channels',
+            f'{config["band"]}-band',
+            f'{config["integration_time"]}s integrations',
+            f'{config["dsims"]} dsims',
+        ]
+        if int(config["narrowband_decimation"]) > 1:
+            parts.append(f'1/{config["narrowband_decimation"]} narrowband')
+        config_mode = ", ".join(parts) + "."
     else:
         antpols = int(config["antennas"]) * 2
         chans = int(config["channels"]) // 1000


### PR DESCRIPTION
<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report: [report.pdf](https://github.com/ska-sa/katgpucbf/files/11686943/report.pdf)
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Relates to NGC-984.
