### PR TITLE
Add qualification tests for beamformer delay

### DIFF
--- a/qualification/__init__.py
+++ b/qualification/__init__.py
@@ -204,6 +204,7 @@ class XBReceiver:
             self.decimation_factor = acv_config["narrowband"]["decimation_factor"]
         else:
             self.decimation_factor = 1
+        self.adc_sample_rate = cbf.config["outputs"][acv_config["src_streams"][0]]["adc_sample_rate"]
 
         # But some we don't. Note: these could be properties. But copying them up
         # front ensures we get an exception early if the sensor is missing.

--- a/qualification/__init__.py
+++ b/qualification/__init__.py
@@ -405,7 +405,8 @@ class TiedArrayChannelisedVoltageReceiver(XBReceiver):
         self.n_bits_per_sample = cbf.sensors[f"{stream_names[0]}.beng-out-bits-per-sample"].value
         self.timestamp_step = self.n_samples_between_spectra * self.n_spectra_per_heap
         self.source_indices = [
-            ast.literal_eval(cbf.sensors[f"{stream_name}.source-indices"].value) for stream_name in stream_names
+            ast.literal_eval(cbf.sensors[f"{stream_name}.source-indices"].value.decode())
+            for stream_name in stream_names
         ]
 
         self.stream = create_tied_array_channelised_voltage_receive_stream(

--- a/qualification/__init__.py
+++ b/qualification/__init__.py
@@ -404,6 +404,9 @@ class TiedArrayChannelisedVoltageReceiver(XBReceiver):
 
         self.n_bits_per_sample = cbf.sensors[f"{stream_names[0]}.beng-out-bits-per-sample"].value
         self.timestamp_step = self.n_samples_between_spectra * self.n_spectra_per_heap
+        self.source_indices = [
+            ast.literal_eval(cbf.sensors[f"{stream_name}.source-indices"].value) for stream_name in stream_names
+        ]
 
         self.stream = create_tied_array_channelised_voltage_receive_stream(
             interface_address,

--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -289,16 +289,15 @@ def check_phases(
     ax.set_xlabel("Channel")
     ax.set_ylabel("Phase (degrees)")
     ax.xaxis.set_major_locator(POTLocator())
-    # It's very noisy, and a thinner linewidth allows more detail to be seen
-    ax.plot(x, np.rad2deg(wrap_angle(actual)), linewidth=0.3, label="Actual")
-    ax.plot(x, np.rad2deg(wrap_angle(expected)), linewidth=0.3, label="Expected")
+    ax.plot(x, np.rad2deg(wrap_angle(actual)), label="Actual")
+    ax.plot(x, np.rad2deg(wrap_angle(expected)), label="Expected")
     ax.legend()
 
     ax_err.set_title(f"Phase error with {caption}")
     ax_err.set_xlabel("Channel")
     ax_err.set_ylabel("Error (degrees)")
     ax_err.xaxis.set_major_locator(POTLocator())
-    ax_err.plot(x, np.rad2deg(delta), linewidth=0.3)
+    ax_err.plot(x, np.rad2deg(delta))
 
     pdf_report.figure(fig)
 

--- a/qualification/baseline_correlation_products/test_consistency.py
+++ b/qualification/baseline_correlation_products/test_consistency.py
@@ -68,8 +68,7 @@ async def test_consistency(
     pdf_report.step("Plot spectrum")
     fig = matplotlib.figure.Figure()
     ax = fig.subplots()
-    # It's very noisy, and a thinner linewidth allows more detail to be seen
-    ax.plot(10 * np.log10(data[0][:, 0, 0, 0] / (2**31 - 1)), linewidth=0.3)
+    ax.plot(10 * np.log10(data[0][:, 0, 0, 0] / (2**31 - 1)))
     ax.set_title("Power")
     ax.set_xlabel("Channel")
     ax.set_ylabel("dBfs")

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -281,6 +281,9 @@ def matplotlib_report_style() -> Generator[None, None, None]:
             # Serif fonts better match the rest of the document
             "font.family": "serif",
             "font.serif": ["Liberation Serif"],
+            # A lot of the graphs are noisy and a narrower linewidth makes
+            # the detail easier to see.
+            "lines.linewidth": 0.3,
         }
     ):
         yield

--- a/qualification/report/requirements_text/CBF-REQ-0220.tex
+++ b/qualification/report/requirements_text/CBF-REQ-0220.tex
@@ -1,0 +1,2 @@
+The CBF shall apply a per beam, per antenna pointing polynomial, as provided via the
+CAM interface, with the following criteria: \textcolor{red}{CBF.TBD.30}

--- a/qualification/tied_array_channelised_voltage/test_delay.py
+++ b/qualification/tied_array_channelised_voltage/test_delay.py
@@ -57,7 +57,8 @@ async def test_delay_small(
     This test is only valid for delays of less than half a sample. For larger
     delays, the F-engine delay is done partially in the time domain, while the
     compensating beam delay is purely a phase correction, and so they aren't
-    expected to cancel out.
+    expected to cancel out. The delays tested are a spread of positive and
+    negative values in the picosecond range.
     """
     receiver = receive_tied_array_channelised_voltage
     client = cbf.product_controller_client

--- a/qualification/tied_array_channelised_voltage/test_delay.py
+++ b/qualification/tied_array_channelised_voltage/test_delay.py
@@ -1,0 +1,98 @@
+################################################################################
+# Copyright (c) 2024, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Delay test."""
+
+import numpy as np
+import pytest
+from pytest_check import check
+
+from katgpucbf import DIG_SAMPLE_BITS
+
+from .. import CBFRemoteControl, TiedArrayChannelisedVoltageReceiver
+from ..reporter import Reporter
+
+
+@pytest.mark.requirements("CBF-REQ-0220")
+async def test_delay(
+    cbf: CBFRemoteControl,
+    receive_tied_array_channelised_voltage: TiedArrayChannelisedVoltageReceiver,
+    pdf_report: Reporter,
+) -> None:
+    r"""Test beam steering delay application.
+
+    Verification method
+    -------------------
+    Verification by means of test. Set a delay on one input and form a beam
+    from it with a compensating delay. Use a different input with no delay
+    to form a reference beam. Check that the results are consistent to within 1
+    ULP.
+    """
+    receiver = receive_tied_array_channelised_voltage
+    client = cbf.product_controller_client
+
+    pdf_report.step("Configure the D-sim with Gaussian noise.")
+    dig_max = 2 ** (DIG_SAMPLE_BITS - 1) - 1
+    # Small so that we don't saturate, as delaying and undelaying a saturated
+    # value won't round-trip properly
+    amplitude = 16 / dig_max
+    await cbf.dsim_clients[0].request("signals", f"common=nodither(wgn({amplitude}));common;common;")
+    pdf_report.detail(f"Set D-sim with wgn amplitude={amplitude}.")
+
+    pdf_report.step("Choose random inputs for delay and reference beams and set weights.")
+    rng = np.random.default_rng(seed=123)
+    delay_beam = 0
+    delay_input_idx = rng.integers(len(receiver.source_indices[delay_beam]))
+    delay_input = receiver.source_indices[delay_beam][delay_input_idx]
+    pdf_report.detail(f"Using input {delay_input} for delay beam.")
+
+    ref_beam = 1
+    ref_input_idx = rng.integers(len(receiver.source_indices[ref_beam]))
+    ref_input = receiver.source_indices[ref_beam][ref_input_idx]
+    pdf_report.detail(f"Using input {ref_input} for reference beam.")
+    # Should never happen because they're different polarisations
+    assert delay_input != ref_input
+
+    delay_weights = [0.0] * len(receiver.source_indices[delay_beam])
+    delay_weights[delay_input_idx] = 1.0
+    await client.request("beam-weights", receiver.stream_names[delay_beam], *delay_weights)
+    pdf_report.detail(f"Set weights on {receiver.stream_names[delay_beam]} to {delay_weights}")
+    ref_weights = [0.0] * len(receiver.source_indices[ref_beam])
+    ref_weights[ref_input_idx] = 1.0
+    await client.request("beam-weights", receiver.stream_names[ref_beam], *ref_weights)
+    pdf_report.detail(f"Set weights on {receiver.stream_names[ref_beam]} to {delay_weights}")
+
+    # TODO: need the final version of the requirements to know what values to test
+    delays = [-509e-9, 509e-9]
+    for delay in delays:
+        pdf_report.step(f"Test with delay {delay * 1e12} ps.")
+        now = await cbf.dsim_time()
+        input_delays = ["0,0:0,0"] * receiver.n_inputs
+        input_delays[delay_input] = f"{delay},0:0,0"
+        await client.request("delays", "antenna-channelised-voltage", now, *input_delays)
+        pdf_report.detail(f"Set input delays to {input_delays}")
+        beam_delays = ["0:0"] * len(receiver.source_indices[ref_beam])
+        beam_delays[delay_input_idx] = f"{-delay}:0"
+        await client.request("beam-delays", receiver.stream_names[ref_beam], *beam_delays)
+        pdf_report.detail(f"Set beam {delay_beam} delays to {beam_delays}")
+        timestamp, data = await receiver.next_complete_chunk()
+        pdf_report.detail(f"Received chunk with timestamp {timestamp}")
+        # Need more precision to avoid overflows when subtracting
+        data = data.astype(np.int16)
+        max_error = np.max(np.abs(data[delay_beam] - data[ref_beam]))
+        with check:
+            assert max_error <= 1
+        pdf_report.detail(f"Maximum difference is {max_error} ULP")

--- a/qualification/tied_array_channelised_voltage/test_delay.py
+++ b/qualification/tied_array_channelised_voltage/test_delay.py
@@ -91,19 +91,27 @@ async def test_delay_small(
 
     # TODO: need the final version of the requirements to know what values to test
     max_delay = 0.5 / receiver.adc_sample_rate
-    delays = [-200e-12, -10e-12, 0.0, 16e-12, 400e-12]
-    delays = [delay for delay in delays if abs(delay) <= max_delay]
-    for delay in delays:
+    delay_phases = [
+        (-200e-12, -np.pi / 2),
+        (-10e-12, -1.0),
+        (0.0, 0.35),
+        (16e-12, 0.0),
+        (400e-12, np.pi / 2),
+    ]
+    for delay, phase in delay_phases:
         pdf_report.step(f"Test with delay {delay * 1e12} ps.")
+        if abs(delay) > max_delay:
+            pdf_report.detail(f"Skipping because delay > max_delay ({max_delay * 1e12:.1} ps).")
+            continue
         # Ensure load time is in the past, so that it is already applied when we
         # receive data.
         load_time = await cbf.dsim_time() - 5.0
         input_delays = ["0,0:0,0"] * receiver.n_inputs
-        input_delays[delay_input] = f"{delay},0:0,0"
+        input_delays[delay_input] = f"{delay},0:{phase},0"
         await client.request("delays", "antenna-channelised-voltage", load_time, *input_delays)
         pdf_report.detail(f"Set input delays to {input_delays}")
         beam_delays = ["0:0"] * len(receiver.source_indices[delay_beam])
-        beam_delays[delay_input_idx] = f"{-delay}:0"
+        beam_delays[delay_input_idx] = f"{-delay}:{-phase}"
         await client.request("beam-delays", receiver.stream_names[delay_beam], *beam_delays)
         pdf_report.detail(f"Set beam {delay_beam} delays to {beam_delays}")
         timestamp, data = await receiver.next_complete_chunk()

--- a/qualification/tied_array_channelised_voltage/test_delay.py
+++ b/qualification/tied_array_channelised_voltage/test_delay.py
@@ -41,8 +41,8 @@ async def test_delay_small(
     to form a reference beam. Check that the results are consistent to within 1
     ULP.
 
-    This test is only valid for delays less than half a sample. For larger
-    delays, the F-engine delay is done partially in the time domain, which the
+    This test is only valid for delays of less than half a sample. For larger
+    delays, the F-engine delay is done partially in the time domain, while the
     compensating beam delay is purely a phase correction, and so they aren't
     expected to cancel out.
     """


### PR DESCRIPTION
There are two tests:
- One uses small delays and cancels them out with the F-engine delays. This is largely to test that the sign conventions, scale etc are consistently implemented in the beamformer compared to the F-engine. It doesn't work on larger delays because the time-domain delay can't be exactly cancelled out in the frequency domain.
- The other uses a wider range of delays, and does not try to cancel out delays in the F-engine. It does show some quantisation effects in the average phase applied, particularly for small delays. I plan to separately experiment with dithering in the beamformer which will hopefully smooth these out. They're probably also exacerbated by having all inputs the same. 

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report: [report.pdf](https://github.com/ska-sa/katgpucbf/files/14482804/report.pdf)
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Contributes to NGC-653.
