### PR TITLE
Update katsdpservices to 1.3

### DIFF
--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -125,7 +125,7 @@ iniconfig==2.0.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   pytest
-katsdpservices==1.2
+katsdpservices==1.3
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -131,7 +131,7 @@ jedi==0.19.1
     # via ipython
 jinja2==3.1.3
     # via sphinx
-katsdpservices==1.2
+katsdpservices==1.3
     # via
     #   -c requirements.txt
     #   katgpucbf (setup.cfg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ idna==3.6
     # via yarl
 importlib-metadata==7.0.0
     # via dask
-katsdpservices==1.2
+katsdpservices==1.3
     # via katgpucbf (setup.cfg)
 katsdpsigproc==1.8.1
     # via katgpucbf (setup.cfg)


### PR DESCRIPTION
This adds the --aiomonitor-webui-port command-line option, which we'll need before being able to upgrade aiomonitor to a newer version.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml` (setup.cfg is not updated because katgpucbf itself doesn't depend on the new version; we just want it in the Docker image)
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] (n/a) Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
