### PR TITLE
Qual report: include directory structure in report

### DIFF
--- a/qualification/demo/demo.py
+++ b/qualification/demo/demo.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2022-2023, National Research Foundation (SARAO)
+# Copyright (c) 2022-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -21,7 +21,7 @@ import numpy as np
 import pytest
 from pytest_check import check
 
-from .reporter import POTLocator, Reporter
+from ..reporter import POTLocator, Reporter
 
 
 @pytest.mark.requirements("DEMO-000")


### PR DESCRIPTION
- The section that used to be called either "Detailed test results" or "Test procedure" is replaced by one section per directory.
- The Result summary section now has a subsection per directory. It's slightly unsatisfying that we no longer have grand totals - I'm open to suggestions.
- The requirements verified list now indications which section the test comes from (to disambiguate tests like "Test delays").
- demo.py moves down a level to give all tests the same directory structuring.

Closes NGC-985

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [ ] If qualification tests are changed: attach a sample qualification report: too big to attach
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
