### PR TITLE
Replace np.product with np.prod

### DIFF
--- a/src/katgpucbf/dsim/shared_array.py
+++ b/src/katgpucbf/dsim/shared_array.py
@@ -42,7 +42,7 @@ class SharedArray:
 
     @staticmethod
     def _byte_size(shape: tuple[int, ...], dtype: DTypeLike) -> int:
-        return int(np.product(shape)) * np.dtype(dtype).itemsize
+        return int(np.prod(shape)) * np.dtype(dtype).itemsize
 
     def __init__(self, fd: int, shape: tuple[int, ...], dtype: DTypeLike) -> None:
         size = self._byte_size(shape, dtype)

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -282,7 +282,7 @@ class MappedArray:
         """
         assert isinstance(slot, accel.IOSlot)
         padded_shape = slot.required_padded_shape()
-        n_bytes = int(np.product(padded_shape)) * slot.dtype.itemsize
+        n_bytes = int(np.prod(padded_shape)) * slot.dtype.itemsize
         with context:
             handle = vkgdr.pycuda.Memory(vkgdr_handle, n_bytes)
         # Slice out the shape from the padded shape

--- a/src/katgpucbf/fgpu/postproc.py
+++ b/src/katgpucbf/fgpu/postproc.py
@@ -202,7 +202,7 @@ class Postproc(accel.Operation):
                 self.buffer("gains").buffer,
                 np.int32(out.padded_shape[1] * out.padded_shape[2]),  # out_stride_z
                 np.int32(out.padded_shape[2]),  # out_stride
-                np.int32(np.product(in_.padded_shape[1:])),  # in_stride
+                np.int32(np.prod(in_.padded_shape[1:])),  # in_stride
                 np.int32(self.spectra_per_heap),  # spectra_per_heap
             ],
             global_size=(self.template.block * groups_x, self.template.block * groups_y, groups_z),

--- a/src/katgpucbf/xbgpu/correlation.py
+++ b/src/katgpucbf/xbgpu/correlation.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2022, National Research Foundation (SARAO)
+# Copyright (c) 2020-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katgpucbf/xbgpu/correlation.py
+++ b/src/katgpucbf/xbgpu/correlation.py
@@ -242,7 +242,7 @@ class Correlation(accel.Operation):
                 mid_visibilities_buffer.buffer,
                 np.uint32(self.n_batches),
             ],
-            global_size=(accel.roundup(int(np.product(out_visibilities_buffer.shape)), wgs), 1, 1),
+            global_size=(accel.roundup(int(np.prod(out_visibilities_buffer.shape)), wgs), 1, 1),
             local_size=(wgs, 1, 1),
         )
 

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -564,7 +564,7 @@ class TestEngine:
             #   we test that output dumps are aligned correctly, despite
             #   the first data processed not being on an accumulation
             #   boundary.
-            n_heaps = np.product(heap_accumulation_thresholds)
+            n_heaps = np.prod(heap_accumulation_thresholds)
             batch_start_index = 12 * n_heaps  # Somewhere arbitrary that isn't zero
             batch_end_index = batch_start_index + n_heaps
             # Add an extra chunk before the first full accumulation


### PR DESCRIPTION
Running mypy in an environment that happened to have a newer numpy told me that np.product is deprecated and we should be using np.prod instead.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
