### PR TITLE
Adjust thread count for benchmark_fgpu

### DIFF
--- a/scratch/benchmarks/benchmark_fgpu.py
+++ b/scratch/benchmarks/benchmark_fgpu.py
@@ -129,12 +129,12 @@ def fgpu_factory(
         dst_chunk_jones = src_chunk_samples // 4
     if n == 1:
         interface = ",".join(server.interfaces[:2])
-        src_affinity = f"0,1,2,3,{qstep},{qstep + 1},{qstep + 2},{qstep + 3}"
+        src_affinity = f"0,1,{qstep},{qstep + 1}"
         dst_affinity = f"{2 * qstep}"
         other_affinity = f"{3 * qstep}"
     elif n == 2:
         interface = server.interfaces[index % len(server.interfaces)]
-        src_affinity = f"{my_cpus[0]},{my_cpus[1]},{my_cpus[hstep]},{my_cpus[hstep + 1]}"
+        src_affinity = f"{my_cpus[0]},{my_cpus[hstep]}"
         dst_affinity = f"{my_cpus[qstep]}"
         other_affinity = f"{my_cpus[hstep + qstep]}"
     else:


### PR DESCRIPTION
Using 4 threads for n=1 and 2 threads for n=2 seems to improve performance.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Relates to NGC-1120.
