### PR TITLE
Bring run-fgpu-hbw.sh up to date

### DIFF
--- a/scratch/fgpu/run-fgpu-hbw.sh
+++ b/scratch/fgpu/run-fgpu-hbw.sh
@@ -11,8 +11,8 @@ dst_affinity="8"
 dst_comp=$dst_affinity
 other_affinity="12"
 src="239.102.0.64+15:7148"
-dst="239.102.200.0+15:7148"
-nb_dst="239.102.216.0+15:7148"
+dst="239.102.200.0+63:7148"
+nb_dst="239.102.216.0+7:7148"
 katcp_port="7140"
 prom_port="7150"
 feng_id="0"
@@ -21,8 +21,9 @@ export CUDA_VISIBLE_DEVICES="$cuda1"
 
 set -x
 exec spead2_net_raw taskset -c $other_affinity fgpu \
-    --src-chunk-samples 67108864 \
+    --src-chunk-samples 134217728 \
     --dst-chunk-jones 33554432 \
+    --src-buffer=268435456 \
     --src-interface $iface1,$iface2 --src-ibv \
     --dst-interface $iface1,$iface2 --dst-ibv \
     --src-affinity $src_affinity --src-comp-vector=$src_comp \


### PR DESCRIPTION
- Set number of destination multicast groups to match run-fgpu.sh
- Set --src-buffer and --src-chunk-samples to match benchmark_fgpu.py
