### PR TITLE
Reduce Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,17 +20,26 @@
 # nvidia and cuda runtime and development tools. pycuda needs nvcc, so
 # the development tools are necessary.
 
-FROM nvidia/cuda:12.0.1-devel-ubuntu22.04 as base
+FROM nvidia/cuda:12.0.1-runtime-ubuntu22.04 as base
 
 # This "base" layer is modified to better support running with Vulkan. That's
 # needed by both build-base (used by Jenkins to run unit tests) and the final
 # image. Additionally, for the Vulkan drivers to work one needs
-# libvulkan1, libegl1 and libxext6, but that's done in later layers together
-# with other packages.
+# libvulkan1, libegl1 and libxext6.
+#
+# Some development packages are also installed that are needed for pycuda.
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics
 COPY docker/10_nvidia.json /usr/share/glvnd/egl_vendor.d/10_nvidia.json
 # See also https://github.com/NVIDIA/nvidia-container-toolkit/issues/16
 COPY docker/nvidia_icd.json /usr/share/vulkan/icd.d/nvidia_icd.json
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cuda-nvcc-12-0 \
+    cuda-profiler-api-12-0 \
+    libcurand-dev-12-0 \
+    libvulkan1 \
+    libegl1 \
+    libxext6
 
 FROM base as build-base
 
@@ -56,7 +65,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     libpcap-dev \
     libcap-dev \
     libdivide-dev \
-    libvulkan-dev libxext6 libegl1 \
+    libvulkan-dev \
     wget
 
 # Create a virtual environment
@@ -167,8 +176,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
     ibverbs-providers \
     libpcap0.8 \
     libcap2 \
-    libcap2-bin \
-    libvulkan1 libxext6 libegl1
+    libcap2-bin
 
 COPY --from=build-py /venv /venv
 COPY --from=build-cxx /tmp/tools/fsim /usr/local/bin


### PR DESCRIPTION
This reduces the compressed size (i.e. what gets pulled over the network) from 3.3GB to 680MB, by switching to a more minimal base image and adding back necessary packages.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1005.
