### PR TITLE
Bump dependencies to latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: no-commit-to-branch # without arguments, master/main will be protected.
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
@@ -23,12 +23,12 @@ repos:
       - id: isort
         name: isort
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
         additional_dependencies: [
-          'flake8-bugbear==22.6.22',
-          'pep8-naming==0.13.0'
+          'flake8-bugbear==23.7.10',
+          'pep8-naming==0.13.3'
         ]
   - repo: https://github.com/pycqa/pydocstyle
     rev: 6.3.0
@@ -36,7 +36,7 @@ repos:
       - id: pydocstyle
         exclude: 'setup.py|scratch/'  # Because complaining about docstrings here is annoying.
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.3.0'
+    rev: 'v1.4.1'
     hooks:
       - id: mypy
         # Passing filenames to mypy can do odd things. See
@@ -50,20 +50,20 @@ repos:
         types_or: [python, pyi]
         additional_dependencies: [
             'aiokatcp==1.7.0',
-            'dask==2023.5.0',
+            'dask==2023.7.1',
             'katsdpsigproc==1.7.0',
             'katsdptelstate==0.13',
-            'numpy==1.23.4',
+            'numpy==1.24.4',
             'pyparsing==3.0.9',
-            'pytest==7.3.1',
+            'pytest==7.4.0',
             'spead2==3.12.0',
             'types-decorator==5.1.1',
             'types-docutils==0.18.1',
-            'types-redis==4.5.5',
+            'types-redis==4.6.0',
             'types-six==1.16.0',
         ]
   - repo: https://github.com/jazzband/pip-tools
-    rev: 6.13.0
+    rev: 7.1.0
     hooks:
       - id: pip-compile
         name: pip-compile requirements.txt

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -4,12 +4,12 @@
 #
 #    pip-compile --extra=qualification --output-file=qualification/requirements.txt --strip-extras qualification/requirements.in setup.cfg
 #
-aioconsole==0.6.1
+aioconsole==0.6.2
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   aiomonitor
-aiohttp==3.8.4
+aiohttp==3.8.5
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
@@ -47,17 +47,17 @@ attrs==23.1.0
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   aiohttp
-certifi==2023.5.7
+certifi==2023.7.22
     # via
     #   -c qualification/../requirements-dev.txt
     #   requests
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   aiohttp
     #   requests
-click==8.1.3
+click==8.1.6
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
@@ -67,11 +67,11 @@ cloudpickle==2.2.1
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   dask
-contourpy==1.0.7
+contourpy==1.1.0
     # via matplotlib
 cycler==0.11.0
     # via matplotlib
-dask==2023.5.0
+dask==2023.7.1
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
@@ -88,19 +88,19 @@ docutils==0.18.1
     # via
     #   -c qualification/../requirements-dev.txt
     #   katgpucbf (setup.cfg)
-exceptiongroup==1.1.1
+exceptiongroup==1.1.2
     # via
     #   -c qualification/../requirements-dev.txt
     #   pytest
-fonttools==4.39.4
+fonttools==4.41.1
     # via matplotlib
-frozenlist==1.3.3
+frozenlist==1.4.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   aiohttp
     #   aiosignal
-fsspec==2023.5.0
+fsspec==2023.6.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
@@ -118,7 +118,7 @@ idna==3.4
     #   -c qualification/../requirements.txt
     #   requests
     #   yarl
-importlib-metadata==6.6.0
+importlib-metadata==6.8.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
@@ -159,12 +159,12 @@ mako==1.2.4
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   katsdpsigproc
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   mako
-matplotlib==3.7.1
+matplotlib==3.7.2
     # via
     #   katgpucbf (setup.cfg)
     #   prometheus-api-client
@@ -184,13 +184,13 @@ netifaces==0.11.0
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   katsdpservices
-numba==0.56.3
+numba==0.56.4
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   katgpucbf (setup.cfg)
     #   katsdpsigproc
-numpy==1.23.4
+numpy==1.23.5
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
@@ -215,7 +215,7 @@ packaging==23.1
     #   matplotlib
     #   pytest
     #   xarray
-pandas==2.0.1
+pandas==2.0.3
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
@@ -227,9 +227,9 @@ partd==1.4.0
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   dask
-pillow==9.5.0
+pillow==10.0.0
     # via matplotlib
-pluggy==1.0.0
+pluggy==1.2.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   pytest
@@ -240,7 +240,7 @@ prometheus-async==22.2.0
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   katgpucbf (setup.cfg)
-prometheus-client==0.16.0
+prometheus-client==0.17.1
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
@@ -259,7 +259,7 @@ pyparsing==3.0.9
     #   -c qualification/../requirements.txt
     #   katgpucbf (setup.cfg)
     #   matplotlib
-pytest==7.3.1
+pytest==7.4.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   katgpucbf (setup.cfg)
@@ -267,11 +267,11 @@ pytest==7.3.1
     #   pytest-check
     #   pytest-custom-exit-code
     #   pytest-reportlog
-pytest-asyncio==0.21.0
+pytest-asyncio==0.21.1
     # via
     #   -c qualification/../requirements-dev.txt
     #   katgpucbf (setup.cfg)
-pytest-check==2.1.4
+pytest-check==2.2.0
     # via katgpucbf (setup.cfg)
 pytest-custom-exit-code==0.3.0
     # via
@@ -292,24 +292,24 @@ pytz==2023.3
     #   -c qualification/../requirements.txt
     #   dateparser
     #   pandas
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   dask
-redis==4.5.5
+redis==4.6.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   katsdptelstate
-regex==2023.5.5
+regex==2023.6.3
     # via dateparser
 requests==2.31.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   httmock
     #   prometheus-api-client
-scipy==1.10.1
+scipy==1.11.1
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
@@ -341,7 +341,7 @@ toolz==0.12.0
     #   -c qualification/../requirements.txt
     #   dask
     #   partd
-typing-extensions==4.6.1
+typing-extensions==4.7.1
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
@@ -354,7 +354,7 @@ tzdata==2023.3
     #   pandas
 tzlocal==5.0.1
     # via dateparser
-urllib3==2.0.2
+urllib3==2.0.4
     # via
     #   -c qualification/../requirements-dev.txt
     #   requests
@@ -363,7 +363,7 @@ wrapt==1.15.0
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   prometheus-async
-xarray==2023.5.0
+xarray==2023.7.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
@@ -373,7 +373,7 @@ yarl==1.9.2
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   aiohttp
-zipp==3.15.0
+zipp==3.16.2
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile --extra=doc --extra=test --output-file=requirements-dev.txt --strip-extras requirements-dev.in setup.cfg
 #
-aioconsole==0.6.1
+aioconsole==0.6.2
     # via
     #   -c requirements.txt
     #   aiomonitor
-aiohttp==3.8.4
+aiohttp==3.8.5
     # via
     #   -c requirements.txt
     #   prometheus-async
@@ -52,16 +52,16 @@ backcall==0.2.0
     # via ipython
 build==0.10.0
     # via pip-tools
-certifi==2023.5.7
+certifi==2023.7.22
     # via requests
 cfgv==3.3.1
     # via pre-commit
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via
     #   -c requirements.txt
     #   aiohttp
     #   requests
-click==8.1.3
+click==8.1.6
     # via
     #   -c requirements.txt
     #   dask
@@ -70,9 +70,9 @@ cloudpickle==2.2.1
     # via
     #   -c requirements.txt
     #   dask
-coverage==7.2.6
+coverage==7.2.7
     # via pytest-cov
-dask==2023.5.0
+dask==2023.7.1
     # via
     #   -c requirements.txt
     #   katgpucbf (setup.cfg)
@@ -82,7 +82,7 @@ decorator==5.1.1
     #   aiokatcp
     #   ipython
     #   katsdpsigproc
-distlib==0.3.6
+distlib==0.3.7
     # via virtualenv
 docutils==0.18.1
     # via
@@ -90,20 +90,20 @@ docutils==0.18.1
     #   sphinx
     #   sphinx-rtd-theme
     #   sphinxcontrib-bibtex
-exceptiongroup==1.1.1
+exceptiongroup==1.1.2
     # via pytest
-execnet==1.9.0
+execnet==2.0.2
     # via pytest-xdist
 executing==1.2.0
     # via stack-data
-filelock==3.12.0
+filelock==3.12.2
     # via virtualenv
-frozenlist==1.3.3
+frozenlist==1.4.0
     # via
     #   -c requirements.txt
     #   aiohttp
     #   aiosignal
-fsspec==2023.5.0
+fsspec==2023.6.0
     # via
     #   -c requirements.txt
     #   dask
@@ -111,7 +111,7 @@ hiredis==2.2.3
     # via
     #   -c requirements.txt
     #   katsdptelstate
-identify==2.5.24
+identify==2.5.26
     # via pre-commit
 idna==3.4
     # via
@@ -120,15 +120,15 @@ idna==3.4
     #   yarl
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.6.0
+importlib-metadata==6.8.0
     # via
     #   -c requirements.txt
     #   dask
 iniconfig==2.0.0
     # via pytest
-ipython==8.13.2
+ipython==8.14.0
     # via -r requirements-dev.in
-jedi==0.18.2
+jedi==0.19.0
     # via ipython
 jinja2==3.1.2
     # via sphinx
@@ -159,7 +159,7 @@ mako==1.2.4
     #   -c requirements.txt
     #   katsdpsigproc
     #   pycuda
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -c requirements.txt
     #   jinja2
@@ -181,12 +181,12 @@ netifaces==0.11.0
     #   katsdpservices
 nodeenv==1.8.0
     # via pre-commit
-numba==0.56.3
+numba==0.56.4
     # via
     #   -c requirements.txt
     #   katgpucbf (setup.cfg)
     #   katsdpsigproc
-numpy==1.23.4
+numpy==1.23.5
     # via
     #   -c requirements.txt
     #   katgpucbf (setup.cfg)
@@ -205,7 +205,7 @@ packaging==23.1
     #   pytest
     #   sphinx
     #   xarray
-pandas==2.0.1
+pandas==2.0.3
     # via
     #   -c requirements.txt
     #   katsdpsigproc
@@ -220,27 +220,27 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip-tools==6.13.0
+pip-tools==7.1.0
     # via -r requirements-dev.in
-platformdirs==3.5.1
+platformdirs==3.10.0
     # via
     #   -c requirements.txt
     #   pytools
     #   virtualenv
-pluggy==1.0.0
+pluggy==1.2.0
     # via pytest
-pre-commit==3.3.2
+pre-commit==3.3.3
     # via -r requirements-dev.in
 prometheus-async==22.2.0
     # via
     #   -c requirements.txt
     #   katgpucbf (setup.cfg)
-prometheus-client==0.16.0
+prometheus-client==0.17.1
     # via
     #   -c requirements.txt
     #   katgpucbf (setup.cfg)
     #   prometheus-async
-prompt-toolkit==3.0.38
+prompt-toolkit==3.0.39
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
@@ -270,7 +270,7 @@ pyparsing==3.0.9
     #   katgpucbf (setup.cfg)
 pyproject-hooks==1.0.0
     # via build
-pytest==7.3.1
+pytest==7.4.0
     # via
     #   katgpucbf (setup.cfg)
     #   pytest-asyncio
@@ -278,13 +278,13 @@ pytest==7.3.1
     #   pytest-custom-exit-code
     #   pytest-mock
     #   pytest-xdist
-pytest-asyncio==0.21.0
+pytest-asyncio==0.21.1
     # via katgpucbf (setup.cfg)
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements-dev.in
 pytest-custom-exit-code==0.3.0
     # via katgpucbf (setup.cfg)
-pytest-mock==3.10.0
+pytest-mock==3.11.1
     # via katgpucbf (setup.cfg)
 pytest-xdist==3.3.1
     # via -r requirements-dev.in
@@ -292,7 +292,7 @@ python-dateutil==2.8.2
     # via
     #   -c requirements.txt
     #   pandas
-pytools==2022.1.14
+pytools==2023.1.1
     # via
     #   -c requirements.txt
     #   pycuda
@@ -300,19 +300,19 @@ pytz==2023.3
     # via
     #   -c requirements.txt
     #   pandas
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -c requirements.txt
     #   dask
     #   pre-commit
     #   pybtex
-redis==4.5.5
+redis==4.6.0
     # via
     #   -c requirements.txt
     #   katsdptelstate
 requests==2.31.0
     # via sphinx
-scipy==1.10.1
+scipy==1.11.1
     # via
     #   -c requirements.txt
     #   katgpucbf (setup.cfg)
@@ -341,7 +341,7 @@ sphinx==6.2.1
     #   sphinxcontrib-tikz
 sphinx-mathjax-offline==0.0.2
     # via katgpucbf (setup.cfg)
-sphinx-rtd-theme==1.2.1
+sphinx-rtd-theme==1.2.2
     # via katgpucbf (setup.cfg)
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -371,6 +371,7 @@ tomli==2.0.1
     # via
     #   build
     #   coverage
+    #   pip-tools
     #   pyproject-hooks
     #   pytest
 toolz==0.12.0
@@ -382,7 +383,7 @@ traitlets==5.9.0
     # via
     #   ipython
     #   matplotlib-inline
-typing-extensions==4.6.1
+typing-extensions==4.7.1
     # via
     #   -c requirements.txt
     #   aiokatcp
@@ -392,19 +393,19 @@ tzdata==2023.3
     # via
     #   -c requirements.txt
     #   pandas
-urllib3==2.0.2
+urllib3==2.0.4
     # via requests
-virtualenv==20.23.0
+virtualenv==20.24.2
     # via pre-commit
 wcwidth==0.2.6
     # via prompt-toolkit
-wheel==0.40.0
+wheel==0.41.0
     # via pip-tools
 wrapt==1.15.0
     # via
     #   -c requirements.txt
     #   prometheus-async
-xarray==2023.5.0
+xarray==2023.7.0
     # via
     #   -c requirements.txt
     #   katgpucbf (setup.cfg)
@@ -412,7 +413,7 @@ yarl==1.9.2
     # via
     #   -c requirements.txt
     #   aiohttp
-zipp==3.15.0
+zipp==3.16.2
     # via
     #   -c requirements.txt
     #   importlib-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --extra=gpu --output-file=requirements.txt --strip-extras requirements.in setup.cfg
 #
-aioconsole==0.6.1
+aioconsole==0.6.2
     # via aiomonitor
-aiohttp==3.8.4
+aiohttp==3.8.5
     # via prometheus-async
 aiokatcp==1.7.0
     # via katgpucbf (setup.cfg)
@@ -27,29 +27,29 @@ attrs==23.1.0
     # via aiohttp
 cffi==1.15.1
     # via vkgdr
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via aiohttp
-click==8.1.3
+click==8.1.6
     # via dask
 cloudpickle==2.2.1
     # via dask
-dask==2023.5.0
+dask==2023.7.1
     # via katgpucbf (setup.cfg)
 decorator==5.1.1
     # via
     #   aiokatcp
     #   katsdpsigproc
-frozenlist==1.3.3
+frozenlist==1.4.0
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2023.5.0
+fsspec==2023.6.0
     # via dask
 hiredis==2.2.3
     # via katsdptelstate
 idna==3.4
     # via yarl
-importlib-metadata==6.6.0
+importlib-metadata==6.8.0
     # via dask
 katsdpservices==1.2
     # via katgpucbf (setup.cfg)
@@ -65,7 +65,7 @@ mako==1.2.4
     # via
     #   katsdpsigproc
     #   pycuda
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via mako
 msgpack==1.0.5
     # via katsdptelstate
@@ -75,11 +75,11 @@ multidict==6.0.4
     #   yarl
 netifaces==0.11.0
     # via katsdpservices
-numba==0.56.3
+numba==0.56.4
     # via
     #   katgpucbf (setup.cfg)
     #   katsdpsigproc
-numpy==1.23.4
+numpy==1.23.5
     # via
     #   katgpucbf (setup.cfg)
     #   katsdpsigproc
@@ -93,17 +93,17 @@ packaging==23.1
     # via
     #   dask
     #   xarray
-pandas==2.0.1
+pandas==2.0.3
     # via
     #   katsdpsigproc
     #   xarray
 partd==1.4.0
     # via dask
-platformdirs==3.5.1
+platformdirs==3.10.0
     # via pytools
 prometheus-async==22.2.0
     # via katgpucbf (setup.cfg)
-prometheus-client==0.16.0
+prometheus-client==0.17.1
     # via
     #   katgpucbf (setup.cfg)
     #   prometheus-async
@@ -119,15 +119,15 @@ pyparsing==3.0.9
     # via katgpucbf (setup.cfg)
 python-dateutil==2.8.2
     # via pandas
-pytools==2022.1.14
+pytools==2023.1.1
     # via pycuda
 pytz==2023.3
     # via pandas
-pyyaml==6.0
+pyyaml==6.0.1
     # via dask
-redis==4.5.5
+redis==4.6.0
     # via katsdptelstate
-scipy==1.10.1
+scipy==1.11.1
     # via
     #   katgpucbf (setup.cfg)
     #   katsdpsigproc
@@ -143,7 +143,7 @@ toolz==0.12.0
     # via
     #   dask
     #   partd
-typing-extensions==4.6.1
+typing-extensions==4.7.1
     # via
     #   aiokatcp
     #   katsdpsigproc
@@ -154,11 +154,11 @@ vkgdr==0.1
     # via katgpucbf (setup.cfg)
 wrapt==1.15.0
     # via prometheus-async
-xarray==2023.5.0
+xarray==2023.7.0
     # via katgpucbf (setup.cfg)
 yarl==1.9.2
     # via aiohttp
-zipp==3.15.0
+zipp==3.16.2
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
A couple of packages are kept back:
- mypy is limited to 1.4.1, since that's the latest version at https://github.com/pre-commit/mirrors-mypy
- pyparsing is kept back at 3.0.9, because matplotlib has a dependency on pyparsing<3.1 which prevents upgrading to 3.1.1.
- numba is limited to 0.56.* because 0.57 is logging warnings about the TBB library on Ubuntu 22.04 being too old. Using 0.56 restricts numpy to 1.23.*.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] (N/A) Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
- [ ] Run a qualification test to ensure it still works
