### PR TITLE
Add BPipeline infrastructure

### DIFF
--- a/doc/katgpucbf.xbgpu.bsend.rst
+++ b/doc/katgpucbf.xbgpu.bsend.rst
@@ -1,0 +1,7 @@
+katgpucbf.xbgpu.bsend module
+============================
+
+.. automodule:: katgpucbf.xbgpu.bsend
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/katgpucbf.xbgpu.rst
+++ b/doc/katgpucbf.xbgpu.rst
@@ -7,6 +7,7 @@ Submodules
 .. toctree::
    :maxdepth: 4
 
+   katgpucbf.xbgpu.bsend
    katgpucbf.xbgpu.correlation
    katgpucbf.xbgpu.engine
    katgpucbf.xbgpu.main

--- a/src/katgpucbf/spead.py
+++ b/src/katgpucbf/spead.py
@@ -28,6 +28,7 @@ FREQUENCY_ID = 0x4103
 ADC_SAMPLES_ID = 0x3300  # Digitiser data
 XENG_RAW_ID = 0x1800
 TIMESTAMP_ID = 0x1600
+BF_RAW_ID = 0x5000
 MAX_PACKET_SIZE = 8872
 
 #: Bit position in digitiser_status SPEAD item for ADC saturation flag

--- a/src/katgpucbf/xbgpu/bsend.py
+++ b/src/katgpucbf/xbgpu/bsend.py
@@ -307,13 +307,16 @@ class BSend:
 
         self.descriptor_heap = item_group.get_heap(descriptors="all", data="none")
 
-    def enable_substream(self, stream_id: int, enable: bool = True) -> None:
+    def enable_substream(self, stream_id: int = 0, enable: bool = True) -> None:
         """Enable/Disable a substream's data transmission.
 
         :class:`.BSend` operates as a large single stream with multiple
         substreams. Each substream is its own data product and is required
         to be enabled/disabled independently.
 
+        .. todo::
+            Update to actually carry out substream enable/disable once
+            multiple substreams are supported.
         Parameters
         ----------
         stream_id
@@ -323,7 +326,7 @@ class BSend:
             Boolean indicating whether the `stream_id` should be enabled or
             disabled.
         """
-        pass
+        self.tx_enabled = enable
 
     async def get_free_chunk(self) -> Chunk:
         """Return a Chunk once it has completed its send futures."""
@@ -339,8 +342,8 @@ class BSend:
         # It's a heavy-handed approach, but we don't care about performance
         # during shutdown.
         await self.stream.async_flush()
-        # TODO: Send across all substreams once multiple beams are supported
-        await self.stream.async_send_heap(stop_heap)
+        for i in range(self.n_beams):
+            await self.stream.async_send_heap(stop_heap, substream_index=i)
 
 
 def make_stream(

--- a/src/katgpucbf/xbgpu/bsend.py
+++ b/src/katgpucbf/xbgpu/bsend.py
@@ -279,7 +279,6 @@ class BSend:
             self._chunks_queue.put_nowait(chunk)
             buffers.append(chunk.data)
 
-        # Multicast stream parameters
         heap_payload_size_bytes = n_channels_per_substream * spectra_per_heap * COMPLEX * SEND_DTYPE.itemsize
 
         # Transport-agnostic stream information

--- a/src/katgpucbf/xbgpu/bsend.py
+++ b/src/katgpucbf/xbgpu/bsend.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2023, National Research Foundation (SARAO)
+# Copyright (c) 2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -65,7 +65,7 @@ class BSend:
 
     def __init__(
         self,
-        outputs: list[BOutput],
+        output: BOutput,
         n_channels_per_substream: int,
         spectra_per_heap: int,
         send_rate_factor: float,
@@ -87,7 +87,7 @@ class BSend:
 
         # `n_heaps_to_send` is actually used to dictate the amount of buffers (in XSend)
         # So perhaps we need to change the number of buffers to be range(send_free_queue.maxsize)
-        n_heaps_to_send = len(buffers) // spectra_per_heap * len(outputs)
+        n_heaps_to_send = len(buffers) // spectra_per_heap
 
         for _ in range(n_heaps_to_send):
             heap = Heap(context, n_channels_per_substream, spectra_per_heap)
@@ -103,9 +103,9 @@ class BSend:
 
         stream_config = spead2.send.StreamConfig(
             max_packet_size=packet_payload + BSend.header_size,
-            max_heaps=10 + len(outputs),  # TODO: Update this to be proper
+            max_heaps=10,  # TODO: Update this to be proper
             rate_method=spead2.send.RateMethod.AUTO,
-            rate=0,  # Send as fast as possible
+            rate=0,  # TODO: Update to use `send_rate_bytes_per_second`, this sends as fast as possible
         )
         self.source_stream = stream_factory(stream_config, buffers)
 
@@ -113,8 +113,8 @@ class BSend:
         """Take in a buffer and send it as a SPEAD heap."""
         pass
 
-    def disable_substream(self, stream_id: int) -> None:
-        """Disable a substream's data transmission.
+    def enable_substream(self, stream_id: int, enable: bool = True) -> None:
+        """Enable/Disable a substream's data transmission.
 
         :class:`.BSend` operates as a large single stream with multiple
         substreams. Each substream is its own data product and is required
@@ -125,6 +125,9 @@ class BSend:
         stream_id
             ID of the substream, corresponds to the <beam-id><pol>
             convention, e.g. stream_id 3 has a stream_name ending in <1x>.
+        enable
+            Boolean indicating whether the `stream_id` should be enabled or
+            disabled.
         """
         pass
 

--- a/src/katgpucbf/xbgpu/bsend.py
+++ b/src/katgpucbf/xbgpu/bsend.py
@@ -335,7 +335,7 @@ class BSend:
         try:
             await chunk.future
         except asyncio.CancelledError:
-            raise asyncio.CancelledError("Sending chunk was cancelled")
+            raise
         except Exception:
             logger.exception("Error sending chunk")
         return chunk

--- a/src/katgpucbf/xbgpu/bsend.py
+++ b/src/katgpucbf/xbgpu/bsend.py
@@ -188,7 +188,7 @@ class Chunk:
 
 
 class BSend:
-    """
+    r"""
     Class for turning tied array channelised voltage products into SPEAD heaps.
 
     This class creates a queue of chunks that can be sent out onto the network.
@@ -212,7 +212,7 @@ class BSend:
     outputs
         Sequence of :class:`.output.BOutput`.
     frames_per_chunk
-        Number of SPEAD heaps from one F-engine in a single received Chunk.
+        Number of :class:`Frame`\ s in each transmitted :class:`Chunk`.
     n_tx_items
         Number of :class:`Chunk` to create.
     adc_sample_rate, n_channels, n_channels_per_substream, spectra_per_heap, channel_offset

--- a/src/katgpucbf/xbgpu/bsend.py
+++ b/src/katgpucbf/xbgpu/bsend.py
@@ -1,0 +1,207 @@
+################################################################################
+# Copyright (c) 2020-2023, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Module for sending tied array channelised voltage products onto the network."""
+
+import asyncio
+from typing import Callable, Final, Sequence
+
+import katsdpsigproc.accel as accel
+import numpy as np
+import spead2
+import spead2.send.asyncio
+from katsdpsigproc.abc import AbstractContext
+from katsdptelstate.endpoint import Endpoint
+
+from .. import COMPLEX, DEFAULT_PACKET_PAYLOAD_BYTES
+from ..spead import BF_RAW_ID, FLAVOUR, FREQUENCY_ID, IMMEDIATE_FORMAT, TIMESTAMP_ID
+from .output import BOutput
+
+# NOTE: ICD suggests `beng_out_bits_per_sample`,
+# MK correlator doesn't make this configurable.
+SEND_DTYPE = np.dtype(np.int8)
+
+
+class Heap:
+    """Hold all data for a heap.
+
+    # TODO: This will likely need to be updated to the 'fgpu.send.Chunk' methodology
+            - Especially to dictate 'Frames' within the Chunk
+    """
+
+    def __init__(
+        self,
+        context: AbstractContext,
+        n_channels_per_substream: int,
+        n_spectra_per_heap: int,
+    ) -> None:
+        self.buffer: Final = accel.HostArray(
+            (n_channels_per_substream, n_spectra_per_heap, COMPLEX), SEND_DTYPE, context=context
+        )
+
+
+class BSend:
+    """
+    Class for turning tied array channelised voltage products into SPEAD heaps.
+
+    NOTE: Each BSend shouldn't need its own *version* of a descriptor heap
+    """
+
+    descriptor_heap: spead2.send.Heap
+    header_size: Final[int] = 64
+
+    def __init__(
+        self,
+        outputs: list[BOutput],
+        n_channels_per_substream: int,
+        spectra_per_heap: int,
+        send_rate_factor: float,
+        channel_offset: int,
+        context: AbstractContext,
+        stream_factory: Callable[[spead2.send.StreamConfig, Sequence[np.ndarray]], "spead2.send.asyncio.AsyncStream"],
+        packet_payload: int = DEFAULT_PACKET_PAYLOAD_BYTES,
+        tx_enabled: bool = False,
+    ) -> None:
+        # Now that we've moved away from *multiple* BSend objects, towards
+        # a single send_stream with multiple substreams, the BSend object
+        # probably still needs to exist
+        # - The `send` function will need to keep track of "which substream
+        #   is enabled/disabled" Re: capture-{start, stop} <stream_name>
+        self.enabled_stream_ids: list[int] = []
+
+        self._heaps_queue: asyncio.Queue[Heap] = asyncio.Queue()
+        buffers: list[accel.HostArray] = []
+
+        # `n_heaps_to_send` is actually used to dictate the amount of buffers (in XSend)
+        # So perhaps we need to change the number of buffers to be range(send_free_queue.maxsize)
+        n_heaps_to_send = len(buffers) // spectra_per_heap * len(outputs)
+
+        for _ in range(n_heaps_to_send):
+            heap = Heap(context, n_channels_per_substream, spectra_per_heap)
+            self._heaps_queue.put_nowait(heap)
+            buffers.append(heap.buffer)
+
+        # Multicast stream parameters
+        self.heap_payload_size_bytes = n_channels_per_substream * spectra_per_heap * COMPLEX * SEND_DTYPE.itemsize
+        # Transport-agnostic stream information
+        # Used in XSend to calculate `send_rate_bytes_per_second`, do we need it here?
+        # packets_per_heap = math.ceil(self.heap_payload_size_bytes / packet_payload)
+        # packet_header_overhead_bytes = packets_per_heap * BSend.header_size
+
+        stream_config = spead2.send.StreamConfig(
+            max_packet_size=packet_payload + BSend.header_size,
+            max_heaps=10 + len(outputs),  # TODO: Update this to be proper
+            rate_method=spead2.send.RateMethod.AUTO,
+            rate=0,  # Send as fast as possible
+        )
+        self.source_stream = stream_factory(stream_config, buffers)
+
+    async def send_heap(self, heap: Heap) -> None:
+        """Take in a buffer and send it as a SPEAD heap."""
+        pass
+
+    def disable_substream(self, stream_id: int) -> None:
+        """Disable a substream's data transmission.
+
+        :class:`.BSend` operates as a large single stream with multiple
+        substreams. Each substream is its own data product and is required
+        to be enabled/disabled independently.
+
+        Parameters
+        ----------
+        stream_id
+            ID of the substream, corresponds to the <beam-id><pol>
+            convention, e.g. stream_id 3 has a stream_name ending in <1x>.
+        """
+        pass
+
+
+def make_stream(
+    *,
+    endpoints: list[Endpoint],
+    interface: str,
+    ttl: int,
+    use_ibv: bool,
+    affinity: int,
+    comp_vector: int,
+    stream_config: spead2.send.StreamConfig,
+    buffers: Sequence[np.ndarray],
+) -> "spead2.send.asyncio.AsyncStream":
+    """Create asynchronous SPEAD stream for transmission.
+
+    This is architected to be a single send stream with multiple substreams,
+    each corresponding to a tied-array-channelised-voltage output data product.
+    The `endpoints` need not be a contiguous list of multicast addresses.
+    """
+    stream: spead2.send.asyncio.AsyncStream
+    thread_pool = spead2.ThreadPool(1, [] if affinity < 0 else [affinity])
+
+    if use_ibv:
+        stream = spead2.send.asyncio.UdpIbvStream(
+            thread_pool,
+            stream_config,
+            spead2.send.UdpIbvConfig(
+                endpoints=[(ep.host, ep.port) for ep in endpoints],
+                interface_address=interface,
+                ttl=ttl,
+                comp_vector=comp_vector,
+                memory_regions=list(buffers),
+            ),
+        )
+    else:
+        stream = spead2.send.asyncio.UdpStream(
+            thread_pool,
+            [(ep.host, ep.port) for ep in endpoints],
+            stream_config,
+            interface_address=interface,
+            ttl=ttl,
+        )
+
+    return stream
+
+
+def make_descriptor_heap(
+    *,
+    n_channels_per_substream: int,
+    spectra_per_heap: int,
+) -> "spead2.send.Heap":
+    """Create a descriptor heap for output B-engine data."""
+    heap_data_shape = (n_channels_per_substream, spectra_per_heap, COMPLEX)
+
+    ig = spead2.send.ItemGroup(flavour=FLAVOUR)
+    ig.add_item(
+        FREQUENCY_ID,
+        "frequency",  # Misleading name, but it's what the ICD specifies
+        "Value of the first channel in collections stored here.",
+        shape=[],
+        format=IMMEDIATE_FORMAT,
+    )
+    ig.add_item(
+        TIMESTAMP_ID,
+        "timestamp",
+        "Timestamp provided by the MeerKAT digitisers and scaled to the digitiser sampling rate.",
+        shape=[],
+        format=IMMEDIATE_FORMAT,
+    )
+    ig.add_item(
+        BF_RAW_ID,
+        "bf_raw",
+        "",  # TODO: What to even say here? ICD says "Channelised complex data"
+        shape=heap_data_shape,
+        dtype=SEND_DTYPE,
+    )
+
+    return ig.get_heap(descriptors="all", data="none")

--- a/src/katgpucbf/xbgpu/bsend.py
+++ b/src/katgpucbf/xbgpu/bsend.py
@@ -97,10 +97,10 @@ class Chunk:
         channel_offset: int,
         n_substreams: int,
     ) -> None:
-        # data.shape[0] should be some outer element indicating n_heaps
+        # data.shape[0] should be some outer element indicating n_frames
         # to fill a Chunk.
         # NOTE: I think this value == heaps-per-feng-per-chunk????
-        n_heaps = data.shape[0]
+        n_frames = data.shape[0]
         n_channels_per_substream = data.shape[1]
         spectra_per_heap = data.shape[2]
         self.data = data  # data should have all the dimensions required
@@ -110,10 +110,10 @@ class Chunk:
         #       `engine.rx_heap_timestamp_step`.
         self._timestamp = 0
         self._timestamp_step = n_channels_per_substream * spectra_per_heap
-        self._timestamps = (np.arange(n_heaps) * self._timestamp_step).astype(">u8")
+        self._timestamps = (np.arange(n_frames) * self._timestamp_step).astype(">u8")
 
         # Need a future for each heap to be sent
-        self.futures: list[asyncio.Future] = [asyncio.get_running_loop().create_future() for _ in range(n_heaps)]
+        self.futures: list[asyncio.Future] = [asyncio.get_running_loop().create_future() for _ in range(n_frames)]
         for future in self.futures:
             future.set_result(None)
 
@@ -125,7 +125,7 @@ class Chunk:
                 channel_offset=channel_offset,
                 n_substreams=n_substreams,
             )
-            for i in range(n_heaps)
+            for i in range(n_frames)
         ]
 
     @property
@@ -143,7 +143,7 @@ class Chunk:
     def timestamp(self, value: int) -> None:
         delta = value - self.timestamp
         # TODO: This specifically needs some attention Re: Casting error
-        self._timestamps = self._timestamps + delta
+        self._timestamps += delta
         self._timestamp = value
 
 

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -307,10 +307,6 @@ class BPipeline(Pipeline):
             tx_item = TxQueueItem(buffer_device, saturated, present_ants)
             self._tx_free_item_queue.put_nowait(tx_item)
 
-        # TODO: Collate all output.dst addresses into one list to give to BSend
-        # The order doesn't *matter*, it's more for peace of mind
-        # To keep the output.name and output.dst in lock-step, probably best to
-        # pass `outputs` to BSend constructor?
         # TODO: The way this is imported will change once the OperationSequence is in place
         self.send_stream = bsend.BSend(
             output,
@@ -353,11 +349,10 @@ class BPipeline(Pipeline):
         )
 
     def capture_enable(self, enable: bool = True) -> None:  # noqa: D102
-        # TODO: Maybe pass this off to BSend?
-        # If enable is True, ensure that this `beam_name` is present
-        # else: Remove the entry
-
-        pass
+        # NOTE: Defaulting to handle its single output for now.
+        # Actual implementation will require some kind of 'stream_id' arg,
+        # which currently contravenes the base function signature.
+        self.send_stream.enable_substream(enable=enable)
 
     async def gpu_proc_loop(self) -> None:  # noqa: D102
         while True:

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -105,14 +105,10 @@ class TxQueueItem(QueueItem):
     """
     Extension of the QueueItem to track antennas that have missed data.
 
-    The TxQueueItem between the gpu-proc and sender loops needs to carry a record
-    of which antennas have missed data at any point in the accumulation being
-    processed. This is used to determine whether any baselines were affected, and have
-    their data zeroed accordingly.
-
-    .. todo::
-        Update final sentence above to accommodate for BPipeline usage, i.e.
-        Not X-engine-specific wording.
+    The TxQueueItem between the gpu-proc and sender loops needs to carry a
+    record of which antennas have missed data at any point in the accumulation
+    being processed. This is used to determine whether any output products were
+    affected, and have their data zeroed accordingly.
     """
 
     def __init__(
@@ -156,6 +152,7 @@ class Pipeline:
     complete.
 
     .. todo::
+
         Update the `output` parameter to be a list of `Output`s once multiple
         beams are supported. This will require some updates to the plumbing
         that uses `output` to e.g. capture-{start, stop}.
@@ -275,7 +272,7 @@ class Pipeline:
 
 
 class BPipeline(Pipeline):
-    """Processing pipeline for a collection of :class:`~output.BOutput`."""
+    """Processing pipeline for a collection of :class:`.output.BOutput`."""
 
     output: BOutput
 
@@ -366,7 +363,6 @@ class BPipeline(Pipeline):
 
             tx_item = await self._tx_free_item_queue.get()
             await tx_item.async_wait_for_events()
-            # TODO: Is it fine to update the timestamp like this?
             tx_item.reset(rx_item.timestamp)
 
             # Bind input buffers
@@ -394,8 +390,8 @@ class BPipeline(Pipeline):
         # chunk.send, which then takes care of directing data to each beam's
         # output destination.
 
-        # Get a populated TxQueueItem from the tx_item_queue
         while True:
+            # Get a populated TxQueueItem from the tx_item_queue
             item = await self._tx_item_queue.get()
             if item is None:
                 break
@@ -417,7 +413,7 @@ class BPipeline(Pipeline):
             # Set the Chunk timestamp
             chunk.timestamp = item.timestamp
             if self.send_stream.tx_enabled:
-                # Update beng-clip-cnt sensor
+                # TODO: Update beng-clip-cnt sensor
                 # But fgpu does it all in chunk.send by passing it
                 # - Send stream(s),
                 # - Frames (int, to send)

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -63,7 +63,7 @@ from ..ringbuffer import ChunkRingbuffer
 from ..send import DescriptorSender
 from ..utils import DeviceStatusSensor, TimeConverter, add_time_sync_sensors
 from . import DEFAULT_BPIPELINE_NAME, DEFAULT_N_RX_ITEMS, DEFAULT_N_TX_ITEMS, DEFAULT_XPIPELINE_NAME, recv
-from .bsend import BSend, make_descriptor_heap
+from .bsend import BSend
 from .bsend import make_stream as make_bstream
 from .correlation import Correlation, CorrelationTemplate
 from .output import BOutput, Output, XOutput
@@ -305,11 +305,6 @@ class BPipeline(Pipeline):
                 stream_config=stream_config,
                 buffers=buffers,
             ),
-        )
-
-        self.send_stream.descriptor_heap = make_descriptor_heap(
-            n_channels_per_substream=engine.n_channels_per_substream,
-            spectra_per_heap=engine.src_layout.n_spectra_per_heap,
         )
 
     def capture_enable(self, enable: bool = True) -> None:  # noqa: D102

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -311,6 +311,7 @@ class BPipeline(Pipeline):
             self.n_tx_items,
             n_channels_per_substream=engine.n_channels_per_substream,
             spectra_per_heap=engine.src_layout.n_spectra_per_heap,
+            timestamp_step=engine.rx_heap_timestamp_step,
             send_rate_factor=engine.send_rate_factor,
             channel_offset=engine.channel_offset_value,
             context=context,

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -154,7 +154,7 @@ class Pipeline:
     Parameters
     ----------
     outputs
-        List of Output config for data product (BOutput or XOutput).
+        Sequence of Output config for data product (BOutput or XOutput).
     name
         Name of Pipeline.
     engine
@@ -943,7 +943,7 @@ class XBEngine(DeviceServer):
         x_outputs = [output for output in outputs if isinstance(output, XOutput)]
         b_outputs = [output for output in outputs if isinstance(output, BOutput)]
         self._pipelines = [XPipeline(x_output, self, context, tx_enabled) for x_output in x_outputs]
-        if len(b_outputs):
+        if b_outputs:
             self._pipelines.append(BPipeline(b_outputs, self, context, tx_enabled))
 
         self._upload_command_queue = context.create_command_queue()

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -299,6 +299,7 @@ class BPipeline(Pipeline):
             outputs=outputs,
             heaps_per_fengine_per_chunk=engine.heaps_per_fengine_per_chunk,
             n_tx_items=self.n_tx_items,
+            n_channels=engine.n_channels_total,
             n_channels_per_substream=engine.n_channels_per_substream,
             spectra_per_heap=engine.src_layout.n_spectra_per_heap,
             timestamp_step=engine.rx_heap_timestamp_step,

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -422,7 +422,7 @@ class BPipeline(Pipeline):
                 # - output_name, because the Chunk didn't have access to it
                 #   (to find sensor name).
                 pass
-            await self.send_stream.send_chunk(chunk, self.engine.time_converter, self.engine.sensors)
+            self.send_stream.send_chunk(chunk, self.engine.time_converter, self.engine.sensors)
             self._tx_free_item_queue.put_nowait(item)
 
         await self.send_stream.send_stop_heap()
@@ -977,9 +977,8 @@ class XBEngine(DeviceServer):
         self._pipelines: list[Pipeline] = []
         x_outputs = [output for output in outputs if isinstance(output, XOutput)]
         b_outputs = [output for output in outputs if isinstance(output, BOutput)]
-        if len(x_outputs):
-            self._pipelines = [XPipeline(x_outputs, self, context, tx_enabled)]
-        elif len(b_outputs):
+        self._pipelines = [XPipeline([x_output], self, context, tx_enabled) for x_output in x_outputs]
+        if len(b_outputs):
             self._pipelines.append(BPipeline(b_outputs, self, context, tx_enabled))
 
         self._upload_command_queue = context.create_command_queue()

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -302,6 +302,7 @@ class BPipeline(Pipeline):
             n_channels=engine.n_channels_total,
             n_channels_per_substream=engine.n_channels_per_substream,
             spectra_per_heap=engine.src_layout.n_spectra_per_heap,
+            adc_sample_rate=engine.adc_sample_rate_hz,
             timestamp_step=engine.rx_heap_timestamp_step,
             send_rate_factor=engine.send_rate_factor,
             channel_offset=engine.channel_offset_value,

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -407,7 +407,7 @@ class BPipeline(Pipeline):
                 # - output_name, because the Chunk didn't have access to it
                 #   (to find sensor name).
                 pass
-            await self.send_stream.send_chunk(chunk, self.engine.time_converter, self.engine.sensors)
+            self.send_stream.send_chunk(chunk, self.engine.time_converter, self.engine.sensors)
             self._tx_free_item_queue.put_nowait(item)
 
         await self.send_stream.send_stop_heap()

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -274,7 +274,7 @@ class Pipeline:
 
 
 class BPipeline(Pipeline):
-    """Processing pipeline for a collection of :class:`BOutput`s."""
+    """Processing pipeline for a collection of :class:`~output.BOutput`."""
 
     output: BOutput
 

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -297,7 +297,7 @@ class BPipeline(Pipeline):
         # TODO: The way this is imported will change once the OperationSequence is in place
         self.send_stream = bsend.BSend(
             outputs=outputs,
-            heaps_per_fengine_per_chunk=engine.heaps_per_fengine_per_chunk,
+            frames_per_chunk=engine.heaps_per_fengine_per_chunk,
             n_tx_items=self.n_tx_items,
             n_channels=engine.n_channels_total,
             n_channels_per_substream=engine.n_channels_per_substream,

--- a/test/xbgpu/test_bsend.py
+++ b/test/xbgpu/test_bsend.py
@@ -166,7 +166,7 @@ class TestBSend:
         channel_offset = n_channels_per_substream * 3
         queue = spead2.InprocQueue()
         send_stream = BSend(
-            output=output,
+            outputs=[output],
             heaps_per_fengine_per_chunk=HEAPS_PER_FENG_PER_CHUNK,
             n_tx_items=N_TX_ITEMS,
             n_channels_per_substream=n_channels_per_substream,

--- a/test/xbgpu/test_bsend.py
+++ b/test/xbgpu/test_bsend.py
@@ -88,7 +88,7 @@ class TestBSend:
             # Give the chunk back to the send_stream to transmit out
             # onto the network.
             chunk.timestamp = i * HEAPS_PER_FENG_PER_CHUNK * heap_timestamp_step
-            chunk.send(send_stream, time_converter, sensors)
+            send_stream.send_chunk(chunk, time_converter, sensors)
         # send_heap just queues data for sending but is non-blocking.
         # Flush to ensure that the data all gets sent before we return.
         await send_stream.stream.async_flush()

--- a/test/xbgpu/test_bsend.py
+++ b/test/xbgpu/test_bsend.py
@@ -79,7 +79,7 @@ class TestBSend:
 
         for i in range(N_TX_ITEMS):
             # Get a free chunk - there is not always a free one available. This
-            # function yields until one it available.
+            # function blocks until one is available.
             chunk = await send_stream.get_free_chunk()
 
             # Populate the buffer with dummy data.
@@ -129,8 +129,11 @@ class TestBSend:
             assert items["bf_raw"].value.dtype == np.int8
             np.testing.assert_equal(items["bf_raw"].value, zero_data)
 
-    @pytest.mark.parametrize("num_channels", test_parameters.num_channels)
-    @pytest.mark.parametrize("num_spectra_per_heap", test_parameters.num_spectra_per_heap)
+    @pytest.mark.combinations(
+        "num_channels, num_spectra_per_heap",
+        test_parameters.num_channels,
+        test_parameters.num_spectra_per_heap,
+    )
     async def test_send_simple(
         self,
         context: AbstractContext,

--- a/test/xbgpu/test_bsend.py
+++ b/test/xbgpu/test_bsend.py
@@ -35,9 +35,9 @@ from katgpucbf.xbgpu.output import BOutput
 
 from . import test_parameters
 
-HEAPS_PER_CHUNK: Final[int] = 5
+FRAMES_PER_CHUNK: Final[int] = 5
 N_TX_ITEMS: Final[int] = 2
-TX_HEAPS_PER_SUBSTREAM: Final[int] = N_TX_ITEMS * HEAPS_PER_CHUNK
+TX_HEAPS_PER_SUBSTREAM: Final[int] = N_TX_ITEMS * FRAMES_PER_CHUNK
 
 
 @pytest.fixture
@@ -79,7 +79,7 @@ class TestBSend:
         """Send a fixed number of heaps.
 
         More specifically, in addition to a descriptor heap per substream, send
-        `N_TX_ITEMS` Chunks, each of which contain `HEAPS_PER_CHUNK` heaps.
+        `N_TX_ITEMS` Chunks, each of which contain `FRAMES_PER_CHUNK` heaps.
 
         Parameters
         ----------
@@ -92,7 +92,7 @@ class TestBSend:
         -------
         data
             Array of shape
-            (N_TX_ITEMS, HEAPS_PER_CHUNK, len(outputs), n_channels_per_substream, n_spectra_per_heap, COMPLEX)
+            (N_TX_ITEMS, FRAMES_PER_CHUNK, len(outputs), n_channels_per_substream, n_spectra_per_heap, COMPLEX)
         """
         # Send the descriptors as the recv_stream object needs it to
         # interpret the received heaps correctly.
@@ -103,7 +103,7 @@ class TestBSend:
             )
 
         data = np.zeros(
-            shape=(N_TX_ITEMS, HEAPS_PER_CHUNK, len(outputs), n_channels_per_substream, n_spectra_per_heap, COMPLEX),
+            shape=(N_TX_ITEMS, FRAMES_PER_CHUNK, len(outputs), n_channels_per_substream, n_spectra_per_heap, COMPLEX),
             dtype=SEND_DTYPE,
         )
 
@@ -121,7 +121,7 @@ class TestBSend:
 
             # Give the chunk back to the send_stream to transmit out
             # onto the network.
-            chunk.timestamp = i * HEAPS_PER_CHUNK * heap_timestamp_step
+            chunk.timestamp = i * FRAMES_PER_CHUNK * heap_timestamp_step
             send_stream.send_chunk(chunk, time_converter, sensors)
         # send_heap just queues data for sending but is non-blocking.
         # Flush to ensure that the data all gets sent before we return.
@@ -133,7 +133,7 @@ class TestBSend:
     async def _recv_data(
         data: np.ndarray,
         queues: list[spead2.InprocQueue],
-        n_engines: int,
+        num_engines: int,
         engine_id: int,
         channel_offset: int,
         n_channels_per_substream: int,
@@ -148,11 +148,11 @@ class TestBSend:
         ----------
         data
             Random data generated during data transmission, of shape
-            - (N_TX_ITEMS, HEAPS_PER_CHUNK, len(outputs), n_channels_per_substream, n_spectra_per_heap, COMPLEX)
+            - (N_TX_ITEMS, FRAMES_PER_CHUNK, len(outputs), n_channels_per_substream, n_spectra_per_heap, COMPLEX)
         queues
             List of :class:`spead2.InprocQueue` used to transmit heaps
             in :meth:`_send_data`.
-        n_engines, engine_id, channel_offset, n_channels_per_substream, n_spectra_per_heap, heap_timestamp_step
+        num_engines, engine_id, channel_offset, n_channels_per_substream, n_spectra_per_heap, heap_timestamp_step
             Variables declared by the calling unit test to verify
             transmitted data.
         """
@@ -169,7 +169,7 @@ class TestBSend:
             # SPEAD descriptor.
             ig = spead2.ItemGroup()
             heap = await stream.get()
-            assert heap.cnt % n_engines == engine_id, "The heap IDs are not correctly strided"
+            assert heap.cnt % num_engines == engine_id, "The heap IDs are not correctly strided"
             items = ig.update(heap)
             assert items == {}, "This heap contains item values not just the expected descriptors."
 
@@ -188,15 +188,15 @@ class TestBSend:
                 np.testing.assert_equal(items["bf_raw"].value, data[j, i, ...])
 
     @pytest.mark.combinations(
-        "num_ants, num_channels, num_spectra_per_heap",
-        [1, 19, 80],
+        "num_engines, num_channels, num_spectra_per_heap",
+        [4, 128, 512],
         test_parameters.num_channels,
         test_parameters.num_spectra_per_heap,
     )
     async def test_send_simple(
         self,
         context: AbstractContext,
-        num_ants: int,
+        num_engines: int,
         num_channels: int,
         num_spectra_per_heap: int,
         outputs: Sequence[BOutput],
@@ -213,6 +213,8 @@ class TestBSend:
         ----------
         context
             Device context for allocating buffers.
+        num_engines
+            Total number of engines required to process this array configuration.
         num_channels
             Total number of channels processed by a (theoretical) F-engine.
         num_spectra_per_heap
@@ -220,26 +222,19 @@ class TestBSend:
         outputs, time_converter, sensors
             Fixtures.
         """
-        # We need the "total number of engines required" to process this array
-        # configuration.
-        n_engines = 1
-        while n_engines < num_ants * 4:
-            n_engines *= 2
-
         # The test still needs to have some idea of "which engine" this is in a
         # sequence of B-engines. The value is chosen arbitrarily, but to ensure
-        # it satisfies all values of `n_engines`, which can be as small as 4
-        # for `num_ants` == 1.
+        # it satisfies all values of `num_engines`, which can be as small as 4.
         engine_id = 3
 
         # TODO: We don't do channels * 2 anymore, but n-samples-between-spectra
         heap_timestamp_step = num_channels * 2 * num_spectra_per_heap
-        n_channels_per_substream = num_channels // n_engines
+        n_channels_per_substream = num_channels // num_engines
         channel_offset = n_channels_per_substream * engine_id
         queues = [spead2.InprocQueue() for _ in outputs]
         send_stream = BSend(
             outputs=outputs,
-            heaps_per_fengine_per_chunk=HEAPS_PER_CHUNK,
+            frames_per_chunk=FRAMES_PER_CHUNK,
             n_tx_items=N_TX_ITEMS,
             n_channels=num_channels,
             n_channels_per_substream=n_channels_per_substream,
@@ -269,7 +264,7 @@ class TestBSend:
         await self._recv_data(
             data,
             queues,
-            n_engines,
+            num_engines,
             engine_id,
             channel_offset,
             n_channels_per_substream,

--- a/test/xbgpu/test_bsend.py
+++ b/test/xbgpu/test_bsend.py
@@ -200,7 +200,7 @@ class TestBSend:
         # TODO: We don't do channels * 2 anymore, but n-samples-between-spectra
         heap_timestamp_step = num_channels * 2 * num_spectra_per_heap
         # Arbitrarily chosen, channels-per-substream is dictated by the
-        # F-engine anyway.
+        # top-level correlator configuration anyway.
         n_channels_per_substream = 512
         channel_offset = n_channels_per_substream * 3
         queues = [spead2.InprocQueue() for _ in outputs]

--- a/test/xbgpu/test_bsend.py
+++ b/test/xbgpu/test_bsend.py
@@ -216,8 +216,9 @@ class TestBSend:
             n_channels=num_channels,
             n_channels_per_substream=n_channels_per_substream,
             spectra_per_heap=num_spectra_per_heap,
+            adc_sample_rate=time_converter.adc_sample_rate,
             timestamp_step=heap_timestamp_step,
-            send_rate_factor=0.0,
+            send_rate_factor=0.0,  # Send as fast as possible
             channel_offset=channel_offset,
             context=context,
             stream_factory=lambda stream_config, buffers: spead2.send.asyncio.InprocStream(

--- a/test/xbgpu/test_bsend.py
+++ b/test/xbgpu/test_bsend.py
@@ -1,0 +1,144 @@
+################################################################################
+# Copyright (c) 2023, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Unit tests for the :mod:`katgpucbf.xbgpu.bsend` module."""
+
+from typing import Final
+
+import numpy as np
+import spead2
+import spead2.recv.asyncio
+from katsdpsigproc.abc import AbstractContext
+from katsdptelstate.endpoint import Endpoint
+
+from katgpucbf import COMPLEX
+from katgpucbf.spead import BF_RAW_ID, FREQUENCY_ID, TIMESTAMP_ID
+from katgpucbf.xbgpu.bsend import BSend
+from katgpucbf.xbgpu.output import BOutput
+
+HEAPS_PER_FENG_PER_CHUNK: Final[int] = 5
+n_channels_per_substream = 512
+channel_offset = n_channels_per_substream * 2
+n_spectra_per_heap = 256
+TIMESTAMP_STEP: Final[int] = n_channels_per_substream * n_spectra_per_heap
+N_TX_ITEMS: Final[int] = 2
+TOTAL_HEAPS: Final[int] = N_TX_ITEMS * HEAPS_PER_FENG_PER_CHUNK
+
+
+class TestBSend:
+    """Test :class:`katgpucbf.xbgpu.bsend.BSend`."""
+
+    @staticmethod
+    async def _send_data(send_stream: BSend) -> None:
+        """Send a fixed number of heaps.
+
+        More specifically, send `N_TX_ITEMS` Chunks, each of which contain
+        `HEAPS_PER_FENG_PER_CHUNK` heaps.
+        """
+        # Send the descriptors as the recv_stream object needs it to
+        # interpret the received heaps correctly.
+        await send_stream.stream.async_send_heap(send_stream.descriptor_heap)
+
+        for i in range(N_TX_ITEMS):
+            # Get a free heap - there is not always a free one available. This
+            # function yields until one it available.
+            chunk = await send_stream.get_free_chunk()
+
+            # Populate the buffer with dummy data.
+            chunk.data.fill(0)
+
+            # Give the chunk back to the send_stream to transmit out
+            # onto the network.
+            # TODO: The `timestamp` needs some attention, maybe replicate actual use?
+            # Need some kind of `n_samples_between_spectra` to dictate the
+            # `rx_heap_timestamp_step` that's used in 'reality'.
+            chunk.timestamp = i * TIMESTAMP_STEP
+            send_stream.send_chunk(chunk)
+        # send_heap just queues data for sending but is non-blocking.
+        # Flush to ensure that the data all gets sent before we return.
+        await send_stream.stream.async_flush()
+
+    @staticmethod
+    async def _recv_data(
+        recv_stream: spead2.recv.asyncio.Stream,
+        channel_offset: int,
+        n_channels_per_substream: int,
+        n_spectra_per_heap: int,
+    ) -> None:
+        """Receive data transmitted from :func:`_send_data`.
+
+        Error-check data here as well.
+        """
+        ig = spead2.ItemGroup()
+
+        # Wait for the first packet to arrive - it is expected to be the
+        # SPEAD descriptor.
+        heap = await recv_stream.get()
+        # TODO: No checks on the count sequence yet
+        items = ig.update(heap)
+        assert items == {}, "This heap contains item values not just the expected descriptors."
+
+        # Check the data heaps
+        zero_data = np.zeros(shape=(n_channels_per_substream, n_spectra_per_heap, COMPLEX), dtype=np.int8)
+        for i in range(TOTAL_HEAPS):
+            heap = await recv_stream.get()
+            items = ig.update(heap)
+            assert set(items.keys()) == {"timestamp", "frequency", "bf_raw"}
+            assert items["timestamp"].id == TIMESTAMP_ID
+            assert items["timestamp"].value == i * TIMESTAMP_STEP
+            assert items["frequency"].id == FREQUENCY_ID
+            assert items["frequency"].value == channel_offset
+            assert items["bf_raw"].id == BF_RAW_ID
+            assert items["bf_raw"].value.shape == (n_channels_per_substream, n_spectra_per_heap, COMPLEX)
+            assert items["bf_raw"].value.dtype == np.int8
+            np.testing.assert_equal(items["bf_raw"].value, zero_data)
+
+    async def test_send_simple(self, context: AbstractContext) -> None:
+        """
+        Test :class:`katgpucbf.xbgpu.bsend.BSend`.
+
+        This test transmits a number of heaps from a BSend object over a spead2
+        in-process transport. The received heaps are then checked.
+
+        This test does not generate random data as it will take much more compute
+        to check that the random data is received correctly.
+
+        Parameters
+        ----------
+        context
+            Device context for allocating buffers.
+        """
+        queue = spead2.InprocQueue()
+        send_stream = BSend(
+            output=BOutput(name="test", dst=Endpoint("localhost", 7150)),
+            heaps_per_fengine_per_chunk=HEAPS_PER_FENG_PER_CHUNK,
+            n_tx_items=N_TX_ITEMS,
+            n_channels_per_substream=n_channels_per_substream,
+            spectra_per_heap=n_spectra_per_heap,
+            send_rate_factor=0.0,
+            channel_offset=channel_offset,
+            context=context,
+            stream_factory=lambda stream_config, buffers: spead2.send.asyncio.InprocStream(
+                spead2.ThreadPool(1), [queue], stream_config
+            ),
+            tx_enabled=True,
+        )
+        await self._send_data(send_stream)
+        queue.stop()
+
+        recv_stream = spead2.recv.asyncio.Stream(spead2.ThreadPool(1), spead2.recv.StreamConfig())
+        recv_stream.add_inproc_reader(queue)
+        await self._recv_data(recv_stream, channel_offset, n_channels_per_substream, n_spectra_per_heap)

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -618,7 +618,9 @@ class TestEngine:
                 np.testing.assert_equal(expected_output, device_result)
             incomplete_accums_counters.append(incomplete_accums_counter)
 
-        xpipelines: list[XPipeline] = [pipeline for pipeline in xbengine._pipelines if isinstance(pipeline, XPipeline)]
+        xpipelines: list[XPipeline] = [
+            pipeline for pipeline in xbengine._pipelines if isinstance(pipeline, XPipeline)  # type: ignore
+        ]
         for pipeline, device_result, incomplete_accums_counter in zip(
             xpipelines, device_results, incomplete_accums_counters
         ):

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -614,9 +614,7 @@ class TestEngine:
                 np.testing.assert_equal(expected_output, device_result)
             incomplete_accums_counters.append(incomplete_accums_counter)
 
-        xpipelines: list[XPipeline] = [
-            pipeline for pipeline in xbengine._pipelines if isinstance(pipeline, XPipeline)  # type: ignore
-        ]
+        xpipelines: list[XPipeline] = [pipeline for pipeline in xbengine._pipelines if isinstance(pipeline, XPipeline)]
         for pipeline, device_result, incomplete_accums_counter in zip(
             xpipelines, device_results, incomplete_accums_counters
         ):


### PR DESCRIPTION
As the title suggests, this aims to put in place some of the minimum infrastructure required to
run a Beamformer. Comments on NGC-1011 (and related tickets) will perhaps provide more detailed
info on some decisions. 
* This PR only addresses support for a single `--beam`; although,
* I have tried to make provision for multiple beams/outputs where it didn't require too much renovation. 
* Furthermore, it is currently configured to only transmit zeroed data via its BSend.
* There is a corresponding `test_bsend.py` to test this specific functionality (in its current, zeroed guise).

Areas of concern/seeking feedback include (but are not limited to)
* `saturated` array configuration (specifically its `shape`),
* How to 'verify' I've provisioned enough in the actual `spead2...AsyncStream` for high speed data transmission (e.g. `max_heaps`),
* A method of handling `capture-enable` for the eventual multiple `--beam`s/substreams within the BSend,

I've left quite a few `TODOs` in, mostly to grab the reviewer's attention in case I don't mention it here.

More admin-related, I'm not entirely trusting of `sphinx-apidoc -o doc/ src/` as it didn't pick up/automatically
generate a `.rst` file for `katgpucbf.xbgpu.bsend` (when I ran it on `gareth`).
* I didn't want to commit the file created by hand, but let me know if I should do that anyway.

EDIT: Also unsure if I should start with a corresponding katsdpcontroller update just yet (which is why I left it unchecked and without an `(N/A)`).

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [ ] If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [ ] If design has changed: ensure documentation is up to date
- [ ] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1011 and NGC-1139.
