### PR TITLE
Add test that beamformer quantisation gives 8-bit output

### DIFF
--- a/qualification/__init__.py
+++ b/qualification/__init__.py
@@ -52,7 +52,7 @@ from katgpucbf import COMPLEX, DIG_SAMPLE_BITS
 from katgpucbf.spead import DEFAULT_PORT, FREQUENCY_ID, TIMESTAMP_ID
 from katgpucbf.utils import TimeConverter
 
-from .reporter import Reporter as _Reporter
+from .reporter import Reporter
 
 logger = logging.getLogger(__name__)
 DEFAULT_MAX_DELAY = 1000000  # Around 0.5-1ms, depending on band. Increase if necessary
@@ -185,7 +185,7 @@ class CBFRemoteControl:
         reply, _ = await self.dsim_clients[dsim_idx].request("time")
         return aiokatcp.decode(float, reply[0])
 
-    async def dsim_gaussian(self, amplitude: float, pdf_report: _Reporter | None = None, *, dsim_idx: int = 0) -> None:
+    async def dsim_gaussian(self, amplitude: float, pdf_report: Reporter | None = None, *, dsim_idx: int = 0) -> None:
         """Configure a dsim with Gaussian noise.
 
         The identical signal is produced on both polarisations.

--- a/qualification/tied_array_channelised_voltage/test_precision.py
+++ b/qualification/tied_array_channelised_voltage/test_precision.py
@@ -1,0 +1,59 @@
+################################################################################
+# Copyright (c) 2024, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Test that beamformer output has required precision."""
+
+import numpy as np
+import pytest
+from pytest_check import check
+
+from .. import CBFRemoteControl, TiedArrayChannelisedVoltageReceiver
+from ..reporter import Reporter
+
+
+@pytest.mark.requirements("CBF-REQ-0118")
+async def test_precision(
+    cbf: CBFRemoteControl,
+    receive_tied_array_channelised_voltage: TiedArrayChannelisedVoltageReceiver,
+    pdf_report: Reporter,
+) -> None:
+    r"""Test tied array beam quantisation bits.
+
+    Verification method
+    -------------------
+    Verification by means of test. Set an input Gaussian noise signal that
+    will cause all the output bits to be used. Check that the full range -127
+    to 127 is present.
+    """
+    receiver = receive_tied_array_channelised_voltage
+    client = cbf.product_controller_client
+
+    await cbf.dsim_gaussian(64.0, pdf_report)
+
+    pdf_report.step("Set weights to select a single input.")
+    weights = [0.0] * len(receiver.source_indices[0])
+    weights[0] = 1.0
+    await client.request("beam-weights", receiver.stream_names[0], *weights)
+    pdf_report.detail(f"Weights for {receiver.stream_names[0]} set to {weights}.")
+
+    pdf_report.step("Collect and validate a chunk.")
+    timestamp, data = await receiver.next_complete_chunk()
+    pdf_report.detail(f"Received chunk with timestamp {timestamp}.")
+    unique_values = np.unique(data)
+    pdf_report.detail(f"{len(unique_values)} unique values observed.")
+    with check:
+        assert len(unique_values) == 255
+        assert unique_values[0] == -127 and unique_values[-1] == 127


### PR DESCRIPTION
The dsim_gaussian function from test_delay.py is generalised and moved up to `__init__.py` so that it can be reused.

Closes NGC-1260

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report: [report.pdf](https://github.com/ska-sa/katgpucbf/files/14510649/report.pdf)
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match