### PR TITLE
Qual: relax tavc/test_gains tolerance

### DIFF
--- a/qualification/tied_array_channelised_voltage/test_gain.py
+++ b/qualification/tied_array_channelised_voltage/test_gain.py
@@ -83,5 +83,9 @@ async def test_gain(
         max_value = 2 ** (receiver.n_bits_per_sample - 1) - 1
         expected = np.clip(expected, -max_value, max_value)
         with check:
-            np.testing.assert_allclose(data[i], expected, atol=round(0.5 * scale))
+            # Differences are typically limited to 0.5 * scale, but when
+            # n_ants is not a power of 2, the weight (1/n_ants) is inexact
+            # and so the pre-quantisation value is not exactly an integer.
+            # In that case dithering can have an effect.
+            np.testing.assert_allclose(data[i], expected, atol=scale, rtol=0.0)
             pdf_report.detail(f"Beams {stream_names[0]} and {stream_names[i]} agree.")


### PR DESCRIPTION
There are corner cases when n_ants is not a power of 2, causing 1/n_ants to be inexact, which causes the pre-quantisation values to be non-integers and subject to dithering.

Closes NGC-1268.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report (no visible change expected in the report)
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
