### PR TITLE
Use larger receiver group window

### DIFF
--- a/src/katgpucbf/recv.py
+++ b/src/katgpucbf/recv.py
@@ -20,7 +20,7 @@ import ctypes
 import time
 import weakref
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -315,7 +315,7 @@ def make_stream_group(
     max_active_chunks: int,
     data_ringbuffer: spead2.recv.asyncio.ChunkRingbuffer,
     free_ringbuffer: spead2.recv.ChunkRingbuffer,
-    affinity: Iterable[int],
+    affinity: Sequence[int],
     stream_stats: list[str],
     user_data: np.ndarray,
     max_heap_extra: int = 0,

--- a/src/katgpucbf/recv.py
+++ b/src/katgpucbf/recv.py
@@ -360,7 +360,12 @@ def make_stream_group(
         max_heap_extra=max_heap_extra,
         place=layout.chunk_place(user_data),
     )
-    group_config = spead2.recv.ChunkStreamGroupConfig(max_chunks=max_active_chunks, eviction_mode=EVICTION_MODE)
+    max_chunks = max_active_chunks
+    # If there is more than one stream in the group, allow the group to have
+    # one extra active chunk to reduce inter-thread communication.
+    if len(affinity) > 1:
+        max_chunks += 1
+    group_config = spead2.recv.ChunkStreamGroupConfig(max_chunks=max_chunks, eviction_mode=EVICTION_MODE)
 
     group = spead2.recv.ChunkStreamRingGroup(group_config, data_ringbuffer, free_ringbuffer)
     for core in affinity:


### PR DESCRIPTION
This should remove the requirement for all the receiver threads to move
on to the next chunk in lock-step.

This makes a small improvement in performance (see NGC-1120) at some
cost in system memory (or GPU BAR memory, if using vkgdr).

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use sphinx-apidoc to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] |(N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1120.
