### PR TITLE
Add steady-state-timestamp sensor to xbengine

### DIFF
--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2023, National Research Foundation (SARAO)
+# Copyright (c) 2020-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -52,7 +52,13 @@ from ..queue_item import QueueItem
 from ..recv import RX_SENSOR_TIMEOUT_CHUNKS, RX_SENSOR_TIMEOUT_MIN
 from ..ringbuffer import ChunkRingbuffer
 from ..send import DescriptorSender
-from ..utils import DeviceStatusSensor, TimeConverter, add_time_sync_sensors, gaussian_dtype
+from ..utils import (
+    DeviceStatusSensor,
+    TimeConverter,
+    add_time_sync_sensors,
+    gaussian_dtype,
+    steady_state_timestamp_sensor,
+)
 from . import DIG_RMS_DBFS_HIGH, DIG_RMS_DBFS_LOW, INPUT_CHUNK_PADDING, recv, send
 from .compute import Compute, ComputeTemplate, NarrowbandConfig
 from .delay import AbstractDelayModel, AlignedDelayModel, LinearDelayModel, MultiDelayModel, wrap_angle
@@ -1303,17 +1309,7 @@ class Engine(aiokatcp.DeviceServer):
 
         for sensor in recv.make_sensors(rx_sensor_timeout).values():
             sensors.add(sensor)
-        sensors.add(
-            aiokatcp.Sensor(
-                int,
-                "steady-state-timestamp",
-                "Heaps with this timestamp or greater are guaranteed to "
-                "reflect the effects of previous katcp requests.",
-                default=0,
-                initial_status=aiokatcp.Sensor.Status.NOMINAL,
-            )
-        )
-
+        sensors.add(steady_state_timestamp_sensor())
         sensors.add(DeviceStatusSensor(sensors))
 
         time_sync_task = add_time_sync_sensors(sensors)

--- a/src/katgpucbf/utils.py
+++ b/src/katgpucbf/utils.py
@@ -298,7 +298,7 @@ def steady_state_timestamp_sensor() -> aiokatcp.Sensor[int]:
     return aiokatcp.Sensor(
         int,
         "steady-state-timestamp",
-        "Heaps with this timestamp or greater are guaranteed to " "reflect the effects of previous katcp requests.",
+        "Heaps with this timestamp or greater are guaranteed to reflect the effects of previous katcp requests.",
         default=0,
         initial_status=aiokatcp.Sensor.Status.NOMINAL,
     )

--- a/src/katgpucbf/utils.py
+++ b/src/katgpucbf/utils.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2023, National Research Foundation (SARAO)
+# Copyright (c) 2020-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -291,6 +291,17 @@ def add_time_sync_sensors(sensors: aiokatcp.SensorSet) -> asyncio.Task:
             await asyncio.sleep(MIN_SENSOR_UPDATE_PERIOD)
 
     return asyncio.create_task(run(), name=TIME_SYNC_TASK_NAME)
+
+
+def steady_state_timestamp_sensor() -> aiokatcp.Sensor[int]:
+    """Create ``steady-state-timestamp`` sensor."""
+    return aiokatcp.Sensor(
+        int,
+        "steady-state-timestamp",
+        "Heaps with this timestamp or greater are guaranteed to " "reflect the effects of previous katcp requests.",
+        default=0,
+        initial_status=aiokatcp.Sensor.Status.NOMINAL,
+    )
 
 
 class TimeConverter:

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -21,13 +21,6 @@ The XBEngine comprises multiple Pipeline objects that facilitate output data
 products. Additionally, the RxQueueItem and TxQueueItem objects, used in the
 XBEngine for passing information between different async processing loops,
 are defined here.
-
-.. todo::
-
-    - The B-Engine logic has not been implemented yet - this needs to be added
-      eventually. It is expected that this logic will need to go in the
-      _gpu_proc_loop for the B-Engine processing and then a seperate sender
-      loop would need to be created for sending B-Engine data.
 """
 
 import asyncio

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2023, National Research Foundation (SARAO)
+# Copyright (c) 2020-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -1050,7 +1050,7 @@ class TestEngine:
         )
 
     def _patch_fill_in(self, monkeypatch, engine_client: aiokatcp.Client, output: Output, *request) -> list[int]:
-        """Patch Pipeline._fill_in` to make a request partway through the stream.
+        """Patch :meth:`~.Pipeline._fill_in` to make a request partway through the stream.
 
         The returned list will be populated with the value of the
         ``steady-state-timestamp`` sensor immediately after executing the


### PR DESCRIPTION
<!-- Add a description of your change here -->

It is updated after calls to beam-quant-gains, beam-weights and
beam-delays. This will make it possible for qualification tests to know
how long to wait before checking the results of the commands.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [ ] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match: WIP on branch NGC-446-beamformer-control, but it's not ICD-defined

Relates to NGC-446/NGC-447/NGC-1118.
