### PR TITLE
Actually update BPipeline sensor values

### DIFF
--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -1324,7 +1324,7 @@ class XBEngine(DeviceServer):
             new_delays[i, 1] = float(phase_str)
         pipeline.set_delays(stream_id, new_delays)
         delays_formatted_str = ", ".join(str(value) for value in new_delays.flatten())
-        self.sensors[f"{stream_name}-delays"].set_value(f"({pipeline._weights_steady}, {delays_formatted_str})")
+        self.sensors[f"{stream_name}.delay"].set_value(f"({pipeline._weights_steady}, {delays_formatted_str})")
 
     async def request_beam_quant_gains(self, ctx, stream_name: str, gain: float) -> None:
         """Set the quantisation gain for a beam and update the sensor.


### PR DESCRIPTION
Actually update the BPipeline's katcp sensors. Admittedly missed in PR #682, the XBEngine
now updates the sensor values after each katcp (`?beam`) request. The `test_engine_end_to_end`
unit test has also been updated (and reworked) to verify this.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-447.
