### PR TITLE
XSend.source_stream -> XSend.stream

### DIFF
--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -967,7 +967,7 @@ class XBEngine(DeviceServer):
         # before any data makes its way through the pipeline.
         for pipeline in self._pipelines:
             descriptor_sender = DescriptorSender(
-                pipeline.send_stream.source_stream,
+                pipeline.send_stream.stream,
                 pipeline.send_stream.descriptor_heap,
                 descriptor_interval_s,
             )

--- a/test/xbgpu/test_xsend.py
+++ b/test/xbgpu/test_xsend.py
@@ -42,7 +42,7 @@ class TestXSend:
         """Send a fixed number of heaps."""
         # Send the descriptors as the recv_stream object needs it to
         # interpret the received heaps correctly.
-        await send_stream.source_stream.async_send_heap(send_stream.descriptor_heap)
+        await send_stream.stream.async_send_heap(send_stream.descriptor_heap)
 
         for i in range(TOTAL_HEAPS):
             # Get a free heap - there is not always a free one available. This
@@ -60,7 +60,7 @@ class TestXSend:
             send_stream.send_heap(heap)
         # send_heap just queues data for sending but is non-blocking.
         # Flush to ensure that the data all gets sent before we return.
-        await send_stream.source_stream.async_flush()
+        await send_stream.stream.async_flush()
 
     @staticmethod
     async def _recv_data(


### PR DESCRIPTION
Rename the `source_stream` attribute of `XSend` as it really didn't make sense
for the **destination stream** to be called `source_stream`.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1044.
