### PR TITLE
Bump spead2 version in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
             'numpy==1.24.4',
             'pyparsing==3.0.9',
             'pytest==7.4.0',
-            'spead2==3.12.0',
+            'spead2==4.0.1',
             'types-decorator==5.1.1',
             'types-docutils==0.18.1',
             'types-redis==4.6.0',


### PR DESCRIPTION
I forgot to do it in #624. My bad.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [X] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1075 (again).
