### PR TITLE
Start multiple receive streams at similar time

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
             'numpy==1.24.4',
             'pyparsing==3.0.9',
             'pytest==7.4.0',
-            'spead2==4.0.2',
+            'spead2==4.1.0',
             'types-decorator==5.1.1',
             'types-docutils==0.18.1',
             'types-redis==4.6.0',

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -321,7 +321,7 @@ six==1.16.0
     #   -c qualification/../requirements.txt
     #   katsdptelstate
     #   python-dateutil
-spead2==4.0.2
+spead2==4.1.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -327,7 +327,7 @@ six==1.16.0
     #   python-dateutil
 snowballstemmer==2.2.0
     # via sphinx
-spead2==4.0.2
+spead2==4.1.0
     # via
     #   -c requirements.txt
     #   katgpucbf (setup.cfg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -135,7 +135,7 @@ six==1.16.0
     # via
     #   katsdptelstate
     #   python-dateutil
-spead2==4.0.2
+spead2==4.1.0
     # via katgpucbf (setup.cfg)
 terminaltables==3.1.10
     # via aiomonitor

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     prometheus-client>=0.4  # First version to auto-append _total to counter names
     pyparsing>=3.0.0
     scipy
-    spead2>=3.12.0
+    spead2>=4.1.0
     xarray
 python_requires = >=3.10
 

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1478,6 +1478,8 @@ class Engine(aiokatcp.DeviceServer):
         """
         prev_item = None
         assert isinstance(group.data_ringbuffer, ChunkRingbuffer)
+        for stream in group:
+            stream.start()
         async for chunk in recv.iter_chunks(group.data_ringbuffer, layout, self.sensors, self.time_converter):
             assert isinstance(chunk, base_recv.Chunk)
             with self.monitor.with_state("run_receive", "wait in_free_queue"):

--- a/src/katgpucbf/fgpu/recv.py
+++ b/src/katgpucbf/fgpu/recv.py
@@ -213,6 +213,7 @@ def make_stream_group(
         max_heaps=1,  # Digitiser heaps are single-packet, so no need for more
         stream_stats=["katgpucbf.metadata_heaps", "katgpucbf.bad_timestamp_heaps"],
         user_data=user_data,
+        explicit_start=True,
     )
     for stream in group:
         stats_collector.add_stream(stream)

--- a/test/fgpu/test_recv.py
+++ b/test/fgpu/test_recv.py
@@ -105,6 +105,7 @@ def stream_group(
         chunk = Chunk(data=data, present=present, extra=extra, sink=stream_group)
         chunk.recycle()
     stream_group[0].add_inproc_reader(queue)
+    stream_group[0].start()
 
     yield stream_group
 


### PR DESCRIPTION
Use the new `explicit_start` feature in spead2 4.1.0 to ensure that when multiple receive streams are used (in a stream group), they are all started by more-or-less the same time. This avoids filling up buffers with incoming data while some of the streams are still being set up and the Python thread is not yet ready to receive the data.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Relates to NGC-1113.
