### PR TITLE
xbgpu: disable real-time scheduling for main thread

### DIFF
--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2023, National Research Foundation (SARAO)
+# Copyright (c) 2020-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -33,6 +33,7 @@ import argparse
 import asyncio
 import gc
 import logging
+import os
 from collections.abc import Callable, Sequence
 from typing import TypedDict, TypeVar
 
@@ -445,6 +446,10 @@ async def async_main(args: argparse.Namespace) -> None:
 
         add_signal_handlers(xbengine)
         add_gc_stats()
+        # katsdpcontroller launches us with real-time scheduling, but we don't
+        # want that for the main Python thread since it can starve the
+        # latency-sensitive network threads.
+        os.sched_setscheduler(0, os.SCHED_OTHER, os.sched_param(0))
 
         await xbengine.start()
         # Avoid garbage collections needing to iterate over all the objects


### PR DESCRIPTION
It is sharing the CPU with the transmit thread, and prevents the latter from being scheduled with the low latency it requires for accurate packet pacing. That causes the whole process to fall behind.

Relates to NGC-1232.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

