### PR TITLE
Refactor xbgpu to support multiple output streams

### DIFF
--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -182,10 +182,14 @@ class XPipeline:
         # Once the destination function is finished with an item, it will pass
         # it back to the corresponding _(rx/tx)_free_item_queue to ensure that
         # all allocated buffers are in continuous circulation.
-        self._rx_item_queue: asyncio.Queue[RxQueueItem | None] = engine.monitor.make_queue("rx_item_queue", n_rx_items)
-        self._tx_item_queue: asyncio.Queue[TxQueueItem | None] = engine.monitor.make_queue("tx_item_queue", n_tx_items)
+        self._rx_item_queue: asyncio.Queue[RxQueueItem | None] = engine.monitor.make_queue(
+            f"{output.name}.rx_item_queue", n_rx_items
+        )
+        self._tx_item_queue: asyncio.Queue[TxQueueItem | None] = engine.monitor.make_queue(
+            f"{output.name}.tx_item_queue", n_tx_items
+        )
         self._tx_free_item_queue: asyncio.Queue[TxQueueItem] = engine.monitor.make_queue(
-            "tx_free_item_queue", n_tx_items
+            f"{output.name}.tx_free_item_queue", n_tx_items
         )
 
         allocator = accel.DeviceAllocator(context=context)
@@ -670,7 +674,6 @@ class XBEngine(DeviceServer):
 
         # Array configuration parameters
         self.adc_sample_rate_hz = adc_sample_rate_hz
-        self.heap_accumulation_threshold = outputs[0].heap_accumulation_threshold  # type: ignore
         self.time_converter = TimeConverter(sync_epoch, adc_sample_rate_hz)
         self.n_ants = n_ants
         self.n_channels_total = n_channels_total
@@ -725,8 +728,6 @@ class XBEngine(DeviceServer):
                 / adc_sample_rate_hz,
             ),
         )
-
-        self.timestamp_increment_per_accumulation = self.heap_accumulation_threshold * self.rx_heap_timestamp_step
 
         # Sets the number of batches of heaps to store per chunk
         self.heaps_per_fengine_per_chunk = heaps_per_fengine_per_chunk

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -926,13 +926,37 @@ class XBEngine(DeviceServer):
         for pipeline in self._pipelines:
             pipeline.shutdown()
 
-    # async def request_capture_start(self, ctx) -> None:
-    #     """Start transmission of this baseline-correlation-products stream."""
-    #     self.send_stream.tx_enabled = True
+    def _request_pipeline(self, stream_name: str) -> Pipeline:
+        """Get the pipeline related to the katcp request.
 
-    # async def request_capture_stop(self, ctx) -> None:
-    #     """Stop transmission of this baseline-correlation-products stream."""
-    #     self.send_stream.tx_enabled = False
+        Return the first Pipeline that matches by name.
+
+        Raises
+        ------
+        FailReply
+            If the `stream_name` is not a known output.
+        """
+        for pipeline in self._pipelines:
+            if stream_name == pipeline.output.name:
+                return pipeline
+        raise aiokatcp.FailReply(f"No output stream called {stream_name!r}")
+
+    async def request_capture_start(self, ctx, stream_name: str) -> None:
+        """Start transmission of a stream.
+
+        The request requires a stream name to enable
+        """
+        pipeline = self._request_pipeline(stream_name)
+        # TODO: Introduce `make_send_stream` helper function for each pipeline
+        #       to address this 'has no attribute' mypy error
+        pipeline.send_stream.tx_enabled = True  # type: ignore
+
+    async def request_capture_stop(self, ctx, stream_name: str) -> None:
+        """Stop transmission of a stream."""
+        pipeline = self._request_pipeline(stream_name)
+        # TODO: Introduce `make_send_stream` helper function for each pipeline
+        #       to address this 'has no attribute' mypy error
+        pipeline.send_stream.tx_enabled = False  # type: ignore
 
     async def start(self, descriptor_interval_s: float = SPEAD_DESCRIPTOR_INTERVAL_S) -> None:
         """

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -227,7 +227,7 @@ class XPipeline:
         sensors.add(
             aiokatcp.Sensor(
                 str,
-                "chan-range",
+                f"{self.output.name}.chan-range",
                 "The range of channels processed by this X-engine, inclusive",
                 default=f"({self.engine.channel_offset_value},"
                 f"{self.engine.channel_offset_value + self.engine.n_channels_per_stream - 1})",
@@ -238,7 +238,7 @@ class XPipeline:
         sensors.add(
             aiokatcp.Sensor(
                 bool,
-                "rx.synchronised",
+                f"{self.output.name}.rx.synchronised",
                 "For the latest accumulation, was data present from all F-Engines.",
                 default=False,
                 initial_status=aiokatcp.Sensor.Status.ERROR,
@@ -248,7 +248,7 @@ class XPipeline:
         sensors.add(
             aiokatcp.Sensor(
                 int,
-                "xeng-clip-cnt",
+                f"{self.output.name}.xeng-clip-cnt",
                 "Number of visibilities that saturated",
                 default=0,
                 initial_status=aiokatcp.Sensor.Status.NOMINAL,
@@ -274,7 +274,7 @@ class XPipeline:
             tx_item.present_ants.fill(False)
 
         # Update the sync sensor (converting np.bool_ to Python bool)
-        self.engine.sensors["rx.synchronised"].value = bool(tx_item.present_ants.all())
+        self.engine.sensors[f"{self.output.name}.rx.synchronised"].value = bool(tx_item.present_ants.all())
 
         self.correlation.reduce()
         tx_item.add_marker(self._proc_command_queue)
@@ -485,7 +485,7 @@ class XPipeline:
                 # heap.
                 end_adc_timestamp = item.timestamp + self.timestamp_increment_per_accumulation
                 end_timestamp = self.engine.time_converter.adc_to_unix(end_adc_timestamp)
-                clip_cnt_sensor = self.engine.sensors["xeng-clip-cnt"]
+                clip_cnt_sensor = self.engine.sensors[f"{self.output.name}.xeng-clip-cnt"]
                 clip_cnt_sensor.set_value(clip_cnt_sensor.value + int(heap.saturated), timestamp=end_timestamp)
             self.send_stream.send_heap(heap)
 

--- a/src/katgpucbf/xbgpu/xsend.py
+++ b/src/katgpucbf/xbgpu/xsend.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2022, National Research Foundation (SARAO)
+# Copyright (c) 2020-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/xbgpu/conftest.py
+++ b/test/xbgpu/conftest.py
@@ -16,8 +16,10 @@
 
 """Fixtures for use in xbgpu unit tests."""
 
+from ipaddress import IPv4Address, IPv4Network
+
 import pytest
-import spead2
+import spead2.send.asyncio
 
 
 @pytest.fixture
@@ -27,17 +29,35 @@ def n_src_streams() -> int:  # noqa: D401
 
 
 @pytest.fixture
-def mock_send_stream(mocker) -> spead2.InprocQueue:
+def mock_send_stream_network() -> IPv4Network:
+    """Network mask to filter the queues returned by :func:`mock_send_stream`.
+
+    Test classes can override this to select only a subset.
+    """
+    return IPv4Network("0.0.0.0/0")
+
+
+@pytest.fixture
+def mock_send_stream(mocker, mock_send_stream_network: IPv4Network) -> list[spead2.InprocQueue]:
     """Mock out creation of the send stream.
 
-    Calls to :class:`spead2.send.asyncio.UdpStream` are replaced by an
-    in-process stream. Returns an inproc queue to receive the output from that
-    stream.
+    Each time a :class:`spead2.send.asyncio.UdpStream` is created, it instead
+    creates an in-process stream and appends an equivalent inproc queue to
+    the list returned by the fixture.
+
+    The queues returned can be filtered by IP address by overriding the
+    :func:`mock_send_stream_network` fixture.
     """
-    queue = spead2.InprocQueue()
+    queues: list[spead2.InprocQueue] = []
 
     def constructor(thread_pool, endpoints, config, *args, **kwargs):
-        return spead2.send.asyncio.InprocStream(thread_pool, [queue], config)
+        stream_queues = [spead2.InprocQueue() for _ in endpoints]
+        queues.extend(
+            queue
+            for queue, endpoint in zip(stream_queues, endpoints)
+            if IPv4Address(endpoint[0]) in mock_send_stream_network
+        )
+        return spead2.send.asyncio.InprocStream(thread_pool, stream_queues, config)
 
     mocker.patch("spead2.send.asyncio.UdpStream", autospec=True, side_effect=constructor)
-    return queue
+    return queues

--- a/test/xbgpu/conftest.py
+++ b/test/xbgpu/conftest.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2022, National Research Foundation (SARAO)
+# Copyright (c) 2022-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2022, National Research Foundation (SARAO)
+# Copyright (c) 2020-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -538,7 +538,7 @@ class TestEngine:
         assert prom_diff.get_sample_diff("output_x_heaps_total") == n_total_accumulations
         # Could manually calculate it here, but it's available inside the send_stream
         assert prom_diff.get_sample_diff("output_x_bytes_total") == (
-            xbengine.send_stream.heap_payload_size_bytes * n_total_accumulations
+            xbengine._pipelines[0].send_stream.heap_payload_size_bytes * n_total_accumulations
         )
         assert prom_diff.get_sample_diff("output_x_visibilities_total") == (
             n_channels_per_stream * n_baselines * n_total_accumulations

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -387,9 +387,7 @@ class TestEngine:
         arglist = [
             "--katcp-host=127.0.0.1",
             "--katcp-port=0",
-            "--corrprod=name=bcp1,"
-            f"heap_accumulation_threshold={heap_accumulation_threshold},"
-            "dst=239.21.11.4:7149",
+            f"--corrprod=name=bcp1,heap_accumulation_threshold={heap_accumulation_threshold},dst=239.21.11.4:7149",
             f"--adc-sample-rate={ADC_SAMPLE_RATE}",
             f"--array-size={n_ants}",
             f"--channels={n_channels_total}",
@@ -610,6 +608,7 @@ class TestEngine:
                 n_channels_per_stream=n_channels_per_stream,
                 n_spectra_per_heap=n_spectra_per_heap,
             )
+
             await xbengine.stop()
 
         assert prom_diff.get_sample_diff("output_x_visibilities_total") == n_channels_per_stream * n_baselines

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -459,7 +459,7 @@ class TestEngine:
 
         range_start = n_channels_per_stream * CHANNEL_OFFSET
         range_end = range_start + n_channels_per_stream - 1
-        assert xbengine.sensors["chan-range"].value == f"({range_start},{range_end})"
+        assert xbengine.sensors["bcp1.chan-range"].value == f"({range_start},{range_end})"
 
         # Need a method of capturing synchronised aiokatcp.Sensor updates
         # as they happen in the XBEngine
@@ -469,7 +469,7 @@ class TestEngine:
             """Record sensor updates in a list for later comparison."""
             actual_sensor_updates.append((sensor_reading.value, sensor_reading.status))
 
-        xbengine.sensors["rx.synchronised"].attach(sensor_observer)
+        xbengine.sensors["bcp1.rx.synchronised"].attach(sensor_observer)
 
         def heap_factory(batch_index: int) -> list[spead2.send.HeapReference]:
             timestamp = batch_index * timestamp_step

--- a/test/xbgpu/test_parameters.py
+++ b/test/xbgpu/test_parameters.py
@@ -26,3 +26,5 @@ num_spectra_per_heap = [256]
 
 # Number of FFT channels out of the F-Engine
 num_channels = [1024, 8192, 32768]
+
+heap_accumulation_threshold = [4]

--- a/test/xbgpu/test_parameters.py
+++ b/test/xbgpu/test_parameters.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2021, National Research Foundation (SARAO)
+# Copyright (c) 2020-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/xbgpu/test_xsend.py
+++ b/test/xbgpu/test_xsend.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2022, National Research Foundation (SARAO)
+# Copyright (c) 2020-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/xbgpu/test_xsend.py
+++ b/test/xbgpu/test_xsend.py
@@ -143,6 +143,7 @@ class TestXSend:
 
         queue = spead2.InprocQueue()
         send_stream = XSend(
+            output_name="test",
             n_ants=num_ants,
             n_channels=num_channels,
             n_channels_per_stream=n_channels_per_stream,


### PR DESCRIPTION
Much like #537, the result of this refactoring (and added unit testing endeavours) means the plumbing is in and (mostly?) verified - at least for the case of running multiple XPipelines.

The main change is around moving the gpu-processing and sender loops into an base Pipeline class, to be implemented by subclasses. As mentioned above, I've created an XPipeline (as per NGC-996) which contains most of the existing xbgpu codebase - just a bit reorganised and tweaked where necessary.
* A single `XBEngine` manages multiple `Pipeline`s,
* Each Pipeline corresponds to an `Output`,
* Each Pipeline also has its own processing and download command queues.

Currently only the `XPipeline` is supported (its also the only one that exists).

As mentioned in the last commit before raising this PR, `test_engine` requires a bit of cleaning up, but the structure is there. I might take further inspiration from @bmerry and opt to update relevant documentation at the end of this adventure.

As always, please and thank you.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [ ] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [ ] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [ ] Ensure copyright notices are present and up-to-date
- [ ] (N/A) If qualification tests are changed: attach a sample qualification report
- [ ] If design has changed: ensure documentation is up to date
- [ ] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Contributes to NGC-929 and Closes NGC-996.
