### PR TITLE
Add support for Beam Prometheus counters

### DIFF
--- a/src/katgpucbf/xbgpu/bsend.py
+++ b/src/katgpucbf/xbgpu/bsend.py
@@ -174,7 +174,7 @@ class Chunk:
 
     @staticmethod
     def _inc_counters(
-        data_shape: tuple[int, int, int], data_type: np.dtype, output_names: Sequence[str], future: asyncio.Future
+        data_shape: tuple[int, int, int], data_dtype: np.dtype, output_names: Sequence[str], future: asyncio.Future
     ) -> None:
         """Increment beam stream Prometheus counters.
 
@@ -183,7 +183,7 @@ class Chunk:
         data_shape
             The shape of the beam data being transmitted. Expected in the
             format of (n_channels_per_substream, samples_per_spectra, COMPLEX).
-        data_type
+        data_dtype
             The `np.dtype` of the beam data transmitted.
         output_names
             List of beam stream names that are enabled for transmission for
@@ -199,7 +199,7 @@ class Chunk:
             for output_name in output_names:
                 output_heaps_counter.labels(output_name).inc(1)
                 # Multiply across dimensions to get total bytes
-                output_bytes_counter.labels(output_name).inc(np.prod(data_shape) * data_type.itemsize)
+                output_bytes_counter.labels(output_name).inc(np.prod(data_shape) * data_dtype.itemsize)
                 # Multiply across the first two dimensions to get complex sample count
                 output_samples_counter.labels(output_name).inc(np.prod(data_shape[:-1]))
 

--- a/src/katgpucbf/xbgpu/bsend.py
+++ b/src/katgpucbf/xbgpu/bsend.py
@@ -193,7 +193,6 @@ class Chunk:
         """
         if not future.cancelled() and future.exception() is None:
             for beam_name in beam_names:
-                logger.info(f"\nCallback updating for {beam_name}")
                 output_heaps_counter.labels(beam_name).inc(1)
                 # Each beam data sample is 8-bit
                 # - Multiply across dimensions to get total bytes
@@ -232,12 +231,6 @@ class Chunk:
                 send_futures.append(
                     send_stream.stream.async_send_heaps(heaps_to_send, mode=spead2.send.GroupMode.ROUND_ROBIN)
                 )
-                enabled_streams = [
-                    output_name
-                    for output_name, enabled in zip(send_stream.beam_names, send_stream.tx_enabled)
-                    if enabled
-                ]
-                logger.info(f"Adding callback for {enabled_streams} with {frame.data.shape}")
                 send_futures[-1].add_done_callback(
                     functools.partial(
                         self._inc_counters,

--- a/src/katgpucbf/xbgpu/bsend.py
+++ b/src/katgpucbf/xbgpu/bsend.py
@@ -220,6 +220,9 @@ class Chunk:
         rate = send_stream.bytes_per_second_per_beam * n_enabled
         if n_enabled > 0:
             send_futures: list[asyncio.Future] = []
+            enabled_stream_names = [
+                output_name for output_name, enabled in zip(send_stream.beam_names, send_stream.tx_enabled) if enabled
+            ]
             for frame in self._frames:
                 # TODO (NGC-1232): building this list every time may be too expensive.
                 # Consider caching it and invalidating when streams are enabled/disabled.
@@ -235,11 +238,7 @@ class Chunk:
                     functools.partial(
                         self._inc_counters,
                         frame.data.shape[1:],  # Get rid of 'beam' dimension
-                        [
-                            output_name
-                            for output_name, enabled in zip(send_stream.beam_names, send_stream.tx_enabled)
-                            if enabled
-                        ],
+                        enabled_stream_names,
                     )
                 )
 

--- a/src/katgpucbf/xbgpu/bsend.py
+++ b/src/katgpucbf/xbgpu/bsend.py
@@ -174,13 +174,13 @@ class Chunk:
 
     @staticmethod
     def _inc_counters(
-        beam_data_shape: tuple[int, int, int], beam_dtype: np.dtype, beam_names: Sequence[str], future: asyncio.Future
+        data_shape: tuple[int, int, int], beam_dtype: np.dtype, beam_names: Sequence[str], future: asyncio.Future
     ) -> None:
         """Increment beam stream Prometheus counters.
 
         Parameters
         ----------
-        beam_data_shape
+        data_shape
             The shape of the beam data being transmitted. Expected in the
             format of (n_channels_per_substream, samples_per_spectra, COMPLEX).
         beam_names
@@ -198,9 +198,9 @@ class Chunk:
                 output_heaps_counter.labels(beam_name).inc(1)
                 # Each beam data sample is 8-bit
                 # - Multiply across dimensions to get total bytes
-                output_bytes_counter.labels(beam_name).inc(np.prod(beam_data_shape) * beam_dtype.itemsize)
+                output_bytes_counter.labels(beam_name).inc(np.prod(data_shape) * beam_dtype.itemsize)
                 # - Multiply across the first two dimensions to get complex sample count
-                output_samples_counter.labels(beam_name).inc(np.prod(beam_data_shape[:-1]))
+                output_samples_counter.labels(beam_name).inc(np.prod(data_shape[:-1]))
 
     def send(
         self,

--- a/src/katgpucbf/xbgpu/bsend.py
+++ b/src/katgpucbf/xbgpu/bsend.py
@@ -197,7 +197,7 @@ class Chunk:
                 # Each beam data sample is 8-bit
                 # - Multiply across dimensions to get total bytes
                 output_bytes_counter.labels(beam_name).inc(np.prod(beam_data_shape))
-                # - Multiple across the first two dimensions to get complex sample count
+                # - Multiply across the first two dimensions to get complex sample count
                 output_samples_counter.labels(beam_name).inc(np.prod(beam_data_shape[:-1]))
 
     def send(

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -343,7 +343,7 @@ class BPipeline(Pipeline[BOutput, BTxQueueItem]):
             context=context,
             packet_payload=engine.dst_packet_payload,
             stream_factory=lambda stream_config, buffers: make_bstream(
-                beam_names=[output.name for output in outputs],
+                output_names=[output.name for output in outputs],
                 endpoints=[output.dst for output in outputs],
                 interface=engine.dst_interface,
                 ttl=engine.dst_ttl,

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -343,6 +343,7 @@ class BPipeline(Pipeline[BOutput, BTxQueueItem]):
             context=context,
             packet_payload=engine.dst_packet_payload,
             stream_factory=lambda stream_config, buffers: make_bstream(
+                beam_names=[output.name for output in outputs],
                 endpoints=[output.dst for output in outputs],
                 interface=engine.dst_interface,
                 ttl=engine.dst_ttl,

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -16,7 +16,6 @@
 
 """Unit tests for XBEngine module."""
 
-import logging
 from typing import AbstractSet, Any, AsyncGenerator, Callable, Final, Sequence
 
 import aiokatcp
@@ -41,9 +40,6 @@ from katgpucbf.xbgpu.output import BOutput, XOutput
 from .. import PromDiff, get_sensor
 from . import test_parameters
 from .test_recv import gen_heap
-
-logger = logging.getLogger(__name__)
-logging.basicConfig()
 
 pytestmark = [pytest.mark.device_filter.with_args(device_filter)]
 
@@ -936,7 +932,6 @@ class TestEngine:
             batch_end_index = batch_start_index + n_heaps
             # Add an extra chunk before the first full accumulation
             batch_start_index -= HEAPS_PER_FENGINE_PER_CHUNK
-            logger.info(f"Sending {batch_end_index - batch_start_index} heaps")
 
             for i, output in enumerate(beam_outputs):
                 # We only capture the timestamps before and after all katcp

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -672,7 +672,7 @@ class TestEngine:
         # value to be a multiple of `HEAPS_PER_FENGINE_PER_CHUNK`. The check
         # below is temporary until the BPipeline is able to handle missing
         # data.
-        assert batch_indices == (
+        assert list(batch_indices) == (
             list(range(min(batch_indices), max(batch_indices) + 1))
         ), "Batch indices need to be contiguous for testing beam data"
 

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -675,6 +675,10 @@ class TestEngine:
         assert list(batch_indices) == (
             list(range(min(batch_indices), max(batch_indices) + 1))
         ), "Batch indices need to be contiguous for testing beam data"
+        assert batch_indices[0] % HEAPS_PER_FENGINE_PER_CHUNK == 0, (
+            "Need to start data transmission with a batch index that is a multiple "
+            f"of HEAPS_PER_FENGINE_PER_CHUNK ({HEAPS_PER_FENGINE_PER_CHUNK})"
+        )
 
         # NOTE: Update `batch_indices` to end on a multiple of
         # `HEAPS_PER_FENGINE_PER_CHUNK`, but only for the beam_outputs because
@@ -1017,7 +1021,7 @@ class TestEngine:
             # NOTE: As per the explanation at the end of `_send_data`, we
             # only verify data in the range of `batch_indices` for each
             # `beam_result` as any heaps sent afterwards are sent by default
-            # - not because it is expected to have sane data in it.
+            # - not because they are expected to have sane data in it.
             for j in range(expected_beams.shape[1]):
                 np.testing.assert_allclose(expected_beams[i, j], beam_results[i, j], atol=1)
 

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -351,7 +351,7 @@ def verify_beam_sensors(
     *,
     beam_outputs: list[BOutput],
     beam_results_shape: tuple[int, ...],
-    data_itemsize: int,
+    beam_dtype: np.dtype,
     prom_diff: PromDiff,
     actual_sensor_updates: dict[str, list[tuple[Any, aiokatcp.Sensor.Status]]],
     first_timestamp: int,
@@ -370,8 +370,9 @@ def verify_beam_sensors(
         The shape of the verified beam data for all beams with shape
         (len(beam_outputs), n_beam_heaps_sent, n_channels_per_substream,
         n_samples_between_spectra, COMPLEX).
-    data_itemsize
-        The sample data's length in bytes.
+    beam_dtype
+        The numpy data type of the beam data, used to calculate the number of
+        bytes in each heap.
     prom_diff
         Collection of Prometheus metrics observed during the XBEngine's
         processing of data stimulus.
@@ -393,7 +394,7 @@ def verify_beam_sensors(
     n_beam_heaps_sent = beam_results_shape[1]
     heap_shape = beam_results_shape[2:]
     # NOTE: Explicitly cast np.prod returns to int as the default is np.int64
-    heap_bytes = int(np.prod(heap_shape)) * data_itemsize
+    heap_bytes = int(np.prod(heap_shape)) * beam_dtype.itemsize
     # We get rid of the final dimension in the beam data as we need the total
     # number of (COMPLEX) samples.
     heap_samples = int(np.prod(heap_shape[:-1]))
@@ -1017,7 +1018,7 @@ class TestEngine:
         verify_beam_sensors(
             beam_outputs=beam_outputs,
             beam_results_shape=beam_results.shape,
-            data_itemsize=beam_results.itemsize,
+            beam_dtype=beam_results.dtype,
             prom_diff=prom_diff,
             actual_sensor_updates=actual_sensor_updates,
             first_timestamp=first_timestamp,

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -1021,7 +1021,7 @@ class TestEngine:
             # NOTE: As per the explanation at the end of `_send_data`, we
             # only verify data in the range of `batch_indices` for each
             # `beam_result` as any heaps sent afterwards are sent by default
-            # - not because they are expected to have sane data in it.
+            # - not because they are expected to have sane data in them.
             for j in range(expected_beams.shape[1]):
                 np.testing.assert_allclose(expected_beams[i, j], beam_results[i, j], atol=1)
 

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -427,10 +427,10 @@ def verify_beam_sensors(
             # NOTE: The output_b_{heaps, bytes, samples} counters still think
             # `n-1` heaps were sent, so we need to increment those over by one
             # heap's worth of data respectively.
+            heap_count_diff = n_beam_heaps_sent - prom_output_b_heaps_total
             # Add the mod difference to the heaps counter so it seems less
             # 'hacked' than simply adding the difference between the two values.
             prom_output_b_heaps_total += prom_output_b_heaps_total % HEAPS_PER_FENGINE_PER_CHUNK
-            heap_count_diff = n_beam_heaps_sent - prom_output_b_heaps_total
             prom_output_b_bytes_total += heap_count_diff * heap_bytes
             prom_output_b_samples_total += heap_count_diff * heap_samples
 


### PR DESCRIPTION
Also add verification in the `test_engine_end_to_end` unit test. I'm not entirely happy with the
workarounds I've had to put in place in `test_engine.py::verify_beam_sensors`. I've tried to 
explain my through/out of it, but feel free to be loudly unhappy with it (with a suggestion or
two, please).

I placed the counter increments in a callback because
1. I figured the `chunk.send` needs to be as uninterrupted as possible,
  a. And the updating of sensors isn't as time-critical as sending of data
2. Of course, I took inspiration from fgpu.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1154.
