### PR TITLE
Rework memcpy_loop microbenchmark

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,6 +80,16 @@ pipeline {
           }
         }
 
+        stage('Compile and test memcpy_loop') {
+          steps {
+            dir('scratch') {
+              sh 'make clean'
+              sh 'make'
+              sh './memcpy_loop -T'
+            }
+          }
+        }
+
         /* This stage ensures that all the python style guidelines checks pass.
          * This will catch if someone has committed to the repo without
          * installing the required pre-commit hooks, or has bypassed them.

--- a/scratch/Makefile
+++ b/scratch/Makefile
@@ -1,5 +1,5 @@
 CXX = g++
-CXXFLAGS = -Wall -O2 -pthread
+CXXFLAGS = -std=c++17 -Wall -O2 -pthread
 TARGETS = memcpy_loop
 
 all: $(TARGETS)

--- a/scratch/Makefile
+++ b/scratch/Makefile
@@ -1,5 +1,5 @@
 CXX = g++
-CXXFLAGS = -std=c++17 -Wall -O2 -pthread
+CXXFLAGS = -std=c++17 -Wall -O3 -pthread
 TARGETS = memcpy_loop
 
 all: $(TARGETS)

--- a/scratch/memcpy_loop.cpp
+++ b/scratch/memcpy_loop.cpp
@@ -14,6 +14,34 @@
  * limitations under the License.
  ******************************************************************************/
 
+/**
+ * Memory copy micro-benchmark. It is designed to test both the memory
+ * thoughput of a system and of various subsets of cores, as well as to
+ * test various methods of performing a copy.
+ *
+ * The command-line takes a list of cores on which to run copies, as well
+ * as the following options:
+ *
+ * -t: memory allocation method (malloc/mmap/mmap_huge/madv_huge)
+ * -f: memory copy function (see below)
+ * -p: number of times to do a copy before printing a rate
+ * -r: number of times to run -p passes and print a rate (default is infinite)
+ * -b: size of the buffer to copy
+ * -S: an offset to add to the source address
+ * -D: an offset to add to the destination address
+ * -T: run a test to ensure that the chosen copy function works
+ *
+ * The supported functions are:
+ *
+ * - memcpy: the library memcpy implementation
+ * - memcpy_stream_sse2/memory_stream_avx/memory_stream_avx512: SIMD copies,
+ *     using streaming stores
+ * - memcpy_rep_movsb: use the x86 "REP MOVSB" instruction
+ * - memset: use library memset to clear the destination
+ * - memset: use SSE2 streaming stores to clear the destination
+ * - read: just read the source (using SSE2) and do not write anything
+ */
+
 #include <iostream>
 #include <vector>
 #include <cassert>

--- a/scratch/memcpy_loop.cpp
+++ b/scratch/memcpy_loop.cpp
@@ -29,7 +29,7 @@
  * -b: size of the buffer to copy
  * -S: an offset to add to the source address
  * -D: an offset to add to the destination address
- * -T: run a test to ensure that the chosen copy function works
+ * -T: run tests of the function implementations
  *
  * The supported functions are:
  *
@@ -64,7 +64,7 @@ using namespace std;
 using namespace std::chrono;
 using namespace std::literals::string_literals;
 
-static constexpr std::size_t cache_line_size = 64;  // guesstimate
+static constexpr size_t cache_line_size = 64;  // guesstimate
 
 enum class memory_type
 {
@@ -86,45 +86,71 @@ enum class memory_function
     READ
 };
 
+enum class memory_function_type
+{
+    MEMCPY,
+    MEMSET,
+    READ
+};
+
+static const struct
+{
+    memory_type value;
+    string name;
+} memory_types[] = {
+    { memory_type::MALLOC, "malloc"s },
+    { memory_type::MMAP, "mmap"s },
+    { memory_type::MMAP_HUGE, "mmap_huge"s },
+    { memory_type::MADV_HUGE, "madv_huge"s },
+};
+
+static const struct
+{
+    memory_function value;
+    memory_function_type type;
+    string name;
+    bool supported;
+} memory_functions[] = {
+    { memory_function::MEMCPY, memory_function_type::MEMCPY, "memcpy", true },
+    { memory_function::MEMCPY_STREAM_SSE2, memory_function_type::MEMCPY, "memcpy_stream_sse2", bool(__builtin_cpu_supports("sse2")) },
+    { memory_function::MEMCPY_STREAM_AVX, memory_function_type::MEMCPY, "memcpy_stream_avx", bool(__builtin_cpu_supports("avx")) },
+    { memory_function::MEMCPY_STREAM_AVX512, memory_function_type::MEMCPY, "memcpy_stream_avx512", bool(__builtin_cpu_supports("avx512f")) },
+    { memory_function::MEMCPY_REP_MOVSB, memory_function_type::MEMCPY, "memcpy_rep_movsb", true },
+    { memory_function::MEMSET, memory_function_type::MEMSET, "memset", true },
+    { memory_function::MEMSET_STREAM_SSE2, memory_function_type::MEMSET, "memset_stream_sse2", bool(__builtin_cpu_supports("sse2")) },
+    { memory_function::READ, memory_function_type::READ, "read", true },
+};
+
+template<typename T, typename V>
+static const auto &enum_lookup(T first, T last, V value)
+{
+    for (T it = first; it != last; ++it)
+        if (it->value == value)
+            return *it;
+    abort();
+}
+
 static string memory_type_name(memory_type type)
 {
-    switch (type)
-    {
-    case memory_type::MALLOC:    return "malloc";
-    case memory_type::MMAP:      return "mmap";
-    case memory_type::MMAP_HUGE: return "mmap_huge";
-    case memory_type::MADV_HUGE: return "madv_huge";
-    default: abort();
-    }
+    return enum_lookup(begin(memory_types), end(memory_types), type).name;
 }
 
 static string memory_function_name(memory_function func)
 {
-    switch (func)
-    {
-    case memory_function::MEMCPY: return "memcpy";
-    case memory_function::MEMCPY_STREAM_SSE2: return "memcpy_stream_sse2";
-    case memory_function::MEMCPY_STREAM_AVX: return "memcpy_stream_avx";
-    case memory_function::MEMCPY_STREAM_AVX512: return "memcpy_stream_avx512";
-    case memory_function::MEMCPY_REP_MOVSB: return "memcpy_rep_movsb";
-    case memory_function::MEMSET: return "memset";
-    case memory_function::MEMSET_STREAM_SSE2: return "memset_stream_sse2";
-    case memory_function::READ:   return "read";
-    default: abort();
-    }
+    return enum_lookup(begin(memory_functions), end(memory_functions), func).name;
 }
 
-static char *allocate(std::size_t size, memory_type type)
+static char *allocate(size_t size, memory_type type)
 {
     void *addr;
     if (type == memory_type::MALLOC)
     {
         // Ensure at least cache line alignment
-        std::size_t space = size + cache_line_size;
+        size_t space = size + cache_line_size;
         addr = malloc(size + cache_line_size);
         if (addr == nullptr)
-            throw std::bad_alloc();
-        std::align(cache_line_size, size, addr, space);
+            throw bad_alloc();
+        align(cache_line_size, size, addr, space);
     }
     else
     {
@@ -133,7 +159,7 @@ static char *allocate(std::size_t size, memory_type type)
             flags |= MAP_HUGETLB;
         addr = mmap(NULL, size, PROT_READ | PROT_WRITE, flags, -1, 0);
         if (addr == MAP_FAILED)
-            throw std::bad_alloc();
+            throw bad_alloc();
         if (type == memory_type::MADV_HUGE)
             madvise(addr, size, MADV_HUGEPAGE);
     }
@@ -147,33 +173,33 @@ static char *allocate(std::size_t size, memory_type type)
  * - dest is aligned to a multiple of A
  * - n is a multiple of M
  */
-template<std::size_t A, std::size_t M, typename F>
-static void *memcpy_align(void * __restrict__ dest, const void * __restrict__ src, std::size_t n, const F &inner) noexcept
+template<size_t A, size_t M, typename F>
+static void *memcpy_align(void * __restrict__ dest, const void * __restrict__ src, size_t n, const F &inner) noexcept
 {
     static_assert(A > 0 && !(A & (A - 1)), "A must be a power of 2");
     static_assert(M > 0 && !(M & (M - 1)), "M must be a power of 2");
 
     void *aligned_dest = dest;
     const void *aligned_src = src;  // not necessarily aligned, but corresponds to aligned_dest
-    std::size_t aligned_n = n;
-    if (!std::align(A, M, aligned_dest, aligned_n))
+    size_t aligned_n = n;
+    if (!align(A, M, aligned_dest, aligned_n))
     {
         // Not even room for one aligned block. Just fall back to plain memcpy
         return std::memcpy(dest, src, n);
     }
     // Copy the head
-    std::size_t head = (char *) aligned_dest - (char *) dest;
+    size_t head = (char *) aligned_dest - (char *) dest;
     if (head != 0)
     {
         std::memcpy(dest, src, head);
         aligned_src = (const void *) ((const char *) src + head);
     }
     // Round aligned_n down to a multiple of M
-    std::size_t truncated_n = aligned_n & ~(M - 1);
+    size_t truncated_n = aligned_n & ~(M - 1);
 
     inner(aligned_dest, aligned_src, truncated_n);
 
-    std::size_t tail = aligned_n - truncated_n;
+    size_t tail = aligned_n - truncated_n;
     if (tail != 0)
     {
         std::memcpy(
@@ -187,11 +213,11 @@ static void *memcpy_align(void * __restrict__ dest, const void * __restrict__ sr
 }
 
 // memcpy, with SSE2 streaming stores (requires dest to be 16-byte aligned and n to be a multiple of 64)
-static void *memcpy_stream_sse2_impl(void * __restrict__ dest, const void * __restrict__ src, std::size_t n) noexcept
+static void *memcpy_stream_sse2_impl(void * __restrict__ dest, const void * __restrict__ src, size_t n) noexcept
 {
     char * __restrict__ dest_c = (char *) dest;
     const char * __restrict__ src_c = (const char *) src;
-    for (std::size_t offset = 0; offset + 64 <= n; offset += 64)
+    for (size_t offset = 0; offset + 64 <= n; offset += 64)
     {
         __m128i value0 = _mm_loadu_si128((__m128i const *) (src_c + offset + 0));
         __m128i value1 = _mm_loadu_si128((__m128i const *) (src_c + offset + 16));
@@ -206,18 +232,18 @@ static void *memcpy_stream_sse2_impl(void * __restrict__ dest, const void * __re
     return dest;
 }
 
-static void *memcpy_stream_sse2(void * __restrict__ dest, const void * __restrict__ src, std::size_t n) noexcept
+static void *memcpy_stream_sse2(void * __restrict__ dest, const void * __restrict__ src, size_t n) noexcept
 {
     return memcpy_align<cache_line_size, 64>(dest, src, n, memcpy_stream_sse2_impl);
 }
 
 // memcpy, with AVX streaming stores (requires dest to be 32-byte aligned and n to be a multiple of 64)
 [[gnu::target("avx2")]]
-static void *memcpy_stream_avx_impl(void * __restrict__ dest, const void * __restrict__ src, std::size_t n) noexcept
+static void *memcpy_stream_avx_impl(void * __restrict__ dest, const void * __restrict__ src, size_t n) noexcept
 {
     char * __restrict__ dest_c = (char *) dest;
     const char * __restrict__ src_c = (const char *) src;
-    std::size_t offset = 0;
+    size_t offset = 0;
     for (offset = 0; offset + 256 <= n; offset += 256)
     {
         __m256i value0 = _mm256_loadu_si256((__m256i const *) (src_c + offset + 32 * 0));
@@ -248,18 +274,18 @@ static void *memcpy_stream_avx_impl(void * __restrict__ dest, const void * __res
     return dest;
 }
 
-static void *memcpy_stream_avx(void * __restrict__ dest, const void * __restrict__ src, std::size_t n) noexcept
+static void *memcpy_stream_avx(void * __restrict__ dest, const void * __restrict__ src, size_t n) noexcept
 {
     return memcpy_align<cache_line_size, 64>(dest, src, n, memcpy_stream_avx_impl);
 }
 
 // memcpy, with AVX-512 streaming stores (requires 64-byte alignment)
 [[gnu::target("avx512f")]]
-static void *memcpy_stream_avx512_impl(void * __restrict__ dest, const void * __restrict__ src, std::size_t n) noexcept
+static void *memcpy_stream_avx512_impl(void * __restrict__ dest, const void * __restrict__ src, size_t n) noexcept
 {
     char * __restrict__ dest_c = (char *) dest;
     const char * __restrict__ src_c = (const char *) src;
-    std::size_t offset = 0;
+    size_t offset = 0;
     for (offset = 0; offset + 512 <= n; offset += 512)
     {
         __m512i value0 = _mm512_loadu_si512((__m512i const *) (src_c + offset + 64 * 0));
@@ -288,12 +314,12 @@ static void *memcpy_stream_avx512_impl(void * __restrict__ dest, const void * __
     return dest;
 }
 
-static void *memcpy_stream_avx512(void * __restrict__ dest, const void * __restrict__ src, std::size_t n) noexcept
+static void *memcpy_stream_avx512(void * __restrict__ dest, const void * __restrict__ src, size_t n) noexcept
 {
     return memcpy_align<64, 64>(dest, src, n, memcpy_stream_avx512_impl);
 }
 
-static void *memcpy_rep_movsb(void * __restrict__ dest, const void * __restrict__ src, std::size_t n) noexcept
+static void *memcpy_rep_movsb(void * __restrict__ dest, const void * __restrict__ src, size_t n) noexcept
 {
     void *orig_dest = dest;
     asm volatile("rep movsb" : "+c" (n), "+D" (dest), "+S" (src) : : "memory");
@@ -301,7 +327,7 @@ static void *memcpy_rep_movsb(void * __restrict__ dest, const void * __restrict_
 }
 
 /* memset, but using SSE streaming stores */
-static void memset_stream_sse2(void *dst, int c, std::size_t bytes) noexcept
+static void memset_stream_sse2(void *dst, int c, size_t bytes) noexcept
 {
     // Simplifies some edge cases
     if (bytes <= 16)
@@ -312,7 +338,7 @@ static void memset_stream_sse2(void *dst, int c, std::size_t bytes) noexcept
 
     // Process prefix up to 16-byte alignment
     char *cdst = (char *) dst;
-    char *cdst_round = (char *) ((std::uintptr_t(dst) + 0xf) & ~0xf);
+    char *cdst_round = (char *) ((uintptr_t(dst) + 0xf) & ~0xf);
     if (cdst != cdst_round)
     {
         std::memset(dst, c, cdst_round - cdst);
@@ -338,12 +364,12 @@ static void memset_stream_sse2(void *dst, int c, std::size_t bytes) noexcept
 }
 
 /* Read all the data in [src, src + bytes) and do nothing with it. */
-static void memory_read(const void *src, std::size_t bytes) noexcept
+static void memory_read(const void *src, size_t bytes) noexcept
 {
-    std::uint8_t result1 = 0;
+    uint8_t result1 = 0;
     // Process prefix up to 16-byte alignment
     const char *csrc = (const char *) src;
-    while (((std::uintptr_t) csrc) & 0xf)
+    while (((uintptr_t) csrc) & 0xf)
     {
         result1 ^= *csrc++;
         bytes--;
@@ -373,7 +399,7 @@ static void memory_read(const void *src, std::size_t bytes) noexcept
     /* Dump the results into volatile variables to prevent the compiler
      * optimising the whole thing away.
      */
-    volatile std::uint8_t sink1 = result1;
+    volatile uint8_t sink1 = result1;
     volatile __m128i sink2 = result2;
     // Suppress unused variable warnings
     (void) sink1;
@@ -414,7 +440,7 @@ static void run_passes(
     memory_function mem_func,
     void * __restrict__ dest,
     const void * __restrict__ src,
-    std::size_t buffer_size
+    size_t buffer_size
 )
 {
     switch (mem_func)
@@ -453,52 +479,66 @@ static void run_passes(
     }
 }
 
-static void self_test(
-    memory_function mem_func,
-    void * __restrict__ dest,
-    void * __restrict__ src,
-    std::size_t buffer_size)
+static void self_test()
 {
-    std::mt19937 engine;
-    std::uniform_int_distribution<int> distribution(0, 255);
-    unsigned char *dest_c = static_cast<unsigned char *>(dest);
-    unsigned char *src_c = static_cast<unsigned char *>(src);
-    for (std::size_t i = 0; i < buffer_size; i++)
+    const size_t buffer_size = 12345;
+    const int tail = 64;  // elements to not copy at end
+    const byte dummy{123};  // value to write in guard regions
+    mt19937 engine;
+    uniform_int_distribution<int> distribution(0, 255);
+    // Test the copy functions
+    vector<byte> dest(buffer_size);
+    vector<byte> src(buffer_size);
+    vector<byte> backup;
+    for (size_t i = 0; i < buffer_size; i++)
+        src[i] = byte(distribution(engine));
+    backup = src;
+
+    for (const auto &m : memory_functions)
     {
-        dest_c[i] = distribution(engine);
-        src_c[i] = distribution(engine);
-    }
-    run_passes(1, mem_func, dest, src, buffer_size);
-    switch (mem_func)
-    {
-    case memory_function::MEMCPY:
-    case memory_function::MEMCPY_STREAM_SSE2:
-    case memory_function::MEMCPY_STREAM_AVX:
-    case memory_function::MEMCPY_STREAM_AVX512:
-    case memory_function::MEMCPY_REP_MOVSB:
-        // TODO: should also keep a backup copy to ensure that the src
-        // wasn't modified
-        assert(std::memcmp(dest, src, buffer_size) == 0);
-        break;
-    case memory_function::MEMSET:
-    case memory_function::MEMSET_STREAM_SSE2:
-        assert(std::size_t(std::count(dest_c, dest_c + buffer_size, 0)) == buffer_size);
-        break;
-    case memory_function::READ:
-        /* Not much one can test here */
-        break;
+        cout << "Testing " << m.name << " ... " << flush;
+        if (!m.supported)
+        {
+            cout << "skipped (no HW support)\n";
+            continue;
+        }
+        for (int head = 0; head <= 64; head++)
+        {
+            size_t n = buffer_size - head - tail;
+            fill(dest.begin(), dest.end(), dummy);
+            run_passes(1, m.value, dest.data() + head, src.data() + head, n);
+            // Check that the source didn't get modified
+            assert(equal(src.begin(), src.end(), backup.begin()));
+            // Check that the guard areas were not touched
+            assert(count(dest.begin(), dest.begin() + head, dummy) == head);
+            assert(count(dest.end() - tail, dest.end(), dummy) == tail);
+            switch (m.type)
+            {
+            case memory_function_type::MEMCPY:
+                // Check that the destination was written correctly
+                assert(equal(src.begin() + head, src.end() - tail, dest.begin() + head));
+                break;
+            case memory_function_type::MEMSET:
+                // Check that the destination was cleared
+                assert(size_t(count(dest.begin() + head, dest.end() - tail, byte(0))) == n);
+                break;
+            case memory_function_type::READ:
+                // Not much one can test here
+                break;
+            }
+        }
+        cout << "ok\n" << flush;
     }
 }
 
 static void worker(
     int core,
-    std::size_t buffer_size,
+    size_t buffer_size,
     memory_type mem_type,
     memory_function mem_func,
     int src_align,
     int dst_align,
     int passes,
-    bool do_self_test,
     thread_data &data
 )
 {
@@ -512,8 +552,6 @@ static void worker(
     }
     char *src = allocate(buffer_size + src_align, mem_type) + src_align;
     char *dst = allocate(buffer_size + dst_align, mem_type) + dst_align;
-    if (do_self_test)
-        self_test(mem_func, dst, src, buffer_size);
     post(data.done_sem);  // Tell the main thread we're ready for work
     while (true)
     {
@@ -525,13 +563,30 @@ static void worker(
     }
 }
 
+template<typename T>
+auto parse_enum(T first, T last, const string &value, const string &description)
+{
+    for (T it = first; it != last; ++it)
+        if (it->name == value)
+            return it->value;
+    cerr << "Invalid " << description << " (must be ";
+    for (T it = first; it != last; ++it)
+    {
+        if (it != first)
+            cerr << " / ";
+        cerr << it->name;
+    }
+    cerr << ")\n";
+    exit(1);
+}
+
 int main(int argc, char *const argv[])
 {
     memory_type mem_type = memory_type::MMAP;
     memory_function mem_func = memory_function::MEMCPY;
-    std::size_t buffer_size = 128 * 1024 * 1024;
+    size_t buffer_size = 128 * 1024 * 1024;
     int src_align = 0, dst_align = 0;  // relative to cache line size
-    std::vector<int> cores;
+    vector<int> cores;
     long long passes = 10;
     long long repeats = -1;
     bool do_self_test = false;
@@ -541,42 +596,10 @@ int main(int argc, char *const argv[])
         switch (opt)
         {
         case 't':
-            if (optarg == "malloc"s)
-                mem_type = memory_type::MALLOC;
-            else if (optarg == "mmap"s)
-                mem_type = memory_type::MMAP;
-            else if (optarg == "mmap_huge"s)
-                mem_type = memory_type::MMAP_HUGE;
-            else if (optarg == "madv_huge"s)
-                mem_type = memory_type::MADV_HUGE;
-            else
-            {
-                std::cerr << "Invalid memory type (must be malloc, mmap, mmap_huge or madv_huge)\n";
-                return 1;
-            }
+            mem_type = parse_enum(begin(memory_types), end(memory_types), optarg, "memory type");
             break;
         case 'f':
-            if (optarg == "memcpy"s)
-                mem_func = memory_function::MEMCPY;
-            else if (optarg == "memcpy_stream_sse2"s)
-                mem_func = memory_function::MEMCPY_STREAM_SSE2;
-            else if (optarg == "memcpy_stream_avx"s)
-                mem_func = memory_function::MEMCPY_STREAM_AVX;
-            else if (optarg == "memcpy_stream_avx512"s)
-                mem_func = memory_function::MEMCPY_STREAM_AVX512;
-            else if (optarg == "memcpy_rep_movsb"s)
-                mem_func = memory_function::MEMCPY_REP_MOVSB;
-            else if (optarg == "memset"s)
-                mem_func = memory_function::MEMSET;
-            else if (optarg == "memset_stream_sse2"s)
-                mem_func = memory_function::MEMSET_STREAM_SSE2;
-            else if (optarg == "read"s)
-                mem_func = memory_function::READ;
-            else
-            {
-                std::cerr << "Invalid memory function (must be memcpy, memcpy_stream_sse2, memcpy_stream_avx, memcpy_stream_avx512, memset, memset_stream_sse2 or read)\n";
-                return 1;
-            }
+            mem_func = parse_enum(begin(memory_functions), end(memory_functions), optarg, "memory function");
             break;
         case 'b':
             buffer_size = atoll(optarg);
@@ -605,17 +628,28 @@ int main(int argc, char *const argv[])
     if (cores.empty())
         cores.push_back(-1);
 
-    std::cout << "Using " << cores.size() << " threads, each with " << buffer_size << " bytes of "
+    if (do_self_test)
+    {
+        self_test();
+        return 0;
+    }
+    if (!enum_lookup(begin(memory_functions), end(memory_functions), mem_func).supported)
+    {
+        cerr << "Memory function " << memory_function_name(mem_func) << " is not supported on this CPU\n";
+        return 1;
+    }
+
+    cout << "Using " << cores.size() << " threads, each with " << buffer_size << " bytes of "
         << memory_type_name(mem_type) << " memory (" << passes << " passes)\n";
-    std::cout << "Using function " << memory_function_name(mem_func) << '\n';
+    cout << "Using function " << memory_function_name(mem_func) << '\n';
 
     size_t n = cores.size();
-    std::vector<thread_data> data(n);
+    vector<thread_data> data(n);
     for (size_t i = 0; i < n; i++)
-        data[i].future = std::async(
+        data[i].future = async(
             std::launch::async, worker, cores[i],
             buffer_size, mem_type, mem_func, src_align, dst_align,
-            passes, do_self_test, std::ref(data[i])
+            passes, ref(data[i])
         );
 
     // Wait for all threads to signal they've finished the allocation

--- a/scratch/memcpy_loop.cpp
+++ b/scratch/memcpy_loop.cpp
@@ -39,7 +39,7 @@
  * - memcpy_stream_sse2/avx/avx512: SIMD copies, using streaming stores
  * - memcpy_rep_movsb: use the x86 "REP MOVSB" instruction
  * - memset: use library memset to clear the destination
- * - memset: use SSE2 streaming stores to clear the destination
+ * - memset_stream_sse2: use SSE2 streaming stores to clear the destination
  * - read: just read the source (using SSE2) and do not write anything
  */
 


### PR DESCRIPTION
There are lots of improvements:
- Add documentation to the top of the file
- More copy implementations (non-streaming SIMD copies, AVX512, REP MOVSB)
- Refactoring of the copy implementations so that the SIMD copies share most of their code
- Functions are listed in a table, reducing the number of switch statements and general boilerplate needed to add more functions
- Add -r option to limit number of times to run and print the copy rate
- Add -c option to allow the buffer size to be decoupled from the copy size
- Reorganise the self-test so that it tests all the functions
- Add the self-test to Jenkins

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Relates to NGC-1136.
