### PR TITLE
Get docker-buildx from Ubuntu repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,7 @@ FROM build-base as jenkins
 # All the TeX stuff for building the documentation and qualification report
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     docker.io \
+    docker-buildx \
     latexmk \
     lmodern \
     pdf2svg \
@@ -117,8 +118,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
     texlive-latex-extra \
     texlive-latex-recommended \
     texlive-science
-# Workaround pending https://bugs.launchpad.net/ubuntu/+source/docker.io-app/+bug/2034052
-COPY --from=docker/buildx-bin /buildx /usr/libexec/docker/cli-plugins/docker-buildx
 
 #######################################################################
 


### PR DESCRIPTION
This removes the temporary workaround put in place until Ubuntu packaged docker-buildx (see
https://bugs.launchpad.net/ubuntu/+source/docker.io-app/+bug/2034052)

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1088.
