### PR TITLE
fgpu full support for 4-bit output types

### DIFF
--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -548,7 +548,7 @@ class Pipeline:
         self.descriptor_heap = send.make_descriptor_heap(
             channels_per_substream=output.channels // len(output.dst),
             spectra_per_heap=engine.spectra_per_heap,
-            bits=engine.dst_sample_bits,
+            sample_bits=engine.dst_sample_bits,
         )
 
     def _populate_sensors(self) -> None:

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -410,6 +410,14 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         metavar="BITS",
         help="Number of bits per digitised sample [%(default)s]",
     )
+    parser.add_argument(
+        "--dst-sample-bits",
+        type=int,
+        default=8,
+        choices=[4, 8],
+        metavar="BITS",
+        help="Number of bits per output sample real component [%(default)s]",
+    )
     parser.add_argument("--gain", type=float, default=1.0, help="Initial eq gains [%(default)s]")
     parser.add_argument(
         "--sync-epoch",
@@ -505,6 +513,7 @@ def make_engine(ctx: AbstractContext, args: argparse.Namespace) -> tuple[Engine,
         chunk_jones=chunk_jones,
         spectra_per_heap=args.spectra_per_heap,
         dig_sample_bits=args.dig_sample_bits,
+        dst_sample_bits=args.dst_sample_bits,
         max_delay_diff=args.max_delay_diff,
         gain=args.gain,
         sync_epoch=float(args.sync_epoch),  # CLI arg is an int, but SDP can handle a float downstream.

--- a/src/katgpucbf/fgpu/postproc.py
+++ b/src/katgpucbf/fgpu/postproc.py
@@ -125,7 +125,7 @@ class Postproc(accel.Operation):
     **out** : spectra // spectra_per_heap × out_channels × spectra_per_heap × N_POLS
         Output F-engine data, quantised and corner-turned, ready for
         transmission on the network. See :func:`.gaussian_dtype` for the type.
-    **saturated** : heaps × N_POLS, uint32
+    **saturated** : spectra // spectra_per_heap × N_POLS, uint32
         Number of saturated complex values in **out**.
     **fine_delay** : spectra × N_POLS, float32
         Fine delay in samples (one value per pol).

--- a/src/katgpucbf/fgpu/send.py
+++ b/src/katgpucbf/fgpu/send.py
@@ -40,7 +40,7 @@ output_bytes_counter = Counter(
     "output_bytes", "number of payload bytes transmitted", ["stream"], namespace=METRIC_NAMESPACE
 )
 output_samples_counter = Counter(
-    "output_samples", "number of samples transmitted", ["stream"], namespace=METRIC_NAMESPACE
+    "output_samples", "number of complex samples transmitted", ["stream"], namespace=METRIC_NAMESPACE
 )
 skipped_heaps_counter = Counter(
     "output_skipped_heaps", "heaps not sent because input data was incomplete", ["stream"], namespace=METRIC_NAMESPACE
@@ -116,7 +116,25 @@ def _multi_send(
 
 
 class Chunk:
-    """An array of frames, spanning multiple timestamps."""
+    """An array of frames, spanning multiple timestamps.
+
+    Parameters
+    ----------
+    data
+        Storage for voltage data, with shape (n_frames, n_channels,
+        n_spectra_per_heap, N_POLS) and a dtype returned by
+        :func:`.gaussian_dtype`.
+    saturated
+        Storage for saturation counts, with shape (n_frames, N_POLS)
+        and dtype uint32.
+    n_substreams
+        Number of substreams over which the data will be divided
+        (must divide evenly into the number of channels).
+    feng_id
+        F-Engine ID to place in the SPEAD heaps
+    spectra_samples
+        Difference in timestamps between successive frames
+    """
 
     def __init__(
         self,
@@ -186,7 +204,7 @@ class Chunk:
         """Transmit heaps over SPEAD streams.
 
         Frames from 0 to `frames` - 1 are sent asynchronously. The contents of
-        each frames are distributed over the streams. If the number of streams
+        each frame are distributed over the streams. If the number of streams
         does not divide into the number of destination endpoints, there will be
         imbalances, because the partitioning is the same for every frame.
         """
@@ -297,7 +315,7 @@ def make_descriptor_heap(
     *,
     channels_per_substream: int,
     spectra_per_heap: int,
-    bits: int,
+    sample_bits: int,
 ) -> "spead2.send.Heap":
     """Create a descriptor heap for output F-Engine data."""
     heap_data_shape = (channels_per_substream, spectra_per_heap, N_POLS, COMPLEX)
@@ -327,10 +345,10 @@ def make_descriptor_heap(
 
     raw_kwargs: _RawKwargs = {}
     try:
-        raw_kwargs["dtype"] = np.dtype(f"int{bits}")
+        raw_kwargs["dtype"] = np.dtype(f"int{sample_bits}")
     except TypeError:
         # The number of bits doesn't neatly fit a numpy dtype
-        raw_kwargs["format"] = [("i", bits)]
+        raw_kwargs["format"] = [("i", sample_bits)]
     ig.add_item(
         FENG_RAW_ID,
         "feng_raw",

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -164,3 +164,18 @@ def packbits(data: np.ndarray, sample_bits: int = DIG_SAMPLE_BITS) -> NDArray[np
     bits = bits[..., -sample_bits:]
     bits = bits.reshape(bits.shape[:-2] + (-1,))
     return np.packbits(bits, axis=-1)
+
+
+def unpack_complex(data: np.ndarray) -> np.ndarray:
+    """Unpack array of Gaussian integers to complex dtype.
+
+    The dtype of `data` must be a type returned by :func:`.gaussian_dtype`.
+    """
+    if data.dtype.itemsize == 1:
+        # It's 4-bit packed. We assume that >> will sign extend on signed types
+        real = data.view(np.int8) >> 4
+        imag = data.view(np.int8) << 4 >> 4
+    else:
+        real = data["real"]
+        imag = data["imag"]
+    return real.astype(np.float32) + 1j * imag.astype(np.float32)

--- a/test/fgpu/test_postproc.py
+++ b/test/fgpu/test_postproc.py
@@ -26,6 +26,8 @@ from numpy.typing import DTypeLike
 from katgpucbf import N_POLS
 from katgpucbf.fgpu import postproc
 
+from .. import unpack_complex
+
 pytestmark = [pytest.mark.cuda_only]
 
 
@@ -117,18 +119,6 @@ def postproc_host(
         out.append(pol_out)
         saturated.append(pol_saturated)
     return np.stack(out, axis=3), np.stack(saturated, axis=1)
-
-
-def unpack_complex(data: np.ndarray) -> np.ndarray:
-    """Unpack array of Gaussian integers to complex dtype."""
-    if data.dtype.itemsize == 1:
-        # It's 4-bit packed. We assume that >> will sign extend on signed types
-        real = data.view(np.int8) >> 4
-        imag = data.view(np.int8) << 4 >> 4
-    else:
-        real = data["real"]
-        imag = data["imag"]
-    return real.astype(np.float32) + 1j * imag.astype(np.float32)
 
 
 def _make_complex(func: Callable[[], np.ndarray], dtype: DTypeLike = np.complex64) -> np.ndarray:

--- a/test/fgpu/test_send.py
+++ b/test/fgpu/test_send.py
@@ -189,13 +189,7 @@ async def test_send(
     sensors: aiokatcp.SensorSet,
     time_converter: TimeConverter,
 ) -> None:
-    """Test sending data via the :class:`katgpucbf.fgpu.send.Chunk` interface.
-
-    .. todo::
-
-       This is a very limited test that does not cover sensors, metrics or
-       missing data.
-    """
+    """Test sending data via the :class:`katgpucbf.fgpu.send.Chunk` interface."""
     # Send descriptors to all the streams
     descriptor_heap = make_descriptor_heap(
         channels_per_substream=N_CHANNELS // N_SUBSTREAMS,

--- a/test/fgpu/test_send.py
+++ b/test/fgpu/test_send.py
@@ -1,0 +1,256 @@
+################################################################################
+# Copyright (c) 2023, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Unit tests for :mod:`katgpucbf.fgpu.send`."""
+
+import asyncio
+from unittest import mock
+
+import aiokatcp
+import numpy as np
+import pytest
+import spead2.recv.asyncio
+import spead2.send.asyncio
+from katsdptelstate.endpoint import endpoint_list_parser
+
+from katgpucbf import N_POLS
+from katgpucbf.fgpu import METRIC_NAMESPACE
+from katgpucbf.fgpu.send import Chunk, make_descriptor_heap, make_streams
+from katgpucbf.utils import TimeConverter, gaussian_dtype
+
+from .. import PromDiff, unpack_complex
+
+pytest_mark = pytest.mark.parametrize("bits", [4, 8])
+N_SUBSTREAMS = 16
+N_CHUNKS = 5
+N_FRAMES = 7  # frames per chunk
+N_CHANNELS = 1024
+N_SPECTRA_PER_HEAP = 32  # Small to make the test fast
+SPECTRA_SAMPLES = 2 * N_CHANNELS
+FENG_ID = 3
+INTERFACES = ["10.0.0.1", "10.0.0.2"]
+NAME = "foo"
+
+
+@pytest.fixture(params=[4, 8])
+def sample_bits(request) -> int:
+    return request.param
+
+
+@pytest.fixture
+def time_converter() -> TimeConverter:
+    return TimeConverter(1234567890.0, 1e9)
+
+
+@pytest.fixture
+def queues() -> dict[str, list[spead2.InprocQueue]]:
+    """Create in-process queues to connect the test code to the test."""
+    return {iface: [spead2.InprocQueue() for _ in range(N_SUBSTREAMS)] for iface in INTERFACES}
+
+
+@pytest.fixture
+def chunks(sample_bits) -> list[Chunk]:
+    dtype = gaussian_dtype(sample_bits)
+    return [
+        Chunk(
+            np.zeros((N_FRAMES, N_CHANNELS, N_SPECTRA_PER_HEAP, N_POLS), dtype),
+            np.zeros((N_FRAMES, N_POLS), np.uint32),
+            n_substreams=N_SUBSTREAMS,
+            feng_id=FENG_ID,
+            spectra_samples=SPECTRA_SAMPLES,
+        )
+        for _ in range(N_CHUNKS)
+    ]
+
+
+@pytest.fixture
+def send_streams(
+    queues: dict[str, list[spead2.InprocQueue]], chunks: list[Chunk]
+) -> list["spead2.send.asyncio.AsyncStream"]:
+    """Create the send streams.
+
+    The actual stream constructors are mocked so that we use in-process
+    streams.
+    """
+    expected_endpoints = endpoint_list_parser(None)(f"239.102.1.0+{N_SUBSTREAMS - 1}:7148")
+
+    # Note: this function signature is somewhat fragile. It's built to match the
+    # call in send.py.
+    def make_inproc_stream(
+        thread_pool: spead2.ThreadPool,
+        endpoints: list[tuple[str, int]],
+        config: spead2.send.StreamConfig,
+        interface_address: str,
+        **kwargs,
+    ) -> spead2.send.asyncio.InprocStream:
+        assert endpoints == [tuple(x) for x in expected_endpoints]
+        return spead2.send.asyncio.InprocStream(thread_pool, queues[interface_address], config)
+
+    with mock.patch("spead2.send.asyncio.UdpStream", make_inproc_stream):
+        return make_streams(
+            output_name=NAME,
+            thread_pool=spead2.ThreadPool(1),
+            endpoints=expected_endpoints,
+            interfaces=INTERFACES,
+            ttl=4,
+            ibv=False,
+            packet_payload=8192,
+            comp_vector=0,
+            buffer=65536,
+            bandwidth=1e9,
+            send_rate_factor=1.05,
+            feng_id=FENG_ID,
+            num_ants=64,
+            n_data_heaps=N_CHUNKS * N_FRAMES * N_SUBSTREAMS,
+            chunks=chunks,
+        )
+
+
+@pytest.fixture
+def recv_streams(queues: dict[str, list[spead2.InprocQueue]]) -> dict[str, list[spead2.recv.asyncio.Stream]]:
+    """Create streams for receiving the transmitted data."""
+    config = spead2.recv.StreamConfig()
+    streams: dict[str, list[spead2.recv.asyncio.Stream]] = {}
+    for iface in INTERFACES:
+        streams[iface] = []
+        for queue in queues[iface]:
+            tp = spead2.ThreadPool(1)
+            stream = spead2.recv.asyncio.Stream(tp, config)
+            stream.add_inproc_reader(queue)
+            streams[iface].append(stream)
+    return streams
+
+
+@pytest.fixture
+def sensors() -> aiokatcp.SensorSet:
+    """Create sensors that the send code updates."""
+    sensors = aiokatcp.SensorSet()
+    for pol in range(N_POLS):
+        sensors.add(
+            aiokatcp.Sensor(
+                int,
+                f"{NAME}.input{pol}.feng-clip-cnt",
+                "Number of output samples that are saturated",
+            )
+        )
+    return sensors
+
+
+def _fill_random(data: np.ndarray, rng: np.random.Generator) -> None:
+    """Fill an array with random bytes.
+
+    The underlying bytes are filled, rather than assuming any particular dtype.
+    """
+    view = data.view(np.uint8)
+    view[:] = rng.integers(0, 256, view.shape, dtype=np.uint8)
+
+
+async def test_send(
+    sample_bits: int,
+    queues: dict[str, list[spead2.InprocQueue]],
+    send_streams: list["spead2.send.asyncio.AsyncStream"],
+    recv_streams: dict[str, list[spead2.recv.asyncio.Stream]],
+    chunks: list[Chunk],
+    sensors: aiokatcp.SensorSet,
+    time_converter: TimeConverter,
+) -> None:
+    """Test sending data via the :class:`katgpucbf.fgpu.send.Chunk` interface.
+
+    .. todo::
+
+       This is a very limited test that does not cover sensors, metrics or
+       missing data.
+    """
+    # Send descriptors to all the streams
+    descriptor_heap = make_descriptor_heap(
+        channels_per_substream=N_CHANNELS // N_SUBSTREAMS,
+        spectra_per_heap=N_SPECTRA_PER_HEAP,
+        sample_bits=sample_bits,
+    )
+    for send_stream in send_streams:
+        for substream in range(N_SUBSTREAMS):
+            await send_stream.async_send_heap(descriptor_heap, substream_index=substream)
+
+    rng = np.random.default_rng(seed=1)
+    first_timestamp = 0x123456780000
+    for i, chunk in enumerate(chunks):
+        _fill_random(chunk.data, rng)
+        # Note: this doesn't correspond in any way to the values in data.
+        # That isn't necessary for this test.
+        _fill_random(chunk.saturated, rng)
+        chunk.present[:] = True
+        chunk.timestamp = first_timestamp + i * SPECTRA_SAMPLES * N_SPECTRA_PER_HEAP * N_FRAMES
+    data = np.concatenate([chunk.data for chunk in chunks])
+    saturated = np.sum([chunk.saturated for chunk in chunks], axis=(0, 1), dtype=np.uint64)
+
+    with PromDiff(namespace=METRIC_NAMESPACE) as prom_diff:
+        # Send all the chunks, without waiting for the first one to complete
+        # transmission (to ensure that the send streams have sufficient
+        # capacity).
+        futures = [
+            asyncio.create_task(chunk.send(send_streams, N_FRAMES, time_converter, sensors, NAME)) for chunk in chunks
+        ]
+        await asyncio.gather(*futures)
+
+    for queue_list in queues.values():
+        for queue in queue_list:
+            queue.stop()
+
+    n_channels_per_substream = N_CHANNELS // N_SUBSTREAMS
+    heaps_per_iface = {iface: 0 for iface in INTERFACES}
+    for i in range(N_SUBSTREAMS):
+        seen_frames = np.zeros(N_CHUNKS * N_FRAMES, bool)
+        # Only one of the two interfaces should be receiving any data for
+        # this substream, but it's simpler to just iterate over both and
+        # find the data wherever it happened to fall.
+        for iface in INTERFACES:
+            recv_stream = recv_streams[iface][i]
+            ig = spead2.ItemGroup()
+            frame = 0
+            async for heap in recv_stream:
+                updated = ig.update(heap)
+                if not updated:
+                    continue  # it's a stream control or descriptor heap
+                expected_timestamp = first_timestamp + frame * SPECTRA_SAMPLES * N_SPECTRA_PER_HEAP
+                assert updated["feng_id"].value == FENG_ID
+                assert updated["frequency"].value == i * n_channels_per_substream
+                assert updated["timestamp"].value == expected_timestamp
+                raw = updated["feng_raw"].value
+                raw_complex = raw[..., 0] + 1j * raw[..., 1]
+                expected = data[frame, i * n_channels_per_substream : (i + 1) * n_channels_per_substream]
+                np.testing.assert_equal(raw_complex, unpack_complex(expected))
+                assert not seen_frames[frame]
+                seen_frames[frame] = True
+                frame += 1
+                heaps_per_iface[iface] += 1
+        assert np.all(seen_frames)  # Check that we received all the data we expected
+    # Check the load balancing
+    for iface in INTERFACES:
+        assert heaps_per_iface[iface] == N_SUBSTREAMS * N_CHUNKS * N_FRAMES // len(INTERFACES)
+
+    # Check the sensors and Prometheus metrics
+    labels = {"stream": NAME}
+    assert prom_diff.get_sample_diff("output_heaps_total", labels) == N_CHUNKS * N_FRAMES * N_SUBSTREAMS
+    assert prom_diff.get_sample_diff("output_bytes_total", labels) == data.nbytes
+    assert (
+        prom_diff.get_sample_diff("output_samples_total", labels)
+        == N_CHUNKS * N_FRAMES * N_SPECTRA_PER_HEAP * N_CHANNELS * N_POLS
+    )
+    assert prom_diff.get_sample_diff("output_skipped_heaps_total", labels) == 0
+    for pol in range(N_POLS):
+        pol_labels = {"stream": NAME, "pol": str(pol)}
+        assert prom_diff.get_sample_diff("output_clipped_samples_total", pol_labels) == saturated[pol]
+        assert sensors[f"{NAME}.input{pol}.feng-clip-cnt"].value == saturated[pol]


### PR DESCRIPTION
Support 4-bit output from the command-line. This is a little bit of plumbing, with most of the PR being the addition of test code for fgpu.send (previously not tested in isolation).

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1101.
