### PR TITLE
Bump urllib3 and pillow to latest versions

### DIFF
--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -227,7 +227,7 @@ partd==1.4.0
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   dask
-pillow==10.0.0
+pillow==10.0.1
     # via matplotlib
 pluggy==1.2.0
     # via
@@ -354,7 +354,7 @@ tzdata==2023.3
     #   pandas
 tzlocal==5.0.1
     # via dateparser
-urllib3==2.0.4
+urllib3==2.0.6
     # via
     #   -c qualification/../requirements-dev.txt
     #   requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -393,7 +393,7 @@ tzdata==2023.3
     # via
     #   -c requirements.txt
     #   pandas
-urllib3==2.0.4
+urllib3==2.0.6
     # via requests
 virtualenv==20.24.2
     # via pre-commit


### PR DESCRIPTION
There are security advisories on both, although in practice I don't think either of them have any effect on katgpucbf.
