### PR TITLE
Adjust bsend rate to match # of enabled streams

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
             'pyparsing==3.0.9',
             'pytest==7.4.3',
             'redis==5.0.1',  # Indirect dependency of katsdptelstate
-            'spead2==4.1.1',
+            'spead2==4.3.0',
             'types-decorator==5.1.1',
             # Note: actual docutils version is 0.20.1, but types-docutils
             # doesn't have a release for that yet.

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -319,7 +319,7 @@ six==1.16.0
     #   -c qualification/../requirements.txt
     #   katsdptelstate
     #   python-dateutil
-spead2==4.1.1
+spead2==4.3.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -324,7 +324,7 @@ six==1.16.0
     #   python-dateutil
 snowballstemmer==2.2.0
     # via sphinx
-spead2==4.1.1
+spead2==4.3.0
     # via
     #   -c requirements.txt
     #   katgpucbf (setup.cfg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -133,7 +133,7 @@ six==1.16.0
     # via
     #   katsdptelstate
     #   python-dateutil
-spead2==4.1.1
+spead2==4.3.0
     # via katgpucbf (setup.cfg)
 terminaltables==3.1.10
     # via aiomonitor

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     prometheus-client>=0.4  # First version to auto-append _total to counter names
     pyparsing>=3.0.0
     scipy
-    spead2>=4.1.0
+    spead2>=4.3.0
     xarray
 python_requires = >=3.10
 

--- a/src/katgpucbf/xbgpu/bsend.py
+++ b/src/katgpucbf/xbgpu/bsend.py
@@ -177,7 +177,7 @@ class Chunk:
         if n_enabled > 0:
             send_futures = []
             for frame in self._frames:
-                # TODO: building this list every time may be too expensive.
+                # TODO (NGC-1232): building this list every time may be too expensive.
                 # Consider caching it and invalidating when streams are enabled/disabled.
                 heaps_to_send = [
                     spead2.send.HeapReference(heap, substream_index=i, rate=rate)


### PR DESCRIPTION
This updates spead2 to a newer version that implements the necessary feature.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1143.
