### PR TITLE
Updates to run-xbgpu and run-fsim scratch scripts

### DIFF
--- a/scratch/xbgpu/run-fsim.sh
+++ b/scratch/xbgpu/run-fsim.sh
@@ -29,7 +29,9 @@ esac
 
 exec spead2_net_raw ../../src/tools/fsim \
     --interface $iface_ip \
+    --ibv \
     --array-size ${array_size:-64} \
+    --adc-sample-rate ${adc_sample_rate:-1712000000} \
     --channels ${channels:-32768} \
     --channels-per-substream ${channels_per_substream:-512} \
     --spectra-per-heap ${spectra_per_heap:-256} \

--- a/scratch/xbgpu/run-xbgpu.sh
+++ b/scratch/xbgpu/run-xbgpu.sh
@@ -18,8 +18,9 @@ tx_comp=$tx_affinity
 other_affinity=$tx_affinity
 src_mcast="239.10.10.$((10 + $1)):7148"
 dst_mcast="239.10.11.$((10 + $1)):7148"
-port="$((7150 + $1))"
 channel_offset=$(($channels_per_substream * $1))
+katcp_port="$((7140 + $1))"
+prom_port="$((7150 + $1))"
 
 case "$1" in
     0|1)
@@ -47,6 +48,14 @@ exec spead2_net_raw numactl -C $other_affinity xbgpu \
     --dst-interface $iface \
     --src-ibv --dst-ibv \
     --corrprod=name=bcp1,heap_accumulation_threshold=${heap_accumulation_threshold:-52},dst=$dst_mcast \
+    --beam=name=beam_0x,pol=0,dst=239.10.12.$((0 + $1 * 8)):7148 \
+    --beam=name=beam_0y,pol=1,dst=239.10.12.$((1 + $1 * 8)):7148 \
+    --beam=name=beam_1x,pol=0,dst=239.10.12.$((2 + $1 * 8)):7148 \
+    --beam=name=beam_1y,pol=1,dst=239.10.12.$((3 + $1 * 8)):7148 \
+    --beam=name=beam_2x,pol=0,dst=239.10.12.$((4 + $1 * 8)):7148 \
+    --beam=name=beam_2y,pol=1,dst=239.10.12.$((5 + $1 * 8)):7148 \
+    --beam=name=beam_3x,pol=0,dst=239.10.12.$((6 + $1 * 8)):7148 \
+    --beam=name=beam_3y,pol=1,dst=239.10.12.$((7 + $1 * 8)):7148 \
     --adc-sample-rate ${adc_sample_rate:-1712000000} \
     --array-size ${array_size:-64} \
     --spectra-per-heap ${spectra_per_heap:-256} \
@@ -55,6 +64,7 @@ exec spead2_net_raw numactl -C $other_affinity xbgpu \
     --samples-between-spectra ${samples_between_spectra:-$((channels*2))} \
     --channel-offset-value $channel_offset \
     --sync-epoch 0 \
-    --katcp-port $port \
+    --katcp-port $katcp_port \
+    --prometheus-port $prom_port \
     --tx-enabled \
     $src_mcast


### PR DESCRIPTION
- Add --ibv to run-fsim (it used to be the default for fsim)
- Add adc_sample_rate override to run-fsim
- Add beams to run-xbgpu
- Add Prometheus ports to run-xbgpu (and move katcp to 714x for consistency with run-fgpu)
