### PR TITLE
channels-per-stream -> channels-per-substream

### DIFF
--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -178,7 +178,7 @@ class XBEngine(DeviceServer):
     n_channels_total
         The total number of frequency channels out of the F-Engine.
     n_channels_per_substream
-        The number of frequency channels contained per stream.
+        The number of frequency channels contained per substream.
     n_samples_between_spectra
         The number of samples between frequency spectra received.
     n_spectra_per_heap

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -177,7 +177,7 @@ class XBEngine(DeviceServer):
         The number of antennas to be correlated.
     n_channels_total
         The total number of frequency channels out of the F-Engine.
-    n_channels_per_stream
+    n_channels_per_substream
         The number of frequency channels contained per stream.
     n_samples_between_spectra
         The number of samples between frequency spectra received.
@@ -251,7 +251,7 @@ class XBEngine(DeviceServer):
         send_rate_factor: float,
         n_ants: int,
         n_channels_total: int,
-        n_channels_per_stream: int,
+        n_channels_per_substream: int,
         n_samples_between_spectra: int,
         n_spectra_per_heap: int,
         sample_bits: int,
@@ -287,7 +287,7 @@ class XBEngine(DeviceServer):
             raise ValueError("sample_bits must equal 8 - no other values supported at the moment.")
 
         for output in outputs:
-            if channel_offset_value % n_channels_per_stream != 0:
+            if channel_offset_value % n_channels_per_substream != 0:
                 raise ValueError(f"{output.name}: channel_offset must be an integer multiple of channels_per_substream")
 
         # Array configuration parameters
@@ -295,7 +295,7 @@ class XBEngine(DeviceServer):
         self.heap_accumulation_threshold = outputs[0].heap_accumulation_threshold
         self.time_converter = TimeConverter(sync_epoch, adc_sample_rate_hz)
         self.n_ants = n_ants
-        self.n_channels_per_stream = n_channels_per_stream
+        self.n_channels_per_substream = n_channels_per_substream
         self.sample_bits = sample_bits
         self.channel_offset_value = channel_offset_value
 
@@ -324,7 +324,7 @@ class XBEngine(DeviceServer):
         # spectrum due to symmetric properties of the Fourier Transform. While
         # we can workout the timestamp_step from other parameters that
         # configure the receiver, we pass it as a seperate argument to the
-        # reciever for cases where the n_channels_per_stream changes across
+        # reciever for cases where the n_channels_per_substream changes across
         # streams (likely for non-power-of-two array sizes).
         self.rx_heap_timestamp_step = n_samples_between_spectra * n_spectra_per_heap
 
@@ -356,7 +356,7 @@ class XBEngine(DeviceServer):
         free_ringbuffer = spead2.recv.ChunkRingbuffer(n_free_chunks)
         self._src_layout = recv.Layout(
             n_ants=n_ants,
-            n_channels_per_stream=n_channels_per_stream,
+            n_channels_per_substream=n_channels_per_substream,
             n_spectra_per_heap=n_spectra_per_heap,
             sample_bits=self.sample_bits,
             timestamp_step=self.rx_heap_timestamp_step,
@@ -382,7 +382,7 @@ class XBEngine(DeviceServer):
         correlation_template = CorrelationTemplate(
             self.context,
             n_ants=n_ants,
-            n_channels=n_channels_per_stream,
+            n_channels=n_channels_per_substream,
             n_spectra_per_heap=n_spectra_per_heap,
         )
         self.correlation = correlation_template.instantiate(
@@ -433,7 +433,7 @@ class XBEngine(DeviceServer):
         self.send_stream = XSend(
             n_ants=n_ants,
             n_channels=n_channels_total,
-            n_channels_per_stream=n_channels_per_stream,
+            n_channels_per_substream=n_channels_per_substream,
             dump_interval_s=self.dump_interval_s,
             send_rate_factor=send_rate_factor,
             channel_offset=self.channel_offset_value,  # Arbitrary for now - depends on F-Engine stream
@@ -461,7 +461,8 @@ class XBEngine(DeviceServer):
                 str,
                 "chan-range",
                 "The range of channels processed by this XB-engine, inclusive",
-                default=f"({self.channel_offset_value},{self.channel_offset_value + self.n_channels_per_stream - 1})",
+                default=f"({self.channel_offset_value},"
+                f"{self.channel_offset_value + self.n_channels_per_substream - 1})",
                 initial_status=aiokatcp.Sensor.Status.NOMINAL,
             )
         )

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -376,7 +376,7 @@ def make_engine(context: AbstractContext, args: argparse.Namespace) -> tuple[XBE
         send_rate_factor=args.send_rate_factor,
         n_ants=args.array_size,
         n_channels_total=args.channels,
-        n_channels_per_stream=args.channels_per_substream,
+        n_channels_per_substream=args.channels_per_substream,
         n_samples_between_spectra=args.samples_between_spectra,
         n_spectra_per_heap=args.spectra_per_heap,
         sample_bits=args.sample_bits,

--- a/src/katgpucbf/xbgpu/recv.py
+++ b/src/katgpucbf/xbgpu/recv.py
@@ -83,7 +83,7 @@ class Layout(BaseLayout):
     ----------
     n_ants
         The number of antennas that data will be received from
-    n_channels_per_stream
+    n_channels_per_substream
         The number of frequency channels contained in the stream.
     n_spectra_per_heap
         The number of time samples received per frequency channel.
@@ -103,7 +103,7 @@ class Layout(BaseLayout):
     """
 
     n_ants: int
-    n_channels_per_stream: int
+    n_channels_per_substream: int
     n_spectra_per_heap: int
     timestamp_step: int
     sample_bits: int
@@ -112,7 +112,9 @@ class Layout(BaseLayout):
     @property
     def heap_bytes(self):
         """Calculate number of bytes in a heap based on layout parameters."""
-        return self.n_channels_per_stream * self.n_spectra_per_heap * N_POLS * COMPLEX * self.sample_bits // BYTE_BITS
+        return (
+            self.n_channels_per_substream * self.n_spectra_per_heap * N_POLS * COMPLEX * self.sample_bits // BYTE_BITS
+        )
 
     @property
     def chunk_heaps(self) -> int:  # noqa: D401

--- a/src/katgpucbf/xbgpu/xsend.py
+++ b/src/katgpucbf/xbgpu/xsend.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2022, National Research Foundation (SARAO)
+# Copyright (c) 2020-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katgpucbf/xbgpu/xsend.py
+++ b/src/katgpucbf/xbgpu/xsend.py
@@ -154,7 +154,7 @@ class XSend:
         The total number of channels across all X-Engines. Must be a multiple
         of `n_channels_per_substream`.
     n_channels_per_substream
-        The number of frequency channels contained per stream.
+        The number of frequency channels contained per substream.
     dump_interval_s
         A new heap is transmitted every `dump_interval_s` seconds. Set to zero
         to send as fast as possible.

--- a/src/katgpucbf/xbgpu/xsend.py
+++ b/src/katgpucbf/xbgpu/xsend.py
@@ -57,9 +57,11 @@ class Heap:
     """
 
     def __init__(
-        self, context: AbstractContext, n_channels_per_stream: int, n_baselines: int, channel_offset: int
+        self, context: AbstractContext, n_channels_per_substream: int, n_baselines: int, channel_offset: int
     ) -> None:
-        self.buffer: Final = accel.HostArray((n_channels_per_stream, n_baselines, COMPLEX), SEND_DTYPE, context=context)
+        self.buffer: Final = accel.HostArray(
+            (n_channels_per_substream, n_baselines, COMPLEX), SEND_DTYPE, context=context
+        )
         self.saturated: Final = accel.HostArray((), np.uint32, context=context)
         self._timestamp: Final = np.zeros((), dtype=">u8")  # Big-endian to be used in-place by the heap
         self.future = asyncio.get_running_loop().create_future()
@@ -150,8 +152,8 @@ class XSend:
         The number of antennas that have been correlated.
     n_channels
         The total number of channels across all X-Engines. Must be a multiple
-        of `n_channels_per_stream`.
-    n_channels_per_stream
+        of `n_channels_per_substream`.
+    n_channels_per_substream
         The number of frequency channels contained per stream.
     dump_interval_s
         A new heap is transmitted every `dump_interval_s` seconds. Set to zero
@@ -168,7 +170,7 @@ class XSend:
     channel_offset
         Fixed value to be included in the SPEAD heap indicating the lowest
         channel value transmitted by this heap.  Must be a multiple of
-        `n_channels_per_stream`.
+        `n_channels_per_substream`.
     context
         All buffers to be transmitted will be created from this context.
     stream_factory
@@ -193,7 +195,7 @@ class XSend:
         self,
         n_ants: int,
         n_channels: int,
-        n_channels_per_stream: int,
+        n_channels_per_substream: int,
         dump_interval_s: float,
         send_rate_factor: float,
         channel_offset: int,
@@ -206,26 +208,26 @@ class XSend:
         if dump_interval_s < 0:
             raise ValueError("Dump interval must be 0 or greater.")
 
-        if n_channels % n_channels_per_stream != 0:
-            raise ValueError("n_channels must be an integer multiple of n_channels_per_stream")
-        if channel_offset % n_channels_per_stream != 0:
-            raise ValueError("channel_offset must be an integer multiple of n_channels_per_stream")
+        if n_channels % n_channels_per_substream != 0:
+            raise ValueError("n_channels must be an integer multiple of n_channels_per_substream")
+        if channel_offset % n_channels_per_substream != 0:
+            raise ValueError("channel_offset must be an integer multiple of n_channels_per_substream")
 
         self.tx_enabled = tx_enabled
 
         # Array Configuration Parameters
         self.n_ants: Final[int] = n_ants
-        self.n_channels_per_stream: Final[int] = n_channels_per_stream
+        self.n_channels_per_substream: Final[int] = n_channels_per_substream
         n_baselines: Final[int] = (self.n_ants + 1) * (self.n_ants) * 2
 
         # Multicast Stream Parameters
-        self.heap_payload_size_bytes = self.n_channels_per_stream * n_baselines * COMPLEX * SEND_DTYPE.itemsize
+        self.heap_payload_size_bytes = self.n_channels_per_substream * n_baselines * COMPLEX * SEND_DTYPE.itemsize
 
         self._heaps_queue: asyncio.Queue[Heap] = asyncio.Queue()
         buffers: list[accel.HostArray] = []
 
         for _ in range(n_send_heaps_in_flight):
-            heap = Heap(context, n_channels_per_stream, n_baselines, channel_offset)
+            heap = Heap(context, n_channels_per_substream, n_baselines, channel_offset)
             self._heaps_queue.put_nowait(heap)
             buffers.append(heap.buffer)
 
@@ -251,8 +253,8 @@ class XSend:
         # Set heap count sequence to allow a receiver to ingest multiple
         # X-engine outputs, if they should so choose.
         self.source_stream.set_cnt_sequence(
-            channel_offset // n_channels_per_stream,
-            n_channels // n_channels_per_stream,
+            channel_offset // n_channels_per_substream,
+            n_channels // n_channels_per_substream,
         )
 
         item_group = spead2.send.ItemGroup(flavour=FLAVOUR)

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2022, National Research Foundation (SARAO)
+# Copyright (c) 2020-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/xbgpu/test_recv.py
+++ b/test/xbgpu/test_recv.py
@@ -40,7 +40,7 @@ def layout() -> Layout:
     """Return an example layout."""
     return Layout(
         n_ants=4,
-        n_channels_per_stream=1024 // 4,
+        n_channels_per_substream=1024 // 4,
         n_spectra_per_heap=32,
         timestamp_step=2 * 1024 * 32,
         sample_bits=8,

--- a/test/xbgpu/test_xsend.py
+++ b/test/xbgpu/test_xsend.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2022, National Research Foundation (SARAO)
+# Copyright (c) 2020-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy


### PR DESCRIPTION
Standardise naming convention in xbgpu for usage of `channels_per_substream`, as per the CBF-CAM ICD.
* I will admit, some pre-commit-enforced formatting did get a bit weird-looking.

No need for both of you to review. Whoever gets to it first, please and thank you.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-975.
