### PR TITLE
More features for memcpy_loop

### DIFF
--- a/scratch/memcpy_loop.cpp
+++ b/scratch/memcpy_loop.cpp
@@ -169,11 +169,22 @@ static void *memcpy_stream_avx(void * __restrict__ dest, const void * __restrict
     std::size_t offset = 0;
     for (offset = 0; offset + 256 <= n; offset += 256)
     {
-        __m256i values[8];
-        for (int i = 0; i < 8; i++)
-            values[i] = _mm256_loadu_si256((__m256i const *) (src_c + offset + 32 * i));
-        for (int i = 0; i < 8; i++)
-            _mm256_stream_si256((__m256i *) (dest_c + offset + 32 * i), values[i]);
+        __m256i value0 = _mm256_loadu_si256((__m256i const *) (src_c + offset + 32 * 0));
+        __m256i value1 = _mm256_loadu_si256((__m256i const *) (src_c + offset + 32 * 1));
+        __m256i value2 = _mm256_loadu_si256((__m256i const *) (src_c + offset + 32 * 2));
+        __m256i value3 = _mm256_loadu_si256((__m256i const *) (src_c + offset + 32 * 3));
+        __m256i value4 = _mm256_loadu_si256((__m256i const *) (src_c + offset + 32 * 4));
+        __m256i value5 = _mm256_loadu_si256((__m256i const *) (src_c + offset + 32 * 5));
+        __m256i value6 = _mm256_loadu_si256((__m256i const *) (src_c + offset + 32 * 6));
+        __m256i value7 = _mm256_loadu_si256((__m256i const *) (src_c + offset + 32 * 7));
+        _mm256_stream_si256((__m256i *) (dest_c + offset + 32 * 0), value0);
+        _mm256_stream_si256((__m256i *) (dest_c + offset + 32 * 1), value1);
+        _mm256_stream_si256((__m256i *) (dest_c + offset + 32 * 2), value2);
+        _mm256_stream_si256((__m256i *) (dest_c + offset + 32 * 3), value3);
+        _mm256_stream_si256((__m256i *) (dest_c + offset + 32 * 4), value4);
+        _mm256_stream_si256((__m256i *) (dest_c + offset + 32 * 5), value5);
+        _mm256_stream_si256((__m256i *) (dest_c + offset + 32 * 6), value6);
+        _mm256_stream_si256((__m256i *) (dest_c + offset + 32 * 7), value7);
     }
     for (; offset + 64 <= n; offset += 64)
     {

--- a/scratch/memcpy_loop.cpp
+++ b/scratch/memcpy_loop.cpp
@@ -1,3 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2019-2020, 2022-2023, National Research Foundation (SARAO)
+ *
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
 #include <iostream>
 #include <vector>
 #include <cassert>


### PR DESCRIPTION
- Add copyright block
- Add memcpy_stream_sse2 (based on spead2's memcpy_nontemporal)
- Add memcpy_stream_avx (similar to above, but using AVX)
- Ensure that malloc-based allocator gives cache line alignment (for more comparable results)
- Add command-line options to adjust alignment

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Relates to NGC-1030.
