### PR TITLE
ingest.py: report how many chunks missing

### DIFF
--- a/scratch/ingest.py
+++ b/scratch/ingest.py
@@ -323,7 +323,12 @@ async def async_main(args: argparse.Namespace) -> None:
                 plt.savefig(f"{chunk.chunk_id}.png")
                 logger.info("Wrote chunk %d", chunk.chunk_id)
         else:
-            logger.warning("Chunk %d missing heaps! (This is expected for the first few.)", chunk.chunk_id)
+            logger.warning(
+                "Chunk %d missing %d/%d heaps! (This is expected for the first few.)",
+                chunk.chunk_id,
+                HEAPS_PER_CHUNK - received_heaps,
+                HEAPS_PER_CHUNK,
+            )
         stream.add_free_chunk(chunk)
 
 


### PR DESCRIPTION
When there are 256 groups, it can take a while for the switches to get all the subscriptions, and seeing a count-down helps give confidence that progress is happening.
