### PR TITLE
Wire up the beamformer operation

### DIFF
--- a/doc/katgpucbf.mapped_array.rst
+++ b/doc/katgpucbf.mapped_array.rst
@@ -1,0 +1,7 @@
+katgpucbf.mapped\_array module
+==============================
+
+.. automodule:: katgpucbf.mapped_array
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/katgpucbf.rst
+++ b/doc/katgpucbf.rst
@@ -17,6 +17,7 @@ Submodules
 .. toctree::
    :maxdepth: 4
 
+   katgpucbf.mapped_array
    katgpucbf.meerkat
    katgpucbf.monitor
    katgpucbf.queue_item

--- a/src/katgpucbf/mapped_array.py
+++ b/src/katgpucbf/mapped_array.py
@@ -1,0 +1,64 @@
+################################################################################
+# Copyright (c) 2023, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Implement :class:`MappedArray`."""
+
+from dataclasses import dataclass
+
+import numpy as np
+import vkgdr
+from katsdpsigproc import accel
+from katsdpsigproc.abc import AbstractContext
+
+
+@dataclass
+class MappedArray:
+    """An array visible in the address space of both the host and the device.
+
+    The host view can be updated using normal numpy code, and the changes will
+    be visible to subsequently enqueued kernels on the device.
+    """
+
+    host: np.ndarray
+    device: accel.DeviceArray
+
+    @classmethod
+    def from_slot(cls, vkgdr_handle: vkgdr.Vkgdr, context: AbstractContext, slot: accel.IOSlotBase) -> "MappedArray":
+        """Allocate a :class:`MappedArray` to match a slot.
+
+        Parameters
+        ----------
+        vkgdr_handle
+            Handle for allocating memory from vkgdr. It must be created from the same device
+            as `context`.
+        context
+            CUDA context in which the device view will be used.
+        slot
+            Slot from which the dtype, shape and padded shape will be
+            extracted. The parameter is annotated as
+            :class:`~katsdpsigproc.accel.IOSlotBase` for convenience, but it
+            must actually be an instance of :class:`~katsdpsigproc.accel.IOSlot`.
+        """
+        assert isinstance(slot, accel.IOSlot)
+        padded_shape = slot.required_padded_shape()
+        n_bytes = int(np.prod(padded_shape)) * slot.dtype.itemsize
+        with context:
+            handle = vkgdr.pycuda.Memory(vkgdr_handle, n_bytes)
+        # Slice out the shape from the padded shape
+        index = tuple(slice(0, x) for x in slot.shape)
+        host = np.asarray(handle).view(slot.dtype).reshape(padded_shape)[index]
+        device = accel.DeviceArray(context, slot.shape, slot.dtype, padded_shape, raw=handle)
+        return cls(host=host, device=device)

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -137,7 +137,12 @@ class XTxQueueItem(QueueItem):
 
 
 class BTxQueueItem(QueueItem):
-    """Transmit queue item for the beamformer pipeline."""
+    """Transmit queue item for the beamformer pipeline.
+
+    The `buffer_device`, `weights` and `delays` must have the same shape and
+    type as the ``in``, ``weights`` and ``delays`` slots in
+    :class:`.Beamform`.
+    """
 
     def __init__(
         self,

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -1253,7 +1253,7 @@ class XBEngine(DeviceServer):
         delays
             A sequence of strings (one per input). Each string has the form
             ``delay:fringe-offset``, where ``delay`` is a delay in seconds, and
-            ``fringe-offset` is the net phase adjustment at the centre
+            ``fringe-offset`` is the net phase adjustment at the centre
             frequency (of the whole stream, not of this engine).
         """
         pipeline, stream_id = self._request_bpipeline(stream_name)

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -322,7 +322,7 @@ class BPipeline(Pipeline[BOutput, BTxQueueItem]):
             delays = MappedArray.from_slot(vkgdr_handle, context, self._beamform.slots["delays"])
             tx_item = BTxQueueItem(buffer_device, weights, delays)
             self._tx_free_item_queue.put_nowait(tx_item)
-        # These are the original weights, delays and gainsas provided by the
+        # These are the original weights, delays and gains as provided by the
         # user, rather than the processed values passed to the kernel.
         self._weights = np.ones((len(outputs), engine.n_ants), np.float64)
         self._delays = np.zeros((len(outputs), engine.n_ants, 2), np.float64)

--- a/test/xbgpu/test_beamform.py
+++ b/test/xbgpu/test_beamform.py
@@ -28,7 +28,7 @@ from katgpucbf.xbgpu.beamform import BeamformTemplate
 @numba.njit
 def quant(x):
     """Round to integer and clamp to [-127, 127]."""
-    return np.fmin(np.fmax(np.round(x), -127), 127)
+    return np.fmin(np.fmax(np.rint(x), -127), 127)
 
 
 @numba.njit

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -213,7 +213,7 @@ def generate_expected_beams(
         the first element is the delay in seconds and the second is the phase
         to be applied at the centre frequency.
     channel_spacing
-        Frequency difference between adjacent channels, in Hz
+        Frequency difference between adjacent channels, in Hz.
     centre_channel
         Index of the centre channel of the whole stream, relative to the first
         channel processed by this engine.
@@ -388,6 +388,8 @@ class TestEngine:
         Each full accumulation (for each corrprod-output) requires
         `heap_accumulation_threshold` batches of heaps. However, `batch_indices`
         is not required to contain full accumulations.
+
+        Results are returned for both correlation products and beams.
 
         Parameters
         ----------


### PR DESCRIPTION
The beamformer now works end-to-end, albeit without support for saturation or for missing input data.

I still need to write design documentation, but I'd like to wait until I've done some basic profiling/optimisation on the kernel. I haven't touched fake_servers.py because I assume all the beamformer functionality will get added there in one go.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [ ] If design has changed: ensure documentation is up to date
- [ ] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Relates to NGC-1115.
