### PR TITLE
Cleanup on fgpu's mock_recv_streams

### DIFF
--- a/test/fgpu/conftest.py
+++ b/test/fgpu/conftest.py
@@ -46,7 +46,7 @@ def mock_recv_stream(mocker) -> spead2.InprocQueue:
     Returns
     -------
     queue
-        An in-process queue to use for sending data.``.
+        An in-process queue to use for sending data.
     """
     queue = spead2.InprocQueue()
     have_reader = False
@@ -64,6 +64,7 @@ def mock_recv_stream(mocker) -> spead2.InprocQueue:
         nonlocal have_reader
         assert not have_reader, "A reader has already been added for this queue"
         stream.add_inproc_reader(queue)
+        have_reader = True
 
     mocker.patch("katgpucbf.recv.add_reader", autospec=True, side_effect=add_reader)
     return queue


### PR DESCRIPTION
- Remove some spurious backticks from docstring.
- Actually set the have_reader sanity check variable.

Relates to NGC-1048.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
