### PR TITLE
Update katsdpsigproc to 1.8.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
             'aiokatcp==1.8.0',
             'asyncssh==2.13.2',
             'dask==2023.7.1',
-            'katsdpsigproc==1.8.0',
+            'katsdpsigproc==1.8.1',
             'katsdptelstate==0.13',
             'numpy==1.24.4',
             # Note: actual pandas version is 2.0.3, but the stubs for it depend

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -132,7 +132,7 @@ katsdpservices==1.2
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   katgpucbf (setup.cfg)
-katsdpsigproc==1.8.0
+katsdpsigproc==1.8.1
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -136,7 +136,7 @@ katsdpservices==1.2
     # via
     #   -c requirements.txt
     #   katgpucbf (setup.cfg)
-katsdpsigproc==1.8.0
+katsdpsigproc==1.8.1
     # via
     #   -c requirements.txt
     #   katgpucbf (setup.cfg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ importlib-metadata==6.8.0
     # via dask
 katsdpservices==1.2
     # via katgpucbf (setup.cfg)
-katsdpsigproc==1.8.0
+katsdpsigproc==1.8.1
     # via katgpucbf (setup.cfg)
 katsdptelstate==0.13
     # via katgpucbf (setup.cfg)


### PR DESCRIPTION
Not a hard requirement, but it addresses a deprecation.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] (N/A) Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1135.
