### PR TITLE
Bump spead2 to 4.1.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
             'pandas-stubs==2.0.2.230605',
             'pyparsing==3.0.9',
             'pytest==7.4.0',
-            'spead2==4.1.0',
+            'spead2==4.1.1',
             'types-decorator==5.1.1',
             'types-docutils==0.18.1',
             'types-redis==4.6.0',  # Indirectly needed by katsdptelstate

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -321,7 +321,7 @@ six==1.16.0
     #   -c qualification/../requirements.txt
     #   katsdptelstate
     #   python-dateutil
-spead2==4.1.0
+spead2==4.1.1
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -327,7 +327,7 @@ six==1.16.0
     #   python-dateutil
 snowballstemmer==2.2.0
     # via sphinx
-spead2==4.1.0
+spead2==4.1.1
     # via
     #   -c requirements.txt
     #   katgpucbf (setup.cfg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -135,7 +135,7 @@ six==1.16.0
     # via
     #   katsdptelstate
     #   python-dateutil
-spead2==4.1.0
+spead2==4.1.1
     # via katgpucbf (setup.cfg)
 terminaltables==3.1.10
     # via aiomonitor


### PR DESCRIPTION
This adds the AVX and AVX-512 versions of streaming store.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] (N/A) Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1150.
