### PR TITLE
test_xengine_end_to_end: test fewer combinations

### DIFF
--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -458,14 +458,14 @@ class TestEngine:
         await xbengine.stop()
 
     @pytest.mark.combinations(
-        "n_ants, n_channels_total, n_spectra_per_heap, missing_antenna",
+        "n_ants, n_channels_total, n_spectra_per_heap, missing_antenna, heap_accumulation_threshold",
         test_parameters.array_size,
         test_parameters.num_channels,
         test_parameters.num_spectra_per_heap,
         [None, 0, 3],
+        [(3, 7), (4, 8), (5, 9)],
         filter=valid_end_to_end_combination,
     )
-    @pytest.mark.parametrize("heap_accumulation_threshold", [(3, 7), (4, 8), (5, 9)])
     async def test_xengine_end_to_end(
         self,
         mock_recv_streams: list[spead2.InprocQueue],


### PR DESCRIPTION
Combine heap_accumulation_threshold into the pytest.mark.combinations mark, so that it doesn't test every combination of heap_accumulation_threshold with every set of the others. This should speed up the standard pytest execution.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
