### PR TITLE
Some improvements to run-xbgpu.sh

### DIFF
--- a/scratch/xbgpu/run-xbgpu.sh
+++ b/scratch/xbgpu/run-xbgpu.sh
@@ -7,6 +7,11 @@ set -e -u
 
 channels=${channels:-32768}
 channels_per_substream=${channels_per_substream:-512}
+int_time=${int_time:-0.5}
+adc_sample_rate=${adc_sample_rate:-1712000000.0}
+spectra_per_heap=${spectra_per_heap:-256}
+samples_between_spectra=${samples_between_spectra:-$((channels*2))}
+heap_accumulation_threshold=$(python -c "print(round($int_time * $adc_sample_rate / $samples_between_spectra / $spectra_per_heap))")
 
 nproc=$(nproc)
 step=$(($nproc / 4))
@@ -37,9 +42,20 @@ case "$1" in
         ;;
 esac
 
+if ! command -v schedrr > /dev/null; then
+    cat 1>&2 <<'EOF'
+schedrr not found.
+- Download it from https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-runtime/schedrr.c
+- Compile it with gcc -o schedrr schedrr.c -Wall -O2
+- Run `sudo setcap cap_sys_nice+ep schedrr`
+- Add it to your $PATH
+EOF
+    exit 1
+fi
+
 set -x
 
-exec spead2_net_raw numactl -C $other_affinity xbgpu \
+exec schedrr spead2_net_raw numactl -C $other_affinity xbgpu \
     --src-affinity $rx_affinity \
     --src-comp-vector $rx_comp \
     --dst-affinity $tx_affinity \
@@ -47,7 +63,7 @@ exec spead2_net_raw numactl -C $other_affinity xbgpu \
     --src-interface $iface \
     --dst-interface $iface \
     --src-ibv --dst-ibv \
-    --corrprod=name=bcp1,heap_accumulation_threshold=${heap_accumulation_threshold:-52},dst=$dst_mcast \
+    --corrprod=name=bcp1,heap_accumulation_threshold=${heap_accumulation_threshold},dst=$dst_mcast \
     --beam=name=beam_0x,pol=0,dst=239.10.12.$((0 + $1 * 8)):7148 \
     --beam=name=beam_0y,pol=1,dst=239.10.12.$((1 + $1 * 8)):7148 \
     --beam=name=beam_1x,pol=0,dst=239.10.12.$((2 + $1 * 8)):7148 \
@@ -56,12 +72,13 @@ exec spead2_net_raw numactl -C $other_affinity xbgpu \
     --beam=name=beam_2y,pol=1,dst=239.10.12.$((5 + $1 * 8)):7148 \
     --beam=name=beam_3x,pol=0,dst=239.10.12.$((6 + $1 * 8)):7148 \
     --beam=name=beam_3y,pol=1,dst=239.10.12.$((7 + $1 * 8)):7148 \
-    --adc-sample-rate ${adc_sample_rate:-1712000000} \
+    --adc-sample-rate ${adc_sample_rate} \
     --array-size ${array_size:-64} \
-    --spectra-per-heap ${spectra_per_heap:-256} \
+    --spectra-per-heap ${spectra_per_heap} \
+    --heaps-per-fengine-per-chunk ${heaps_per_fengine_per_chunk:-5} \
     --channels $channels \
     --channels-per-substream $channels_per_substream \
-    --samples-between-spectra ${samples_between_spectra:-$((channels*2))} \
+    --samples-between-spectra $samples_between_spectra \
     --channel-offset-value $channel_offset \
     --sync-epoch 0 \
     --katcp-port $katcp_port \


### PR DESCRIPTION
- Use schedrr to run xbgpu with real-time priority (with instructions on how to obtain it)
- Automatically compute heap_accumulation_threshold from a user-provided integration time, instead of a hard-coding a value that is only appropriate for 32K.
- Allow heaps_per_fengine_per_chunk to be overridden.

This will help with testing for NGC-1232.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] (N/A) Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
