### PR TITLE
Eliminate use of importlib.resource.path

### DIFF
--- a/src/katgpucbf/xbgpu/correlation.py
+++ b/src/katgpucbf/xbgpu/correlation.py
@@ -116,8 +116,7 @@ class CorrelationTemplate:
         else:
             raise ValueError(f"ants_per_block must equal either 64 or 48, currently equal to {self._n_ants_per_block}.")
 
-        with importlib.resources.path("katgpucbf.xbgpu", "kernels") as kernels:
-            source = (kernels / "tensor_core_correlation_kernel.cu").read_text()
+        source = (importlib.resources.files(__package__) / "kernels" / "tensor_core_correlation_kernel.cu").read_text()
         program = context.compile(
             source,
             [


### PR DESCRIPTION
It's deprecated in Python 3.11.

Closes NGC-1164.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match