### PR TITLE
Do not return gains when setting them

### DIFF
--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1585,16 +1585,16 @@ class Engine(aiokatcp.DeviceServer):
         if len(values) not in {0, 1, output.channels}:
             raise aiokatcp.FailReply(f"invalid number of values provided (must be 0, 1 or {output.channels})")
         if not values:
+            # Return the current values.
+            # If they're all the same, we can return just a single value.
             gains = pipeline.gains[:, input]
+            if np.all(gains == gains[0]):
+                gains = gains[:1]
+            return tuple(format_complex(gain) for gain in gains)
         else:
             gains = _parse_gains(*values, channels=output.channels, default_gain=None)
             pipeline.set_gains(input, gains)
-
-        # Return the current values.
-        # If they're all the same, we can return just a single value.
-        if np.all(gains == gains[0]):
-            gains = gains[:1]
-        return tuple(format_complex(gain) for gain in gains)
+            return ()
 
     async def request_gain_all(self, ctx, stream_name: str, *values: str) -> None:
         """Set the eq gains for all inputs.

--- a/test/fgpu/test_katcp_interface.py
+++ b/test/fgpu/test_katcp_interface.py
@@ -83,10 +83,7 @@ class TestKatcpRequests:
         """Test that the eq gain is correctly set with a scalar value."""
         # TODO[nb]: need to update for multiple pipelines
         reply, _informs = await engine_client.request("gain", "wideband", pol, "0.2-3j")
-        assert len(reply) == 1
-        value = aiokatcp.decode(str, reply[0])
-        assert_valid_complex(value)
-        assert complex(value) == pytest.approx(0.2 - 3j)
+        assert reply == []
 
         sensor_value = await get_sensor(engine_client, f"wideband.input{pol}.eq")
         assert_valid_complex_list(sensor_value)
@@ -104,11 +101,7 @@ class TestKatcpRequests:
         gains = np.arange(CHANNELS, dtype=np.float32) * (2 + 3j)
         reply, _informs = await engine_client.request("gain", "wideband", 0, *(str(gain) for gain in gains))
         np.testing.assert_equal(engine_server._pipelines[0].gains[:, 0], gains)
-        assert len(reply) == CHANNELS
-        for value in reply:
-            assert_valid_complex(aiokatcp.decode(str, value))
-        reply_array = np.array([complex(aiokatcp.decode(str, value)) for value in reply])
-        np.testing.assert_equal(reply_array, gains)
+        assert reply == []
 
         sensor_value = await get_sensor(engine_client, "wideband.input0.eq")
         assert_valid_complex_list(sensor_value)

--- a/test/fgpu/test_katcp_interface.py
+++ b/test/fgpu/test_katcp_interface.py
@@ -85,6 +85,13 @@ class TestKatcpRequests:
         reply, _informs = await engine_client.request("gain", "wideband", pol, "0.2-3j")
         assert reply == []
 
+        # Read back the value
+        reply, _informs = await engine_client.request("gain", "wideband", pol)
+        assert len(reply) == 1
+        value = aiokatcp.decode(str, reply[0])
+        assert_valid_complex(value)
+        assert complex(value) == pytest.approx(0.2 - 3j)
+
         sensor_value = await get_sensor(engine_client, f"wideband.input{pol}.eq")
         assert_valid_complex_list(sensor_value)
         assert safe_eval(sensor_value) == pytest.approx([0.2 - 3j])
@@ -102,6 +109,14 @@ class TestKatcpRequests:
         reply, _informs = await engine_client.request("gain", "wideband", 0, *(str(gain) for gain in gains))
         np.testing.assert_equal(engine_server._pipelines[0].gains[:, 0], gains)
         assert reply == []
+
+        # Read back the values
+        reply, _informs = await engine_client.request("gain", "wideband", 0)
+        assert len(reply) == CHANNELS
+        for value in reply:
+            assert_valid_complex(aiokatcp.decode(str, value))
+        reply_array = np.array([complex(aiokatcp.decode(str, value)) for value in reply])
+        np.testing.assert_equal(reply_array, gains)
 
         sensor_value = await get_sensor(engine_client, "wideband.input0.eq")
         assert_valid_complex_list(sensor_value)


### PR DESCRIPTION
That behaviour was due to implementing the word of the MK ICD, but the MK implementation doesn't return the gains when they are being set. Removing this should speed up gain setting.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date: ICD has a proposed change
- [x] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match: see https://github.com/ska-sa/katsdpcontroller/pull/697

Closes NGC-999.
