### PR TITLE
Always run wideband in qualification tests

### DIFF
--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -17,6 +17,7 @@
 """Fixtures and options for qualification testing of the correlator."""
 
 import asyncio
+import copy
 import inspect
 import json
 import logging
@@ -321,6 +322,17 @@ async def _correlator_config_and_description(
         "n_chans": n_channels,
     }
     if narrowband_decimation > 1:
+        # Create a wideband output so that testing is representative of normal
+        # usage, although it will not be consumed.
+        config["outputs"]["wideband-antenna-channelised-voltage"] = copy.deepcopy(
+            config["outputs"]["antenna-channelised-voltage"]
+        )
+        config["outputs"]["wideband-antenna-channelised-voltage"]["n_chans"] = 8192
+        config["outputs"]["wideband-baseline-correlation-products"] = {
+            "type": "gpucbf.baseline_correlation_products",
+            "src_streams": ["wideband-antenna-channelised-voltage"],
+            "int_time": int_time,
+        }
         # Pick a centre frequency that is not going to be a multiple of the
         # channel width (to test the most general case), but which is a
         # multiple of the dsim frequency resolution (to avoid rounding the


### PR DESCRIPTION
This makes it more representative of MeerKAT usage.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Relates to NGC-984.
