### PR TITLE
Update xbgpu/test_engine n_samples_between_spectra

### DIFF
--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -420,8 +420,10 @@ class TestEngine:
 
     @pytest.fixture
     def n_samples_between_spectra(self, n_channels_total: int) -> int:  # noqa: D102
-        # Will need to be updated for narrowband
-        return 2 * n_channels_total
+        # NOTE: Multiply by 8 to account for a decimation factor in the
+        # Narrowband case. It is also included to ensure we don't rely on the
+        # assumption that `n_samples_between_spectra == 2 * n_channels_total`.
+        return 2 * n_channels_total * 8
 
     @pytest.fixture
     def engine_arglist(


### PR DESCRIPTION
To remove the (implied) assumption that we rely on it being 2 * n_channels_total.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1014.
