### PR TITLE
Add --dst-buffer option to fgpu

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
             'numpy==1.24.4',
             'pyparsing==3.0.9',
             'pytest==7.4.0',
-            'spead2==4.0.1',
+            'spead2==4.0.2',
             'types-decorator==5.1.1',
             'types-docutils==0.18.1',
             'types-redis==4.6.0',

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -321,7 +321,7 @@ six==1.16.0
     #   -c qualification/../requirements.txt
     #   katsdptelstate
     #   python-dateutil
-spead2==4.0.1
+spead2==4.0.2
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -327,7 +327,7 @@ six==1.16.0
     #   python-dateutil
 snowballstemmer==2.2.0
     # via sphinx
-spead2==4.0.1
+spead2==4.0.2
     # via
     #   -c requirements.txt
     #   katgpucbf (setup.cfg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -135,7 +135,7 @@ six==1.16.0
     # via
     #   katsdptelstate
     #   python-dateutil
-spead2==4.0.1
+spead2==4.0.2
     # via katgpucbf (setup.cfg)
 terminaltables==3.1.10
     # via aiomonitor

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1093,7 +1093,7 @@ class Engine(aiokatcp.DeviceServer):
     src_packet_samples
         The number of samples per digitiser packet.
     src_buffer
-        The size of the network receive buffer (per polarisation).
+        The size of the network receive buffer.
     dst_interface
         IP addresses of the network devices to use for output.
     dst_ttl
@@ -1108,6 +1108,8 @@ class Engine(aiokatcp.DeviceServer):
     dst_comp_vector
         Completion vector for transmission, or -1 for polling.
         See :class:`spead2.send.UdpIbvConfig` for further information.
+    dst_buffer
+        Size of the network send buffer.
     outputs
         Output streams to generate. At present this must be a single
         WidebandOutput.
@@ -1174,6 +1176,7 @@ class Engine(aiokatcp.DeviceServer):
         dst_packet_payload: int,
         dst_affinity: int,
         dst_comp_vector: int,
+        dst_buffer: int,
         outputs: list[Output],
         adc_sample_rate: float,
         send_rate_factor: float,
@@ -1209,6 +1212,7 @@ class Engine(aiokatcp.DeviceServer):
         self._dst_ibv = dst_ibv
         self._dst_packet_payload = dst_packet_payload
         self._dst_comp_vector = dst_comp_vector
+        self._dst_buffer = dst_buffer
         self._send_rate_factor = send_rate_factor
         self.adc_sample_rate = adc_sample_rate
         self.feng_id = feng_id
@@ -1361,6 +1365,7 @@ class Engine(aiokatcp.DeviceServer):
             ibv=self._dst_ibv,
             packet_payload=self._dst_packet_payload,
             comp_vector=self._dst_comp_vector,
+            buffer=self._dst_buffer,
             adc_sample_rate=self.adc_sample_rate,
             send_rate_factor=self._send_rate_factor * output.send_rate_factor,
             feng_id=self.feng_id,

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -341,6 +341,13 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         help="Completion vector for transmission, or -1 for polling [0]",
     )
     parser.add_argument(
+        "--dst-buffer",
+        type=int,
+        default=512 * 1024,
+        metavar="BYTES",
+        help="Size of network send buffer [512KiB]",
+    )
+    parser.add_argument(
         "--adc-sample-rate",
         type=float,
         required=True,
@@ -488,6 +495,7 @@ def make_engine(ctx: AbstractContext, args: argparse.Namespace) -> tuple[Engine,
         dst_packet_payload=args.dst_packet_payload,
         dst_affinity=args.dst_affinity,
         dst_comp_vector=args.dst_comp_vector,
+        dst_buffer=args.dst_buffer,
         outputs=args.outputs,
         adc_sample_rate=args.adc_sample_rate,
         send_rate_factor=args.send_rate_factor,

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -343,9 +343,9 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--dst-buffer",
         type=int,
-        default=512 * 1024,
+        default=1024 * 1024,
         metavar="BYTES",
-        help="Size of network send buffer [512KiB]",
+        help="Size of network send buffer [1MiB]",
     )
     parser.add_argument(
         "--adc-sample-rate",

--- a/src/katgpucbf/fgpu/send.py
+++ b/src/katgpucbf/fgpu/send.py
@@ -259,10 +259,8 @@ def make_streams(
         ]
         streams = [spead2.send.asyncio.UdpIbvStream(thread_pool, config, ibv_config) for ibv_config in ibv_configs]
     else:
-        # TODO: the type: ignore is just until
-        # https://github.com/ska-sa/spead2/pull/282 is released.
         streams = [
-            spead2.send.asyncio.UdpStream(  # type: ignore
+            spead2.send.asyncio.UdpStream(
                 thread_pool,
                 [(ep.host, ep.port) for ep in endpoints],
                 config,

--- a/src/katgpucbf/fgpu/send.py
+++ b/src/katgpucbf/fgpu/send.py
@@ -220,6 +220,7 @@ def make_streams(
     ibv: bool,
     packet_payload: int,
     comp_vector: int,
+    buffer: int,
     adc_sample_rate: float,
     send_rate_factor: float,
     feng_id: int,
@@ -252,14 +253,22 @@ def make_streams(
                 ttl=ttl,
                 comp_vector=comp_vector,
                 memory_regions=memory_regions,
+                buffer_size=buffer // len(interfaces),
             )
             for interface in interfaces
         ]
         streams = [spead2.send.asyncio.UdpIbvStream(thread_pool, config, ibv_config) for ibv_config in ibv_configs]
     else:
+        # TODO: the type: ignore is just until
+        # https://github.com/ska-sa/spead2/pull/282 is released.
         streams = [
-            spead2.send.asyncio.UdpStream(
-                thread_pool, [(ep.host, ep.port) for ep in endpoints], config, ttl=ttl, interface_address=interface
+            spead2.send.asyncio.UdpStream(  # type: ignore
+                thread_pool,
+                [(ep.host, ep.port) for ep in endpoints],
+                config,
+                ttl=ttl,
+                interface_address=interface,
+                buffer_size=buffer // len(interfaces),
             )
             for interface in interfaces
         ]


### PR DESCRIPTION
This complements the --src-buffer option. The default value matches the previous default, which came from spead2, but it is now more explicitly under the control of katgpucbf and the user.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
- [x] Update spead2 and remove the TODO, once https://github.com/ska-sa/spead2/pull/282 is released

