### PR TITLE
Improve qualification report

### DIFF
--- a/qualification/antenna_channelised_voltage/test_channel_shape.py
+++ b/qualification/antenna_channelised_voltage/test_channel_shape.py
@@ -69,7 +69,7 @@ async def test_channel_shape(
     Verification by means of test. This test selects a base frequency and generates multiple independent
     spectra based on the base frequency with offsets above and below the base frequency. The frequency
     deviations produce differing channel amplitudes in frequency domain which when viewed collectively
-    and in series illustrate a channel shape. These meaurements are used to compute a -3dB and -53dB
+    and in series illustrate a channel shape. These measurements are used to compute a -3dB and -53dB
     channel bandwidth.
     """
     receiver = receive_baseline_correlation_products

--- a/qualification/report/generate_pdf.py
+++ b/qualification/report/generate_pdf.py
@@ -681,7 +681,6 @@ def extract_requirements_verified(result_sets: Iterable[ResultSet]) -> dict[str,
     requirements_verified = defaultdict(list)
     for result_set in result_sets:
         for requirement in result_set.requirements:
-            # TODO: put in the result_set itself, so that we can generate links
             requirements_verified[requirement].append(result_set)
     return requirements_verified
 


### PR DESCRIPTION
Reorganise the qualification report to make it easier to navigate and reduce duplication. Some highlights:

1. Results from the same test run on different CBFs are grouped together, and only report the blurb and requirements tested once, and the outcomes for that test are summarised in a table. This makes the report hundreds of pages shorter.
2. The result summary table similarly lists each test just once, with a count of passes and failures.
3. The pytest parameter strings no longer appear. They will get used if a report has parametric dimensions that don't affect the choice of CBF to use, but we don't currently have any such tests.
4. The top-level Requirements Verified table has links to the sections for each test.
5. The test procedure only lists each test once, instead of once per CBF. In some cases the steps are not identical, in which case just a single example is shown together with a note that it varies. This makes the test procedure *much* shorter.

It was necessary to refactor a lot of code to avoid mccabe complaining about the complexity of functions. I think the new code is cleaner and easier to follow but unfortunately this will make it harder to review.

I still want to add a hierarchy level for the test directory, but I'm going to leave that for a subsequent review.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [ ] If qualification tests are changed: attach a sample qualification report: unfortunately a full example is too large to attach.
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Contributes to NGC-985.
