### PR TITLE
Remove 'wheel' from build-system.requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
 	"setuptools>=45",
-	"wheel",
 	"setuptools_scm[toml]>=6.0",
 ]
 


### PR DESCRIPTION
Based on recommendation from
https://setuptools.pypa.io/en/latest/userguide/quickstart.html