### PR TITLE
Increase Jenkinsfile timeout for `pytest quick`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,7 +106,7 @@ pipeline {
          */
         stage('Run pytest (quick)') {
           when { not { anyOf { changeRequest target: 'main'; branch 'main' } } }
-          options { timeout(time: 10, unit: 'MINUTES') }
+          options { timeout(time: 15, unit: 'MINUTES') }
           steps {
             sh 'pytest -v -ra --junitxml=reports/result.xml --cov=katgpucbf --cov=test --cov-report=xml --cov-branch --suppress-tests-failed-exit-code'
           }


### PR DESCRIPTION
Probably due to the number of unit tests we've added lately, we started seeing timeouts with the `pytest quick` stage of the CI run.

In ideal settings, when the GPU isn't doing anything else, the tests take about 6 and a half minutes. This commit bumps up to 15, to accommodate two simultaneous builds that occupy the GPU, plus a little bit of headroom for in case.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1009.