### PR TITLE
Compare aiokatcp.Reading instances directly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         types: []
         types_or: [python, pyi]
         additional_dependencies: [
-            'aiokatcp==1.7.0',
+            'aiokatcp==1.8.0',
             'asyncssh==2.13.2',
             'dask==2023.7.1',
             'katsdpsigproc==1.8.0',

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -14,7 +14,7 @@ aiohttp==3.8.5
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   prometheus-async
-aiokatcp==1.7.0
+aiokatcp==1.8.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ aiohttp==3.8.5
     # via
     #   -c requirements.txt
     #   prometheus-async
-aiokatcp==1.7.0
+aiokatcp==1.8.0
     # via
     #   -c requirements.txt
     #   katgpucbf (setup.cfg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ aioconsole==0.6.2
     # via aiomonitor
 aiohttp==3.8.5
     # via prometheus-async
-aiokatcp==1.7.0
+aiokatcp==1.8.0
     # via katgpucbf (setup.cfg)
 aiomonitor==0.4.5
     # via katsdpservices

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ package_dir =
     = src
 packages = find:
 install_requires =
-    aiokatcp>=1.6.0
+    aiokatcp>=1.8.0
     dask
     katsdpservices[aiomonitor]
     katsdpsigproc>=1.8.0


### PR DESCRIPTION
Instead of writing
```
assert sensor.timestamp == A
assert sensor.status == B
assert sensor.value == C
```

write
```
assert sensor.reading == Reading(A, B, C)
```

which is more compact, and when one of the fields is in error, you get
to see the entire Reading in the pytest dump.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1063.
