### PR TITLE
Place katgpucbf images in dpp project on Harbor

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021-2023, National Research Foundation (SARAO)
+ * Copyright (c) 2021-2024, National Research Foundation (SARAO)
  *
  * Licensed under the BSD 3-Clause License (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -164,13 +164,13 @@ pipeline {
           // Supply credentials to Dockerhub so that we can reliably pull the base image
           docker.withRegistry("", "dockerhub") {
             dockerImage = docker.build(
-              "harbor.sdp.kat.ac.za/cbf/katgpucbf:${tag}",
+              "harbor.sdp.kat.ac.za/telescope/katgpucbf:${tag}",
               "--pull "
               + "--label=org.opencontainers.image.revision=${env.GIT_COMMIT} "
               + "--label=org.opencontainers.image.source=${env.GIT_URL} ."
             )
           }
-          docker.withRegistry("https://harbor.sdp.kat.ac.za/", "harbor-cbf") {
+          docker.withRegistry("https://harbor.sdp.kat.ac.za/", "harbor-telescope") {
             dockerImage.push()
           }
           // Remove the built and pushed Docker image from host

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -164,13 +164,13 @@ pipeline {
           // Supply credentials to Dockerhub so that we can reliably pull the base image
           docker.withRegistry("", "dockerhub") {
             dockerImage = docker.build(
-              "harbor.sdp.kat.ac.za/telescope/katgpucbf:${tag}",
+              "harbor.sdp.kat.ac.za/dpp/katgpucbf:${tag}",
               "--pull "
               + "--label=org.opencontainers.image.revision=${env.GIT_COMMIT} "
               + "--label=org.opencontainers.image.source=${env.GIT_URL} ."
             )
           }
-          docker.withRegistry("https://harbor.sdp.kat.ac.za/", "harbor-telescope") {
+          docker.withRegistry("https://harbor.sdp.kat.ac.za/", "harbor-dpp") {
             dockerImage.push()
           }
           // Remove the built and pushed Docker image from host

--- a/doc/autotuning.rst
+++ b/doc/autotuning.rst
@@ -16,8 +16,8 @@ compiler version) that will be deployed, the autotuning should be run inside
 the Docker image. This can be done something like this (the Docker image path
 is just an example; adjust as necessary), and takes roughly 30 minutes::
 
-    docker pull harbor.sdp.kat.ac.za/telescope/katgpucbf
-    docker run -it --rm --gpus=all -v $PWD/docker:/output harbor.sdp.kat.ac.za/telescope/katgpucbf /output/autotune.py /output/tuning.db
+    docker pull harbor.sdp.kat.ac.za/dpp/katgpucbf
+    docker run -it --rm --gpus=all -v $PWD/docker:/output harbor.sdp.kat.ac.za/dpp/katgpucbf /output/autotune.py /output/tuning.db
 
 Note that this may cause the database (:file:`docker/tuning.db`) to be
 owned by root and require fixing. Check that the database is non-empty, then

--- a/doc/autotuning.rst
+++ b/doc/autotuning.rst
@@ -16,8 +16,8 @@ compiler version) that will be deployed, the autotuning should be run inside
 the Docker image. This can be done something like this (the Docker image path
 is just an example; adjust as necessary), and takes roughly 30 minutes::
 
-    docker pull harbor.sdp.kat.ac.za/cbf/katgpucbf
-    docker run -it --rm --gpus=all -v $PWD/docker:/output harbor.sdp.kat.ac.za/cbf/katgpucbf /output/autotune.py /output/tuning.db
+    docker pull harbor.sdp.kat.ac.za/telescope/katgpucbf
+    docker run -it --rm --gpus=all -v $PWD/docker:/output harbor.sdp.kat.ac.za/telescope/katgpucbf /output/autotune.py /output/tuning.db
 
 Note that this may cause the database (:file:`docker/tuning.db`) to be
 owned by root and require fixing. Check that the database is non-empty, then

--- a/doc/control.rst
+++ b/doc/control.rst
@@ -95,7 +95,7 @@ full command to run a 4k, 4-antenna, L-band correlator::
     ./sim_correlator -a 4 -c 4096 -i 0.5
     --adc-sample-rate 1712e6
     --name my_test_correlator
-    --image-override katgpucbf:harbor.sdp.kat.ac.za/telescope/katgpucbf:latest
+    --image-override katgpucbf:harbor.sdp.kat.ac.za/dpp/katgpucbf:latest
     lab5.sdp.kat.ac.za
 
 The execution of this command contacts the master controller to request a new

--- a/doc/control.rst
+++ b/doc/control.rst
@@ -95,7 +95,7 @@ full command to run a 4k, 4-antenna, L-band correlator::
     ./sim_correlator -a 4 -c 4096 -i 0.5
     --adc-sample-rate 1712e6
     --name my_test_correlator
-    --image-override katgpucbf:harbor.sdp.kat.ac.za/cbf/katgpucbf:latest
+    --image-override katgpucbf:harbor.sdp.kat.ac.za/telescope/katgpucbf:latest
     lab5.sdp.kat.ac.za
 
 The execution of this command contacts the master controller to request a new

--- a/doc/qualification.rst
+++ b/doc/qualification.rst
@@ -82,7 +82,7 @@ this directory:
 
 .. code:: sh
 
-   spead2_net_raw pytest -v qualification --image-override katgpucbf:harbor.sdp.kat.ac.za/cbf/katgpucbf:latest
+   spead2_net_raw pytest -v qualification --image-override katgpucbf:harbor.sdp.kat.ac.za/telescope/katgpucbf:latest
 
 Explanation:
 

--- a/doc/qualification.rst
+++ b/doc/qualification.rst
@@ -82,7 +82,7 @@ this directory:
 
 .. code:: sh
 
-   spead2_net_raw pytest -v qualification --image-override katgpucbf:harbor.sdp.kat.ac.za/telescope/katgpucbf:latest
+   spead2_net_raw pytest -v qualification --image-override katgpucbf:harbor.sdp.kat.ac.za/dpp/katgpucbf:latest
 
 Explanation:
 

--- a/scratch/benchmarks/benchmark_fgpu.py
+++ b/scratch/benchmarks/benchmark_fgpu.py
@@ -41,7 +41,7 @@ from sighandler import add_sigint_handler
 
 HEAPS_TOL = 0.05  #: Relative tolerance for number of heaps received
 N_POLS = 2
-DEFAULT_IMAGE = "harbor.sdp.kat.ac.za/telescope/katgpucbf"
+DEFAULT_IMAGE = "harbor.sdp.kat.ac.za/dpp/katgpucbf"
 NOISE = 0.01  #: Minimum probability of an incorrect result from each trial
 TOLERANCE = 0.001  #: Complement of confidence interval probability
 #: Verbosity level at which individual test results are reported

--- a/scratch/benchmarks/benchmark_fgpu.py
+++ b/scratch/benchmarks/benchmark_fgpu.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 ################################################################################
-# Copyright (c) 2023, National Research Foundation (SARAO)
+# Copyright (c) 2023-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/scratch/benchmarks/benchmark_fgpu.py
+++ b/scratch/benchmarks/benchmark_fgpu.py
@@ -41,7 +41,7 @@ from sighandler import add_sigint_handler
 
 HEAPS_TOL = 0.05  #: Relative tolerance for number of heaps received
 N_POLS = 2
-DEFAULT_IMAGE = "harbor.sdp.kat.ac.za/cbf/katgpucbf"
+DEFAULT_IMAGE = "harbor.sdp.kat.ac.za/telescope/katgpucbf"
 NOISE = 0.01  #: Minimum probability of an incorrect result from each trial
 TOLERANCE = 0.001  #: Complement of confidence interval probability
 #: Verbosity level at which individual test results are reported


### PR DESCRIPTION
This is to facilitate having Pipelines and CBF images in the same place.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Relates to SPR1-200.
