### PR TITLE
Add pol= parameter to --beam command-line option

### DIFF
--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -74,7 +74,7 @@ class BOutputDict(OutputDict, total=False):
     See :class:`OutputDict` for further information.
     """
 
-    pass
+    pol: int
 
 
 class XOutputDict(OutputDict, total=False):
@@ -123,14 +123,23 @@ def parse_beam(value: str) -> BOutput:
 
     - name
     - dst
+    - pol
     """
 
     def _field_callback(kws: BOutputDict, key: str, data: str) -> None:
-        raise ValueError(f"unknown key {key}")
+        match key:
+            case "pol":
+                kws[key] = int(data)
+                if kws[key] not in {0, 1}:
+                    raise ValueError("pol must be either 0 or 1")
+            case _:
+                raise ValueError(f"unknown key {key}")
 
     try:
         kws: BOutputDict = {}
         _parse_stream(value, kws, _field_callback)
+        if "pol" not in kws:
+            raise ValueError("pol is missing")
         return BOutput(**kws)
     except ValueError as exc:
         raise ValueError(f"--beam: {exc}") from exc
@@ -174,7 +183,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         default=[],
         action="append",
         metavar="KEY=VALUE[,KEY=VALUE...]",
-        help="Add a half-beam output (may be repeated). The required keys are: name, dst.",
+        help="Add a half-beam output (may be repeated). The required keys are: name, dst, pol.",
     )
     parser.add_argument(
         "--corrprod",

--- a/src/katgpucbf/xbgpu/output.py
+++ b/src/katgpucbf/xbgpu/output.py
@@ -41,4 +41,4 @@ class XOutput(Output):
 class BOutput(Output):
     """Static configuration for an output beam stream."""
 
-    pass
+    pol: int

--- a/test/xbgpu/test_bsend.py
+++ b/test/xbgpu/test_bsend.py
@@ -49,8 +49,8 @@ def time_converter() -> TimeConverter:
 def outputs() -> Sequence[BOutput]:
     """Simulate `--beam` configuration."""
     return [
-        BOutput(name="foo", dst=Endpoint("239.10.11.0", 7149)),
-        BOutput(name="bar", dst=Endpoint("239.10.12.0", 7149)),
+        BOutput(name="foo", dst=Endpoint("239.10.11.0", 7149), pol=0),
+        BOutput(name="bar", dst=Endpoint("239.10.12.0", 7149), pol=1),
     ]
 
 

--- a/test/xbgpu/test_main.py
+++ b/test/xbgpu/test_main.py
@@ -28,16 +28,18 @@ class TestParseBeam:
 
     def test_maximal(self) -> None:
         """Test with all valid arguments."""
-        assert parse_beam("name=beam1,dst=239.1.2.3:7148") == BOutput(
+        assert parse_beam("name=beam1,dst=239.1.2.3:7148,pol=1") == BOutput(
             name="beam1",
             dst=Endpoint("239.1.2.3", 7148),
+            pol=1,
         )
 
     @pytest.mark.parametrize(
         "missing,value",
         [
-            ("dst", "name=foo"),
-            ("name", "dst=239.1.2.3:7148"),
+            ("dst", "name=foo,pol=0"),
+            ("name", "dst=239.1.2.3:7148,pol=1"),
+            ("pol", "name=foo,dst=239.1.2.3:7148"),
         ],
     )
     def test_missing_key(self, missing: str, value: str) -> None:
@@ -48,12 +50,17 @@ class TestParseBeam:
     def test_duplicate_key(self) -> None:
         """Test with a key specified twice."""
         with pytest.raises(ValueError, match="--beam: name already specified"):
-            parse_beam("name=foo,name=bar,dst=239.1.2.3:7148")
+            parse_beam("name=foo,name=bar,dst=239.1.2.3:7148,pol=0")
 
     def test_invalid_key(self) -> None:
         """Test with an unknown key/value pair."""
         with pytest.raises(ValueError, match="--beam: unknown key fizz"):
-            parse_beam("fizz=buzz,name=foo,dst=239.1.2.3:7148")
+            parse_beam("fizz=buzz,name=foo,dst=239.1.2.3:7148,pol=0")
+
+    def test_bad_pol(self) -> None:
+        """Test with a polarisation value that isn't 0 or 1."""
+        with pytest.raises(ValueError, match="--beam: pol must be either 0 or 1"):
+            parse_beam("name=foo,dst=239.1.2.3:7148,pol=2")
 
 
 class TestParseCorrprod:


### PR DESCRIPTION
This determines which polarisation of each antennas goes into the calculation for the beam.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Relates to NGC-1115.
