### PR TITLE
Update ingest script

### DIFF
--- a/scratch/ingest.py
+++ b/scratch/ingest.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 ################################################################################
-# Copyright (c) 2021-2022, National Research Foundation (SARAO)
+# Copyright (c) 2021-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy


### PR DESCRIPTION
It was written quite a while ago and relied on some assumptions that are no longer true. First among these is outdated sensor names, but also some logic from the derived classes of Chunks in katgpucbf seems to have found its way here. Which isn't how the base spead2 Chunks worked.

I'm not quite sure how it got to that state, but it's fixed now. I was able to ingest and plot spectra.

Checklist:

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1007