### PR TITLE
Speed up test_xengine_end_to_end tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,7 +106,7 @@ pipeline {
          */
         stage('Run pytest (quick)') {
           when { not { anyOf { changeRequest target: 'main'; branch 'main' } } }
-          options { timeout(time: 15, unit: 'MINUTES') }
+          options { timeout(time: 30, unit: 'MINUTES') }
           steps {
             sh 'pytest -v -ra --junitxml=reports/result.xml --cov=katgpucbf --cov=test --cov-report=xml --cov-branch --suppress-tests-failed-exit-code'
           }


### PR DESCRIPTION
Several inner steps of generate_expected_output allocated tiny (e.g. 2x2) arrays. Restructuring the code to do calculations in-place approximately halves the time needed for these tests.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match