### PR TITLE
Drastically reduce gc pauses

### DIFF
--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -23,6 +23,7 @@ actual running of the processing.
 
 import argparse
 import asyncio
+import gc
 import logging
 import math
 from collections.abc import Callable, Sequence
@@ -313,9 +314,9 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--src-buffer",
         type=int,
-        default=192 * 1024 * 1024,
+        default=64 * 1024 * 1024,
         metavar="BYTES",
-        help="Size of network receive buffer [192MiB]",
+        help="Size of network receive buffer [64MiB]",
     )
     parser.add_argument(
         "--dst-interface", type=comma_split(get_interface_address), required=True, help="Name of output network device"
@@ -520,7 +521,12 @@ async def async_main() -> None:
         prometheus_server = await prometheus_async.aio.web.start_http_server(port=args.prometheus_port)
     with monitor, start_aiomonitor(asyncio.get_running_loop(), args, locals()):
         await engine.start()
+        # Avoid garbage collections needing to iterate over all the objects
+        # allocated so far. That makes garbage collection much faster, and we
+        # don't expect to free up much of what's currently allocated.
+        gc.freeze()
         await engine.join()
+        gc.unfreeze()  # Allow objects to be tidied away during shutdown
         if prometheus_server:
             await prometheus_server.close()
 


### PR DESCRIPTION
Use gc.freeze to move the objects allocated at startup to a permanent generation that is not subject to the GC. This makes GC traversal much faster, and eliminates some 57ms-long GC pauses.

The fgpu src buffer is reduced to 64MiB (I've tested it as low as 16MiB, although not for very long).

xbgpu gets the same gc.freeze treatment. I haven't touched the buffer size since I haven't done any benchmarking on it.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
- [x] Run a largish correlator in the lab

Closes NGC-1060.
