### PR TITLE
Fix URLs for coverage.py

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -70,7 +70,7 @@ warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
 intersphinx_mapping = {
     "aiokatcp": ("https://aiokatcp.readthedocs.io/en/latest/", None),
     "black": ("https://black.readthedocs.io/en/stable/", None),
-    "coverage": ("https://coverage.readthedocs.io/en/stable/", None),
+    "coverage": ("https://coverage.readthedocs.io/en/latest/", None),
     "flake8": ("https://flake8.pycqa.org/en/latest/", None),
     "katpoint": ("https://katpoint.readthedocs.io/en/latest", None),
     "katsdpsigproc": ("https://katsdpsigproc.readthedocs.io/en/latest", None),

--- a/doc/unit-testing.rst
+++ b/doc/unit-testing.rst
@@ -69,12 +69,12 @@ code during the course of their run.
   configuration as described in `coverage's documentation`_. This produces a
   slightly different output which conveys more or less similar information.
 
-  .. _coverage's documentation: https://coverage.readthedocs.io/en/stable/contexts.html#dynamic-contexts
+  .. _coverage's documentation: https://coverage.readthedocs.io/en/latest/contexts.html#dynamic-contexts
 
   :mod:`.coverage`\'s `static context`_ is more difficult to specify in a way that
   is useful. To generate the report above, I executed the following command:
 
-  .. _static context: https://coverage.readthedocs.io/en/stable/contexts.html#static-contexts
+  .. _static context: https://coverage.readthedocs.io/en/latest/contexts.html#static-contexts
 
   .. code-block:: bash
 


### PR DESCRIPTION
It seems they no longer use /en/stable, only /en/latest.
