### PR TITLE
sim_correlator: Enable all gpucbf.baseline_correlation_products streams

### DIFF
--- a/scratch/sim_correlator.py
+++ b/scratch/sim_correlator.py
@@ -208,9 +208,11 @@ async def issue_config(host: str, port: int, name: str, config: dict) -> int:
         product_port = int(reply[2].decode())
         print(f"Product controller is at {product_host}:{product_port}")
 
-        print("Enabling baseline correlation products transmission...")
         product_client = await aiokatcp.Client.connect(product_host, product_port)
-        await product_client.request("capture-start", "baseline-correlation-products")
+        for output_name, output in config["outputs"].items():
+            if output["type"] == "gpucbf.baseline_correlation_products":
+                print(f"Enabling {output_name} transmission...")
+                await product_client.request("capture-start", output_name)
     except (aiokatcp.FailReply, ConnectionError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1


### PR DESCRIPTION
This ensures that narrowband X-engine output is enabled too. It also avoids a (non-fatal) error when using `--last-stage=f` in which case there are no X-engines.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
