### PR TITLE
Make ibverbs optional for fsim

### DIFF
--- a/doc/control.rst
+++ b/doc/control.rst
@@ -143,7 +143,7 @@ single :ref:`feng-packet-sim` on ``host1`` and a single :program:`xbgpu`
 instance on ``host2``::
 
     [Connect to host1, navigate to the location of the fsim and build it using 'make']
-    user@host1:~/katgpucbf/src/tools$ spead2_net_raw ./fsim --interface <100GbE NIC IP> \
+    user@host1:~/katgpucbf/src/tools$ spead2_net_raw ./fsim --interface <100GbE NIC IP> --ibv \
                                       --array-size 4 --channels 4096 \
                                       --channels-per-substream 512 \
                                       --spectra-per-heap 256 \

--- a/doc/fsim.rst
+++ b/doc/fsim.rst
@@ -32,8 +32,12 @@ Where:
 
 The above command will transmit data at about `7.8 * (y+1)` Gbps by default.
 
-The ``fsim`` executable needs ``CAP_NET_RAW`` capability to run. The easiest
-way to do it is with ``spead2_net_raw``.
+For improved performance, use :option:`!--ibv` to enable ibverbs acceleration [#]_.
+This requires the ``CAP_NET_RAW`` capability to run. The easiest way to do it
+is with ``spead2_net_raw``.
 
 See the fsim source code (in ``src/tools/``) for a  detailed description of how the
 F-Engine simulator works and the useful configuration arguments.
+
+.. [#] See the spead2 documentation for information on the requirements
+   (particularly hardware requirements) for ibverbs.

--- a/src/tools/fsim.cpp
+++ b/src/tools/fsim.cpp
@@ -110,6 +110,12 @@ template <typename T> static boost::program_options::typed_value<T> *make_opt(T 
     return boost::program_options::value<T>(&var)->default_value(var);
 }
 
+// Overload that treats boolean options as argument-less flags
+static boost::program_options::typed_value<bool> *make_opt(bool &var)
+{
+    return boost::program_options::bool_switch(&var)->default_value(var);
+}
+
 // Parse command line parameters - this has been kludged together. It can probably be done in a neater way.
 static options parse_options(int argc, const char **argv)
 {

--- a/src/tools/fsim.cpp
+++ b/src/tools/fsim.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020-2021, National Research Foundation (SARAO)
+ * Copyright (c) 2020-2021, 2024 National Research Foundation (SARAO)
  *
  * Licensed under the BSD 3-Clause License (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy

--- a/src/tools/fsim.cpp
+++ b/src/tools/fsim.cpp
@@ -54,6 +54,8 @@
  * document.
  */
 
+#include <spead2/send_stream.h>
+#include <spead2/send_udp.h>
 #include <spead2/send_udp_ibv.h>
 
 #include <boost/program_options.hpp>
@@ -80,6 +82,7 @@ struct options
     int n_spectra_per_heap = 256;
     size_t packet_payload_size_bytes = 8192;
     bool run_once = false;
+    bool ibv = false;
 
     // The variables below are not command-line arguments, they are just calculated based on values provided by the
     // command line. This method of passing these arguments is a bit clunky, but I have not put effort into fixing it.
@@ -127,6 +130,7 @@ static options parse_options(int argc, const char **argv)
                        "The F-Engine cornerturn groups a number of samples into each channel per packet");
     desc.add_options()("dst-packet-payload", make_opt(opts.packet_payload_size_bytes),
                        "The number of payload bytes per packet");
+    desc.add_options()("ibv", make_opt(opts.ibv), "Use ibverbs acceleration");
     desc.add_options()("run-once", make_opt(opts.run_once), "Transmit a single collection of heaps before exiting");
     hidden.add_options()(
         "address", boost::program_options::value<std::string>(&opts.mcast_addr)->composing(),
@@ -329,7 +333,7 @@ struct fengines
     const bool run_once;
 
     // SPEAD 2 stream that every heap will be queued on.
-    spead2::send::udp_ibv_stream stream;
+    std::unique_ptr<spead2::send::stream> stream;
 
     /* Constructor for the fengines simulator.
      *
@@ -343,20 +347,37 @@ struct fengines
              const boost::asio::ip::address &interface_address, boost::asio::io_service &ios)
         : heaps_per_feng(opts.max_heaps), all_heaps(make_heaps(opts)), NUM_ANTS(opts.n_ants),
           timestamp_step(opts.timestamp_step), run_once(opts.run_once),
-          stream(ios,
-                 spead2::send::stream_config()
-                     .set_max_packet_size(opts.packet_payload_size_bytes + PACKET_HEADER_SIZE_BYTES)
-                     .set_rate(opts.adc_sample_rate * N_POLS * SAMPLE_BITS / 8.0 *
-                               opts.n_ants * opts.n_chans_per_output_stream / opts.n_chans_total *
-                               (opts.heap_size_bytes + opts.packets_per_heap * PACKET_HEADER_SIZE_BYTES) /
-                               opts.heap_size_bytes)
-                     .set_max_heaps(opts.max_heaps * opts.n_ants),
-                 spead2::send::udp_ibv_config()
-                     .set_endpoints(endpoints)
-                     .set_interface_address(interface_address)
-                     .set_ttl(opts.ttl)
-                     .set_memory_regions(get_memory_regions(opts, all_heaps)))
+          stream(make_stream(ios, opts, endpoints, interface_address, all_heaps))
     {
+    }
+
+    static std::unique_ptr<spead2::send::stream> make_stream(
+        boost::asio::io_service &ios,
+        const options &opts,
+        const std::vector<boost::asio::ip::udp::endpoint> &endpoints,
+        const boost::asio::ip::address &interface_address,
+        const std::vector<std::vector<heap_data>> &all_heaps)
+    {
+        auto stream_config = spead2::send::stream_config()
+            .set_max_packet_size(opts.packet_payload_size_bytes + PACKET_HEADER_SIZE_BYTES)
+            .set_rate(opts.adc_sample_rate * N_POLS * SAMPLE_BITS / 8.0 *
+                      opts.n_ants * opts.n_chans_per_output_stream / opts.n_chans_total *
+                      (opts.heap_size_bytes + opts.packets_per_heap * PACKET_HEADER_SIZE_BYTES) /
+                      opts.heap_size_bytes)
+            .set_max_heaps(opts.max_heaps * opts.n_ants);
+        if (opts.ibv)
+        {
+            auto udp_ibv_config = spead2::send::udp_ibv_config()
+                .set_endpoints(endpoints)
+                .set_interface_address(interface_address)
+                .set_ttl(opts.ttl)
+                .set_memory_regions(get_memory_regions(opts, all_heaps));
+            return std::make_unique<spead2::send::udp_ibv_stream>(ios, stream_config, udp_ibv_config);
+        }
+        else
+        {
+            return std::make_unique<spead2::send::udp_stream>(ios, endpoints, stream_config, opts.ttl, interface_address);
+        }
     }
 
     /* Registers all heap data in memory regions and returns a vector of these regions to be used by spead2.
@@ -432,9 +453,9 @@ struct fengines
         }
 
         bool queue_success =
-            stream.async_send_heaps(heaps_to_interleave.begin(), heaps_to_interleave.end(),
-                                    std::bind(&fengines::callback, this, std::placeholders::_1, std::placeholders::_2),
-                                    spead2::send::group_mode::ROUND_ROBIN);
+            stream->async_send_heaps(heaps_to_interleave.begin(), heaps_to_interleave.end(),
+                                     std::bind(&fengines::callback, this, std::placeholders::_1, std::placeholders::_2),
+                                     spead2::send::group_mode::ROUND_ROBIN);
         if (queue_success == false)
         {
             std::cerr << "Error: Heaps not queued succesfully on queue" << std::endl;


### PR DESCRIPTION
Add `--ibv` option to fsim, without which it will default to non-ibverbs. To support this, a pointer to the base class (`spead2::send::stream`) is used instead of embedding a concrete subclass into the `fengine` class.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
