### PR TITLE
Set auto_strategy on rx.missing-unixtime sensors

### DIFF
--- a/src/katgpucbf/fgpu/recv.py
+++ b/src/katgpucbf/fgpu/recv.py
@@ -262,6 +262,8 @@ def make_sensors(sensor_timeout: float) -> aiokatcp.SensorSet:
                 "The timestamp (in UNIX time) when missing data was last detected",
                 default=aiokatcp.core.Timestamp(-1.0),
                 initial_status=aiokatcp.Sensor.Status.NOMINAL,
+                auto_strategy=aiokatcp.SensorSampler.Strategy.EVENT_RATE,
+                auto_strategy_parameters=(MIN_SENSOR_UPDATE_PERIOD, math.inf),
             )
         ]
         for sensor in missing_sensors:

--- a/src/katgpucbf/xbgpu/recv.py
+++ b/src/katgpucbf/xbgpu/recv.py
@@ -250,6 +250,8 @@ def make_sensors(sensor_timeout: float) -> SensorSet:
             "The timestamp (in UNIX time) when missing data was last detected",
             default=Timestamp(-1.0),
             initial_status=Sensor.Status.NOMINAL,
+            auto_strategy=SensorSampler.Strategy.EVENT_RATE,
+            auto_strategy_parameters=(MIN_SENSOR_UPDATE_PERIOD, math.inf),
         )
     ]
     for sensor in missing_sensors:


### PR DESCRIPTION
When data was partially missing, these were getting updated at much higher frequency than desired.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
