### PR TITLE
Remove report email attachment

### DIFF
--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -126,7 +126,6 @@ pipeline {
   post {
     always {
       emailext attachLog: true,
-      attachmentsPattern: 'report.pdf',
       body: """<b>Overall Test Results:</b> ${env.JOB_NAME} - Build#${env.BUILD_NUMBER} - ${currentBuild.result}<br>
       <b>Node:</b> ${env.NODE_NAME}<br>
       <b>Duration:</b> ${currentBuild.durationString}<br>


### PR DESCRIPTION
This change will stop the qualification report from being sent with the Jenkins email notification.

The size of the qualification report has grown to 44MB and is unable to get sent as an email attachment to the gpucbf@sarao.ac.za group.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] (N/A) Ensure copyright notices are present and up-to-date
- [x] (N/A)If qualification tests are changed: attach a sample qualification report
- [x] (N/A)If design has changed: ensure documentation is up to date
- [x] (N/A)If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1015.
