### PR TITLE
Clamp dig-rms-dbfs sensor to DBL_MIN in case of zero power

### DIFF
--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -976,7 +976,9 @@ class Pipeline:
                     # Normalise relative to full scale. The factor of 2 is because we
                     # want 1.0 to correspond to a sine wave rather than a square wave.
                     avg_power /= ((1 << (self.engine.src_layout.sample_bits - 1)) - 1) ** 2 / 2
-                    avg_power_db = 10 * math.log10(avg_power) if avg_power else -math.inf
+                    # If for some reason there's zero power, avoid reporting
+                    # -inf dB by assigning the most negative representable value
+                    avg_power_db = 10 * math.log10(avg_power) if avg_power else np.finfo(np.float64).min
                     self.engine.sensors[f"input{pol}.dig-rms-dbfs"].set_value(
                         avg_power_db, timestamp=self.engine.time_converter.adc_to_unix(out_item.end_timestamp)
                     )

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -958,7 +958,9 @@ class TestEngine:
 
     # It's easier to use a constant voltage. Also need to check the case were
     # the input power is zero.
-    @pytest.mark.parametrize("inout", [(0, np.finfo(np.float64).min), (64, -15.034518566376697)])
+    @pytest.mark.parametrize(
+        "input_voltage,output_power_dbfs", [(0, np.finfo(np.float64).min), (64, pytest.approx(-15.0345186))]
+    )
     async def test_dig_rms_dbfs_sensors(
         self,
         mock_recv_stream: spead2.InprocQueue,
@@ -966,13 +968,13 @@ class TestEngine:
         engine_server: Engine,
         engine_client: aiokatcp.Client,
         output: Output,
-        inout: tuple[int, float],
+        input_voltage: int,
+        output_power_dbfs: float,
     ) -> None:
         """Test that the ``dig-rms-dbfs`` sensors are set correctly."""
         sensors = [engine_server.sensors[f"input{pol}.dig-rms-dbfs"] for pol in range(N_POLS)]
         sensor_update_dict = self._watch_sensors(sensors)
         n_samples = 10 * CHUNK_SAMPLES
-        input_voltage, output_power_dbfs = inout
         dig_data = np.full((2, n_samples), input_voltage, np.int16)
 
         await self._send_data(

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -973,7 +973,7 @@ class TestEngine:
         sensor_update_dict = self._watch_sensors(sensors)
         n_samples = 10 * CHUNK_SAMPLES
         input_voltage, output_power_dbfs = inout
-        dig_data = np.ones((2, n_samples), np.int16) * input_voltage
+        dig_data = np.full((2, n_samples), input_voltage, np.int16)
 
         await self._send_data(
             mock_recv_stream,


### PR DESCRIPTION
Or rather strictly speaking it's to np.finfo(np.float64).min, which I think may be the same as DBL_MIN under the hood, though it's probably implementation dependent.

The context to this is that previously in the case of zero input power we'd assign a -inf value. This is OK for the IEEE double specification, but the KATCP spec only allows decimal values for float sensors, so we weren't compliant in this sense. Issues arose with CAM's NATS system which didn't like the -inf values.

I couldn't find any suitable unit test where these sensors were exercised, so I added a simple one.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1059

