### PR TITLE
Add netbase to the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -164,6 +164,7 @@ LABEL maintainer="MeerKAT CBF team <cbf@ska.ac.za>"
 # numactl allows CPU and memory affinity to be controlled.
 # libboost-program-options is for spead2's C++ command-line tools - not
 # strictly needed but useful for debugging.
+# netbase provides /etc/protocols, which libpcap depends on in some cases.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     python3 \
     python3-pip \
@@ -178,7 +179,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
     ibverbs-providers \
     libpcap0.8 \
     libcap2 \
-    libcap2-bin
+    libcap2-bin \
+    netbase
 
 COPY --from=build-py /venv /venv
 COPY --from=build-cxx /tmp/tools/fsim /usr/local/bin


### PR DESCRIPTION
This provides /etc/protocols. Without it, libpcap can give obscure errors (not knowing what 'udp' is). Not needed for production, but helpful when debugging.
