### PR TITLE
Make provision for B-engine sensors

### DIFF
--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -379,6 +379,34 @@ class BPipeline(Pipeline[BOutput, BTxQueueItem]):
             # Dynamic sensors
             sensors.add(
                 aiokatcp.Sensor(
+                    str,
+                    f"{output.name}.delay",
+                    "The delay settings of the inputs for this beam: (loadmcnt"
+                    "<ADC sample count when model was loaded>, delay <in seconds>,"
+                    "phase <radians>, ...)",
+                    initial_status=aiokatcp.Sensor.Status.NOMINAL,
+                )
+            )
+            sensors.add(
+                aiokatcp.Sensor(
+                    float,
+                    f"{output.name}.quantiser-gain",
+                    "Non-complex post-summation quantiser gain applied to this beam",
+                    default=0.0,
+                    initial_status=aiokatcp.Sensor.Status.NOMINAL,
+                )
+            )
+            sensors.add(
+                aiokatcp.Sensor(
+                    str,
+                    f"{output.name}.weight",
+                    "The summing weights applied to all the inputs of this beam",
+                    default="",
+                    initial_status=aiokatcp.Sensor.Status.NOMINAL,
+                )
+            )
+            sensors.add(
+                aiokatcp.Sensor(
                     int,
                     f"{output.name}-beng-clip-cnt",
                     "Number of complex samples that saturated.",

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2023, National Research Foundation (SARAO)
+# Copyright (c) 2020-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -377,13 +377,16 @@ class BPipeline(Pipeline[BOutput, BTxQueueItem]):
                 )
             )
             # Dynamic sensors
+            # Using the zeroth values for defaults as they're all the same at the start
+            default_delays_str = ", ".join(str(value) for value in self._delays[0].flatten())
             sensors.add(
                 aiokatcp.Sensor(
                     str,
                     f"{output.name}.delay",
-                    "The delay settings of the inputs for this beam: (loadmcnt "
-                    "<ADC sample count when model was loaded>, delay <in seconds>, "
-                    "phase <radians>, ...)",
+                    "The delay settings of the inputs for this beam. Each input has "
+                    "a delay [s] and phase [rad]: (loadmcnt, delay0, phase0, delay1,"
+                    "phase1, ...)",
+                    default=f"(0, {default_delays_str})",
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,
                 )
             )
@@ -392,7 +395,7 @@ class BPipeline(Pipeline[BOutput, BTxQueueItem]):
                     float,
                     f"{output.name}.quantiser-gain",
                     "Non-complex post-summation quantiser gain applied to this beam",
-                    default=0.0,
+                    default=self._quant_gains[0],
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,
                 )
             )
@@ -401,6 +404,7 @@ class BPipeline(Pipeline[BOutput, BTxQueueItem]):
                     str,
                     f"{output.name}.weight",
                     "The summing weights applied to all the inputs of this beam",
+                    default=str(list(self._weights[0])),
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,
                 )
             )

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -364,7 +364,7 @@ class BPipeline(Pipeline[BOutput, BTxQueueItem]):
 
     def _populate_sensors(self) -> None:
         sensors = self.engine.sensors
-        for output in self.outputs:
+        for i, output in enumerate(self.outputs):
             # Static sensors
             sensors.add(
                 aiokatcp.Sensor(
@@ -377,8 +377,7 @@ class BPipeline(Pipeline[BOutput, BTxQueueItem]):
                 )
             )
             # Dynamic sensors
-            # Using the zeroth values for defaults as they're all the same at the start
-            default_delays_str = ", ".join(str(value) for value in self._delays[0].flatten())
+            default_delays_str = ", ".join(str(value) for value in self._delays[i].flatten())
             sensors.add(
                 aiokatcp.Sensor(
                     str,
@@ -395,7 +394,7 @@ class BPipeline(Pipeline[BOutput, BTxQueueItem]):
                     float,
                     f"{output.name}.quantiser-gain",
                     "Non-complex post-summation quantiser gain applied to this beam",
-                    default=self._quant_gains[0],
+                    default=self._quant_gains[i],
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,
                 )
             )
@@ -404,7 +403,8 @@ class BPipeline(Pipeline[BOutput, BTxQueueItem]):
                     str,
                     f"{output.name}.weight",
                     "The summing weights applied to all the inputs of this beam",
-                    default=str(list(self._weights[0])),
+                    # Cast to list first to add comma delimeter
+                    default=str(list(self._weights[i])),
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,
                 )
             )

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -401,7 +401,6 @@ class BPipeline(Pipeline[BOutput, BTxQueueItem]):
                     str,
                     f"{output.name}.weight",
                     "The summing weights applied to all the inputs of this beam",
-                    default="",
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,
                 )
             )

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -383,7 +383,7 @@ class BPipeline(Pipeline[BOutput, BTxQueueItem]):
                     str,
                     f"{output.name}.delay",
                     "The delay settings of the inputs for this beam. Each input has "
-                    "a delay [s] and phase [rad]: (loadmcnt, delay0, phase0, delay1,"
+                    "a delay [s] and phase [rad]: (loadmcnt, delay0, phase0, delay1, "
                     "phase1, ...)",
                     default=f"(0, {default_delays_str})",
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,
@@ -403,7 +403,7 @@ class BPipeline(Pipeline[BOutput, BTxQueueItem]):
                     str,
                     f"{output.name}.weight",
                     "The summing weights applied to all the inputs of this beam",
-                    # Cast to list first to add comma delimeter
+                    # Cast to list first to add comma delimiter
                     default=str(list(self._weights[i])),
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,
                 )

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -381,8 +381,8 @@ class BPipeline(Pipeline[BOutput, BTxQueueItem]):
                 aiokatcp.Sensor(
                     str,
                     f"{output.name}.delay",
-                    "The delay settings of the inputs for this beam: (loadmcnt"
-                    "<ADC sample count when model was loaded>, delay <in seconds>,"
+                    "The delay settings of the inputs for this beam: (loadmcnt "
+                    "<ADC sample count when model was loaded>, delay <in seconds>, "
                     "phase <radians>, ...)",
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,
                 )

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -408,7 +408,7 @@ class BPipeline(Pipeline[BOutput, BTxQueueItem]):
             sensors.add(
                 aiokatcp.Sensor(
                     int,
-                    f"{output.name}-beng-clip-cnt",
+                    f"{output.name}.beng-clip-cnt",
                     "Number of complex samples that saturated.",
                     default=0,
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,


### PR DESCRIPTION
There is no logic behind the sensors, this PR simply creates them in preparation for the logic.
* Where I've left defaults out, it's because I'm still not sure what the format of the value is.

The corresponding katsdpcontroller PR is at
* https://github.com/ska-sa/katsdpcontroller/pull/714

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-447.
