### PR TITLE
Explicitly indicate that AnyStream is a type alias

### DIFF
--- a/src/katgpucbf/recv.py
+++ b/src/katgpucbf/recv.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2021-2023, National Research Foundation (SARAO)
+# Copyright (c) 2021-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -22,7 +22,7 @@ import weakref
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypeAlias
 
 import numba.core.ccallback
 import numpy as np
@@ -47,7 +47,7 @@ RX_SENSOR_TIMEOUT_MIN = 1.0
 #: Eviction mode to use when some streams fall behind
 EVICTION_MODE = spead2.recv.ChunkStreamGroupConfig.EvictionMode.LOSSY
 
-AnyStream = spead2.recv.ChunkRingStream | spead2.recv.ChunkStreamGroupMember
+AnyStream: TypeAlias = spead2.recv.ChunkRingStream | spead2.recv.ChunkStreamGroupMember
 
 
 class Chunk(spead2.recv.Chunk):


### PR DESCRIPTION
Mypy complained about this when I ran it by hand - not sure why it doesn't when run under pre-commit.

See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
