### PR TITLE
Add xbgpu --bandwidth option

### DIFF
--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -403,9 +403,7 @@ class BPipeline(Pipeline[BOutput, BTxQueueItem]):
 
             # Recompute the weights and delays if necessary
             if tx_item.weights_version != self._weights_version:
-                # TODO: this should be a command-line parameter. This calculation only
-                # works for a critically-sampled PFB
-                channel_spacing = self.engine.adc_sample_rate_hz / self.engine.n_samples_between_spectra
+                channel_spacing = self.engine.bandwidth_hz / self.engine.n_channels_total
                 # The user provides a fringe phase for the centre frequency. We
                 # need to adjust that to the target fringe phase for the first
                 # channel processed by this engine (channel_offset_value).
@@ -865,6 +863,9 @@ class XBEngine(DeviceServer):
         set incorrectly, the packet spacing could be too large causing the
         pipeline to stall as heaps queue at the sender faster than they are
         sent.
+    bandwidth_hz
+        Total bandwidth across `n_channels_total` channels. This is used in
+        delay calculations.
     send_rate_factor
         Configure the spead2 sender with a rate proportional to this factor.
         This value is intended to dictate a data transmission rate slightly
@@ -944,6 +945,7 @@ class XBEngine(DeviceServer):
         katcp_host: str,
         katcp_port: int,
         adc_sample_rate_hz: float,
+        bandwidth_hz: float,
         send_rate_factor: float,
         n_ants: int,
         n_channels_total: int,
@@ -984,6 +986,7 @@ class XBEngine(DeviceServer):
 
         # Array configuration parameters
         self.adc_sample_rate_hz = adc_sample_rate_hz
+        self.bandwidth_hz = bandwidth_hz
         self.time_converter = TimeConverter(sync_epoch, adc_sample_rate_hz)
         self.n_ants = n_ants
         self.n_channels_total = n_channels_total

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -219,6 +219,11 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         help="Digitiser sample rate (Hz). If this value is set lower than the actual rate, the pipeline will stall.",
     )
     parser.add_argument(
+        "--bandwidth",
+        type=float,
+        help="Total bandwidth (Hz) of all channels (--channels) [computed assuming critically-sampled PFB].",
+    )
+    parser.add_argument(
         "--send-rate-factor",
         type=float,
         default=1.1,
@@ -348,6 +353,8 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
 
     if args.sample_bits != 8:
         parser.error("Only 8-bit values are currently supported.")
+    if args.bandwidth is None:
+        args.bandwidth = args.adc_sample_rate / args.samples_between_spectra * args.channels
 
     used_names = set()
     args.outputs = []
@@ -383,6 +390,7 @@ def make_engine(context: AbstractContext, args: argparse.Namespace) -> tuple[XBE
         katcp_host=args.katcp_host,
         katcp_port=args.katcp_port,
         adc_sample_rate_hz=args.adc_sample_rate,
+        bandwidth_hz=args.bandwidth,
         send_rate_factor=args.send_rate_factor,
         n_ants=args.array_size,
         n_channels_total=args.channels,

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -812,8 +812,7 @@ class TestEngine:
 
         assert actual_sensor_updates == expected_sensor_updates
 
-        # TODO (NGC-1169) have a separate command-line argument for this
-        channel_spacing = ADC_SAMPLE_RATE / n_samples_between_spectra
+        channel_spacing = xbengine.bandwidth_hz / xbengine.n_channels_total
         expected_beams = generate_expected_beams(
             batch_start_index,
             batch_end_index - batch_start_index,


### PR DESCRIPTION
This can be used to override the default calculation, should we ever need it.

Closes NGC-1169

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
