### PR TITLE
Remove DOCKER_BUILDKIT environment variable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -154,9 +154,6 @@ pipeline {
         not { changeRequest() }
         equals expected: "SUCCESS", actual: currentBuild.currentResult
       }
-      environment {
-        DOCKER_BUILDKIT = '1'
-      }
       steps {
         script {
           branch = env.BRANCH_NAME


### PR DESCRIPTION
No longer required now that Jenkins is running on a new enough version of Docker that uses BuildKit by default.
