### PR TITLE
Change sample_tone_response to return float64

### DIFF
--- a/qualification/antenna_channelised_voltage/__init__.py
+++ b/qualification/antenna_channelised_voltage/__init__.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2022-2023, National Research Foundation (SARAO)
+# Copyright (c) 2022-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/qualification/antenna_channelised_voltage/__init__.py
+++ b/qualification/antenna_channelised_voltage/__init__.py
@@ -81,7 +81,6 @@ async def sample_tone_response_hdr(
         await correlator.product_controller_client.request("gain-all", "antenna-channelised-voltage", gain)
 
         data = await sample_tone_response(rel_freqs, amplitude, receiver)
-        data = data.astype(np.float64)
 
         # Store gain adjusted data for SFDR measurement.
         # Use current gain to capture spikes, then adjust gain.
@@ -160,7 +159,7 @@ async def sample_tone_response(
     freqs = receiver.center_freq + (np.asarray(rel_freqs) - receiver.n_chans / 2) * channel_width
     amplitude = np.asarray(amplitude)
     out_shape = np.broadcast_shapes(freqs.shape, amplitude.shape) + (receiver.n_chans,)
-    out = np.empty(out_shape, np.int32)
+    out = np.empty(out_shape, np.float64)
     # Each element is an (out_index, signal_spec) pair. When it fills up to the
     # number of antennas available, `flush` is called.
     tasks: list[tuple[tuple[int, ...], str]] = []
@@ -177,7 +176,7 @@ async def sample_tone_response(
             # In the absence of noise this should be purely real, but
             # due to quantization noise it is complex. Take the absolute
             # value.
-            out[task[0]] = np.hypot(data[:, bl_idx, 0], data[:, bl_idx, 1])
+            np.hypot(data[:, bl_idx, 0], data[:, bl_idx, 1], out=out[task[0]])
 
     with np.nditer([freqs, amplitude], flags=["multi_index"]) as it:
         for f, a in it:


### PR DESCRIPTION
It previously returned int32, which is probably left over from a previous implementation (where self-correlations were used and so it could directly return values computed by the X engine). The result is only used to two places:

- sample_tone_response_hdr, which immediately explicitly cast it to float64.
- test_linearity, which normalised it by dividing by the largest element, hence implicitly casting to float.

It has more recently started causing warnings (NGC-1182) when the result of np.hypot was greater than 2^31, which is expected to happen during sample_tone_response_hdr as the power is cranked up.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] (N/A) Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report: see http://10.8.80.22:8080/job/qualification_katgpucbf/540/
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1182.
