### PR TITLE
Tweak xbgpu's usage of {X,B}TxQueueItems

### DIFF
--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -431,7 +431,7 @@ class BPipeline(Pipeline[BOutput, BTxQueueItem]):
             await rx_item.async_wait_for_events()
 
             tx_item = await self._tx_free_item_queue.get()
-            await tx_item.async_wait_for_events()
+            tx_item.enqueue_wait_for_events(self._proc_command_queue)
             tx_item.reset(rx_item.timestamp)
 
             # After this point it's too late for set_weights etc to update
@@ -719,7 +719,7 @@ class XPipeline(Pipeline[XOutput, XTxQueueItem]):
                 self.correlation.first_batch = last_batch
 
         tx_item = await self._tx_free_item_queue.get()
-        await tx_item.async_wait_for_events()
+        tx_item.enqueue_wait_for_events(self._proc_command_queue)
 
         # Indicate that the timestamp still needs to be filled in.
         tx_item.timestamp = -1


### PR DESCRIPTION
As per [this discussion](https://github.com/ska-sa/katgpucbf/pull/650/files#r1365222902) on PR #650, the update proposed here
> [...] ensures the GPU waits, without holding up the Python code.

Apologies for tagging you both to review, I (still) don't know how to remove a reviewer once added.

Whoever gets to it first, please and thank you.

I see there is also potential to update the XPipeline's usage of the `tx_item` in [flush_accumulation](https://github.com/ska-sa/katgpucbf/blob/main/src/katgpucbf/xbgpu/engine.py#L696)
* Let me know if I can/should update that line as well.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1145.
