### PR TITLE
Qualification report fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,10 +106,11 @@ RUN pip install --no-deps "$(grep '^pycuda==' /tmp/katgpucbf/requirements.txt)" 
 FROM build-base as jenkins
 
 # docker so that Jenkins can build a Docker image
-# All the TeX stuff for building the documentation and qualification report
+# All the TeX and font stuff for building the docs and qualification report
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     docker.io \
     docker-buildx \
+    fonts-liberation2 \
     latexmk \
     lmodern \
     pdf2svg \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 ################################################################################
-# Copyright (c) 2021-2023, National Research Foundation (SARAO)
+# Copyright (c) 2021-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021-2023, National Research Foundation (SARAO)
+ * Copyright (c) 2021-2024, National Research Foundation (SARAO)
  *
  * Licensed under the BSD 3-Clause License (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy

--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -86,7 +86,7 @@ pipeline {
          sh '''
            spead2_net_raw pytest -v -c qualification/pytest-jenkins.ini qualification\
            --suppress-tests-failed-exit-code \
-           --image-override katgpucbf:harbor.sdp.kat.ac.za/cbf/katgpucbf:latest \
+           --image-override katgpucbf:${katgpucbf_image:-harbor.sdp.kat.ac.za/cbf/katgpucbf:latest} \
            --junitxml=result.xml
          '''
        }

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -272,13 +272,9 @@ def matplotlib_report_style() -> Generator[None, None, None]:
     """Set the style of all matplotlib plots."""
     with matplotlib.style.context("ggplot"), matplotlib.rc_context(
         {
-            "pgf.texsystem": "pdflatex",
             # Serif fonts better match the rest of the document
             "font.family": "serif",
-            # Clearing these make matplotlib assume the default LaTeX fonts
-            "font.serif": [],
-            "font.sans-serif": [],
-            "font.monospace": [],
+            "font.serif": ["Times New Roman"],
         }
     ):
         yield

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2022-2023, National Research Foundation (SARAO)
+# Copyright (c) 2022-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -275,7 +275,7 @@ def matplotlib_report_style() -> Generator[None, None, None]:
         {
             # Serif fonts better match the rest of the document
             "font.family": "serif",
-            "font.serif": ["Times New Roman"],
+            "font.serif": ["Liberation Serif"],
         }
     ):
         yield

--- a/qualification/report/generate_pdf.py
+++ b/qualification/report/generate_pdf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 ################################################################################
-# Copyright (c) 2022-2023, National Research Foundation (SARAO)
+# Copyright (c) 2022-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/qualification/report/generate_pdf.py
+++ b/qualification/report/generate_pdf.py
@@ -18,6 +18,7 @@
 
 """Generate a PDF based on the intermediate JSON output."""
 import argparse
+import base64
 import copy
 import json
 import logging
@@ -46,6 +47,7 @@ from pylatex import (
     NoEscape,
     Section,
     SmallText,
+    StandAloneGraphic,
     Subsection,
     Subsubsection,
     TextColor,
@@ -208,21 +210,21 @@ class Failure:
 
 
 @dataclass
-class Figure:
-    """A figure created by ``pdf_report.figure`` or ``pdf_report.raw_figure``."""
+class RawFigure:
+    """A figure created by ``pdf_report.raw_figure``."""
 
     code: str
 
-    def __post_init__(self) -> None:
-        # Matplotlib relies on commands with @ in them, and uses
-        # \makeatletter to change the category code. However, because of the
-        # way longtable and multicolumn interact, the content is scanned
-        # before the category code can be changed. Fix it by using \csname,
-        # which is more robust.
-        self.code = re.sub(r"\\(pgfsys@[a-z@]+)", r"\\csname \1\\endcsname", self.code)
+
+@dataclass
+class Figure:
+    """A figure created by ``pdf_report.figure``."""
+
+    content: bytes
+    type: str
 
 
-Item = Union[Detail, Failure, Figure]  # Any information provided inside a ``pdf_report.step``
+Item = Union[Detail, Failure, Figure, RawFigure]  # Any information provided inside a ``pdf_report.step``
 
 
 @dataclass
@@ -337,7 +339,9 @@ def _parse_item(item: dict) -> Item:
     elif msg_type == "failure":
         return Failure(item["message"], item["timestamp"])
     elif msg_type == "figure":
-        return Figure(item["code"])
+        return RawFigure(item["code"])
+    elif msg_type == "binary_figure":
+        return Figure(base64.standard_b64decode(item["content"]), item["type"])
     else:
         raise ValueError(f"Do not know how to parse item $msg_type of {msg_type!r}")
 
@@ -817,7 +821,7 @@ def _doc_outcome(section: Container, test_configuration: TestConfiguration, resu
             config_table.add_hline()
 
 
-def document_from_list(result_list: list, doc_id: str, *, make_report=True) -> Document:
+def document_from_list(result_list: list, doc_id: str, tmp_dir: pathlib.Path, *, make_report=True) -> Document:
     """Take a test result and generate a :class:`pylatex.Document` for a report.
 
     Parameters
@@ -826,6 +830,8 @@ def document_from_list(result_list: list, doc_id: str, *, make_report=True) -> D
         A list containing the test results.
     doc_id
         The document number that will be embedded into the PDF output.
+    tmp_dir
+        Temporary directory in which to write ancillary files.
     make_report
         Make a report rather than a procedure if true, a procedure rather than
         a report if false.
@@ -835,6 +841,7 @@ def document_from_list(result_list: list, doc_id: str, *, make_report=True) -> D
     doc
         A PyLatex document
     """
+    next_figure_id = 1
     test_configuration, results = parse(result_list)
     sort_results(test_configuration, results)
     requirements_verified = extract_requirements_verified(results)
@@ -903,10 +910,24 @@ def document_from_list(result_list: list, doc_id: str, *, make_report=True) -> D
                                                 NoEscape(cell),
                                             ]
                                         )
-                                    elif isinstance(item, Figure):
+                                    elif isinstance(item, RawFigure):
+                                        filename = f"figure{next_figure_id:04}.tex"
+                                        (tmp_dir / filename).write_text(item.code)
+                                        next_figure_id += 1
                                         mp = MiniPage(width=NoEscape(r"\textwidth"))
                                         mp.append(NoEscape(r"\center"))
-                                        mp.append(NoEscape(item.code))
+                                        mp.append(NoEscape(r"\input{" + filename + "}"))
+                                        procedure_table.add_row((MultiColumn(2, align="|c|", data=mp),))
+                                    elif isinstance(item, Figure):
+                                        filename = f"figure{next_figure_id:04}.{item.type}"
+                                        (tmp_dir / filename).write_bytes(item.content)
+                                        next_figure_id += 1
+                                        mp = MiniPage(width=NoEscape(r"\textwidth"))
+                                        mp.append(NoEscape(r"\center"))
+                                        # pagebox=artbox is needed because the images generated
+                                        # by matplotlib lack a CropBox and without it, graphicx
+                                        # will not fall back to anything else to determine the size.
+                                        mp.append(StandAloneGraphic(filename, "pagebox=artbox"))
                                         procedure_table.add_row((MultiColumn(2, align="|c|", data=mp),))
                                     procedure_table.add_hline()
 
@@ -989,21 +1010,22 @@ def main():
     result_list = list_from_json(args.input)
     if args.commit_id:
         print(test_image_commit(result_list))
-    doc = document_from_list(result_list, args.doc_id, make_report=args.make_report)
-    if args.pdf.endswith(".pdf"):
-        args.pdf = args.pdf[:-4]  # Strip .pdf suffix, because generate_pdf appends it
-    with tempfile.NamedTemporaryFile(mode="w", prefix="latexmkrc") as latexmkrc:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_dir = pathlib.Path(tmp_dir)
+        doc = document_from_list(result_list, args.doc_id, make_report=args.make_report, tmp_dir=tmp_dir)
+        if args.pdf.endswith(".pdf"):
+            args.pdf = args.pdf[:-4]  # Strip .pdf suffix, because generate_pdf appends it
+        latexmkrc = tmp_dir / "latexmkrc"
         # TODO: latexmk uses Perl, which has different string parsing to
         # Python. If the path contains both a single quote and a special
         # symbol it will not produce a valid Perl string.
         parent_dir = str(RESOURCE_PATH)
-        latexmkrc.write(f"ensure_path('TEXINPUTS', {parent_dir!r})\n")
-        latexmkrc.flush()
+        latexmkrc.write_text(f"ensure_path('TEXINPUTS', {parent_dir!r}, {str(tmp_dir)!r})\n")
         # Give TeX an order of magnitude more memory than usual. This is needed
         # to handle the reams of text generated for plots.
         os.environ.setdefault("buf_size", "2000000")
         os.environ.setdefault("extra_mem_top", "50000000")
-        doc.generate_pdf(args.pdf, compiler="latexmk", compiler_args=["--pdf", "-r", latexmkrc.name])
+        doc.generate_pdf(args.pdf, compiler="latexmk", compiler_args=["--pdf", "-r", str(latexmkrc)])
 
 
 if __name__ == "__main__":

--- a/qualification/reporter.py
+++ b/qualification/reporter.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2022-2023, National Research Foundation (SARAO)
+# Copyright (c) 2022-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/qualification/reporter.py
+++ b/qualification/reporter.py
@@ -15,6 +15,7 @@
 ################################################################################
 
 """Mechanism for logging Pytest's output to a PDF."""
+import base64
 import io
 import logging
 import time
@@ -109,7 +110,7 @@ class Reporter:
         potentially contain tables too.
         """
         if self._cur_step is None:
-            raise ValueError("Cannot have figure without a current step")
+            raise ValueError("Cannot have raw_figure without a current step")
         value: dict[str, Any] = {"$msg_type": "figure", "code": code}
         if self._raw_data:
             value["data"] = data
@@ -123,10 +124,17 @@ class Reporter:
         figure
             The figure to plot
         """
+        if self._cur_step is None:
+            raise ValueError("Cannot have figure without a current step")
         data = []
         for ax in figure.axes:
             for line in ax.get_lines():
                 data.append(line.get_xydata().tolist())
-        content = io.StringIO()
-        figure.savefig(content, format="pgf", backend="pgf")
-        self.raw_figure(content.getvalue(), data=data)
+        content = io.BytesIO()
+        figure.savefig(content, format="pdf", backend="pdf")
+        # The .decode converts from bytes to str
+        content_b64 = base64.standard_b64encode(content.getvalue()).decode()
+        value: dict[str, Any] = {"$msg_type": "binary_figure", "content": content_b64, "type": "pdf"}
+        if self._raw_data:
+            value["data"] = data
+        self._cur_step.append(value)


### PR DESCRIPTION
Several modifications to the qualification report:

- Generate figures as PDFs at runtime, instead of as TeX code (faster test execution, much faster report generation, much smaller JSON files, slightly larger final report PDFs, fonts might not perfectly match between figures and text).
- When processing existing JSON files, write figure TeX code to temporary files which are included with `\input` (possibly fixes NGC-1182, and generally should be more robust to catcode changes in the figure TeX)
- Fix reporting of test_check failures (after a previous upgrade of pytest-check)
- Jenkins: allow the image to test to be overridden by an environment variable (in turn set by a parametrized build)

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report: [report-new-opt.pdf](https://github.com/ska-sa/katgpucbf/files/14011452/report-new-opt.pdf) (note, has been run through an optimiser to reduce the file size to fit within Github's limit)
- [x] If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1196.
