### PR TITLE
Remove custom ?sensor-value wrappers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
         types_or: [python, pyi]
         additional_dependencies: [
             'aioconsole==0.7.0',
-            'aiokatcp==1.8.0',
+            'aiokatcp==1.9.0',
             'aiomonitor==0.7.0',
             'asyncssh==2.14.2',
             'dask==2023.12.0',

--- a/qualification/__init__.py
+++ b/qualification/__init__.py
@@ -58,23 +58,6 @@ logger = logging.getLogger(__name__)
 DEFAULT_MAX_DELAY = 1000000  # Around 0.5-1ms, depending on band. Increase if necessary
 
 
-async def get_sensor_val(client: aiokatcp.Client, sensor_name: str):
-    """Get the value of a katcp sensor.
-
-    If the sensor value can't be cast as an int or a float (in that order), the
-    value will get returned as a string. This simple implementation ignores the
-    actual type advertised by the server.
-    """
-    _reply, informs = await client.request("sensor-value", sensor_name)
-
-    expected_types = [int, float, str]
-    for t in expected_types:
-        try:
-            return aiokatcp.decode(t, informs[0].arguments[4])
-        except ValueError:
-            continue
-
-
 @dataclass
 class CBFRemoteControl:
     """A container class for katcp clients needed by qualification tests."""

--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -29,7 +29,7 @@ from pytest_check import check
 from katgpucbf import BYTE_BITS, N_POLS
 from katgpucbf.fgpu.delay import wrap_angle
 
-from .. import BaselineCorrelationProductsReceiver, CBFRemoteControl, get_sensor_val
+from .. import BaselineCorrelationProductsReceiver, CBFRemoteControl
 from ..reporter import POTLocator, Reporter
 from . import compute_tone_gain
 
@@ -419,7 +419,7 @@ async def _test_delay_phase_rate(
 
     pdf_report.step("Set input signals and delays.")
     signal = "common = nodither(wgn(0.05, 1)); common; common;"
-    max_period = await get_sensor_val(cbf.dsim_clients[0], "max-period")
+    max_period = await cbf.dsim_clients[0].sensor_value("max-period", int)
     # Choose a period that makes all accumulations the same, so that we can
     # compare accumulations without extraneous noise.
     period = math.gcd(max_period, receiver.n_samples_between_spectra * receiver.n_spectra_per_acc)

--- a/qualification/antenna_channelised_voltage/test_gain.py
+++ b/qualification/antenna_channelised_voltage/test_gain.py
@@ -23,7 +23,7 @@ import pytest
 from numpy.typing import NDArray
 from pytest_check import check
 
-from .. import BaselineCorrelationProductsReceiver, CBFRemoteControl, get_sensor_val
+from .. import BaselineCorrelationProductsReceiver, CBFRemoteControl
 from ..reporter import Reporter
 
 
@@ -54,7 +54,7 @@ async def test_gains(
     scale = 0.02
     signals = f"common=wgn({scale}, 1); common; common;"
     # Compute repeat period guaranteed to divide into accumulation length.
-    max_period = await get_sensor_val(cbf.dsim_clients[0], "max-period")
+    max_period = await cbf.dsim_clients[0].sensor_value("max-period", int)
     period = receiver.n_samples_between_spectra * receiver.n_spectra_per_heap
     period = min(period, max_period)
     pdf_report.detail(f"Set white Gaussian noise with scale {scale}, period {period} samples.")

--- a/qualification/baseline_correlation_products/test_consistency.py
+++ b/qualification/baseline_correlation_products/test_consistency.py
@@ -19,7 +19,7 @@
 import matplotlib.figure
 import numpy as np
 
-from .. import BaselineCorrelationProductsReceiver, CBFRemoteControl, get_sensor_val
+from .. import BaselineCorrelationProductsReceiver, CBFRemoteControl
 from ..reporter import POTLocator, Reporter
 
 
@@ -41,7 +41,7 @@ async def test_consistency(
 
     pdf_report.step("Configure the D-sim with Gaussian noise.")
     amplitude = 0.2
-    max_period = await get_sensor_val(cbf.dsim_clients[0], "max-period")
+    max_period = await cbf.dsim_clients[0].sensor_value("max-period", int)
     period = receiver.n_samples_between_spectra * receiver.n_spectra_per_heap
     period = min(period, max_period)
     await cbf.dsim_clients[0].request("signals", f"common=wgn({amplitude});common;common;", period)

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -38,7 +38,7 @@ from katsdpservices import get_interface_address
 
 from katgpucbf.meerkat import BANDS
 
-from . import BaselineCorrelationProductsReceiver, CBFRemoteControl, TiedArrayChannelisedVoltageReceiver, get_sensor_val
+from . import BaselineCorrelationProductsReceiver, CBFRemoteControl, TiedArrayChannelisedVoltageReceiver
 from .host_config import HostConfigQuerier
 from .reporter import Reporter
 
@@ -486,9 +486,9 @@ async def _report_cbf_config(
             "git_version": await git_version_futures[task_name],
         }
     tasks["product_controller"] = {
-        "host": await get_sensor_val(master_controller_client, f"{cbf.name}.host"),
+        "host": await master_controller_client.sensor_value(f"{cbf.name}.host", str),
         "interfaces": {},
-        "version": await get_sensor_val(master_controller_client, f"{cbf.name}.version"),
+        "version": await master_controller_client.sensor_value(f"{cbf.name}.version", str),
         "git_version": await _get_git_version_conn(cbf.product_controller_client),
     }
 

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -15,7 +15,7 @@ aiohttp==3.9.3
     #   -c qualification/../requirements.txt
     #   aiomonitor
     #   prometheus-async
-aiokatcp==1.8.0
+aiokatcp==1.9.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ aiohttp==3.9.3
     #   -c requirements.txt
     #   aiomonitor
     #   prometheus-async
-aiokatcp==1.8.0
+aiokatcp==1.9.0
     # via
     #   -c requirements.txt
     #   katgpucbf (setup.cfg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ aiohttp==3.9.3
     # via
     #   aiomonitor
     #   prometheus-async
-aiokatcp==1.8.0
+aiokatcp==1.9.0
     # via katgpucbf (setup.cfg)
 aiomonitor==0.7.0
     # via katsdpservices

--- a/scratch/ingest.py
+++ b/scratch/ingest.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 ################################################################################
-# Copyright (c) 2021-2023, National Research Foundation (SARAO)
+# Copyright (c) 2021-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/scratch/ingest.py
+++ b/scratch/ingest.py
@@ -21,7 +21,7 @@ import ast
 import asyncio
 import logging
 import sys
-from typing import List, Sequence, Tuple, Union
+from typing import List, Sequence, Tuple
 
 import aiokatcp
 import matplotlib
@@ -47,28 +47,11 @@ TIMESTAMP = 0x1600
 FREQUENCY = 0x4103
 
 
-async def get_sensor_val(client: aiokatcp.Client, sensor_name: str) -> Union[int, float, str]:
-    """Get the value of a katcp sensor.
-
-    If the sensor value can't be cast as an int or a float (in that order), the
-    value will get returned as a string. This simple implementation ignores the
-    actual type advertised by the server.
-    """
-    _reply, informs = await client.request("sensor-value", sensor_name)
-
-    expected_types = [int, float, str]
-    for t in expected_types:
-        try:
-            return aiokatcp.decode(t, informs[0].arguments[4])
-        except ValueError:
-            continue
-
-
 async def get_product_controller_endpoint(mc_endpoint: Endpoint, product_name: str) -> Endpoint:
     """Get the katcp address for a named product controller from the master."""
     client = await aiokatcp.Client.connect(*mc_endpoint)
     async with client:
-        return endpoint_parser(None)(await get_sensor_val(client, f"{product_name}.katcp-address"))
+        return endpoint_parser(None)(str(await client.sensor_value(f"{product_name}.katcp-address", aiokatcp.Address)))
 
 
 async def get_subordinate_endpoint(mc_endpoint: Endpoint, product_name: str) -> Endpoint:
@@ -202,30 +185,32 @@ async def async_main(args: argparse.Namespace) -> None:
 
     async with client:
 
-        async def sensor_val(name):
+        async def sensor_val(name, sensor_type=None):
             if args.corr2:
                 name = CORR2_SENSOR_REMAP.get(name, name.replace(".", "-"))
-            return await get_sensor_val(client, name)
+            return await client.sensor_value(name, sensor_type)
 
         # Spead2 doesn't know katsdptelstate so it can't recognise Endpoints.
         # But we can cast Endpoints to tuples, which it does know.
         multicast_endpoints = [
             tuple(endpoint)
-            for endpoint in endpoint_list_parser(7148)(await sensor_val("baseline-correlation-products.destination"))
+            for endpoint in endpoint_list_parser(7148)(
+                await sensor_val("baseline-correlation-products.destination", str)
+            )
         ]
 
         # We need these parameters for various useful reasons.
-        n_bls = await sensor_val("baseline-correlation-products.n-bls")
-        n_chans = await sensor_val("baseline-correlation-products.n-chans")
-        n_chans_per_substream = await sensor_val("baseline-correlation-products.n-chans-per-substream")
-        n_bits_per_sample = await sensor_val("baseline-correlation-products.xeng-out-bits-per-sample")
-        n_spectra_per_acc = await sensor_val("baseline-correlation-products.n-accs")
-        n_samples_between_spectra = await sensor_val("antenna-channelised-voltage.n-samples-between-spectra")
-        adc_sample_rate = await sensor_val("antenna-channelised-voltage.adc-sample-rate")
-        int_time = await sensor_val("baseline-correlation-products.int-time")
+        n_bls = await sensor_val("baseline-correlation-products.n-bls", int)
+        n_chans = await sensor_val("baseline-correlation-products.n-chans", int)
+        n_chans_per_substream = await sensor_val("baseline-correlation-products.n-chans-per-substream", int)
+        n_bits_per_sample = await sensor_val("baseline-correlation-products.xeng-out-bits-per-sample", int)
+        n_spectra_per_acc = await sensor_val("baseline-correlation-products.n-accs", int)
+        n_samples_between_spectra = await sensor_val("antenna-channelised-voltage.n-samples-between-spectra", int)
+        adc_sample_rate = await sensor_val("antenna-channelised-voltage.adc-sample-rate", float)
+        int_time = await sensor_val("baseline-correlation-products.int-time", float)
 
         # I quite like this trick. It gives us a list of tuples.
-        bls_ordering = ast.literal_eval(await sensor_val("baseline-correlation-products.bls-ordering"))
+        bls_ordering = ast.literal_eval(await sensor_val("baseline-correlation-products.bls-ordering", str))
 
     bls_subset = get_bls_subset(args.baseline, bls_ordering)
 

--- a/scratch/populate_telstate_for_sdp.py
+++ b/scratch/populate_telstate_for_sdp.py
@@ -49,10 +49,7 @@ class SensorConverter:
         if telstate_name is None:
             telstate_name = sensor_name.replace("-", "_")
         full_sensor_name = f"{self.stream}-{sensor_name}"
-        reply, informs = await self.client.request("sensor-value", full_sensor_name)
-        if len(informs) != 1:
-            raise RuntimeError(f"Expected 1 sensor value for {full_sensor_name}, received {len(informs)}")
-        value = aiokatcp.decode(katcp_type, informs[0].arguments[4])
+        value = await self.client.sensor_value(full_sensor_name, katcp_type)
         if convert is not None:
             value = convert(value)
         self.set(telstate_name, value)

--- a/scratch/populate_telstate_for_sdp.py
+++ b/scratch/populate_telstate_for_sdp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 ################################################################################
-# Copyright (c) 2021-2023, National Research Foundation (SARAO)
+# Copyright (c) 2021-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ package_dir =
     = src
 packages = find:
 install_requires =
-    aiokatcp>=1.8.0
+    aiokatcp>=1.9.0
     dask
     katsdpservices[aiomonitor]
     katsdpsigproc>=1.8.0

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -16,9 +16,6 @@
 # limitations under the License.
 ################################################################################
 
-from typing import Any
-
-import aiokatcp
 import numpy as np
 import prometheus_client
 from numpy.typing import NDArray
@@ -94,31 +91,6 @@ class PromDiff:
             raise ValueError(f"Metric {name}{labels} did not exist at start")
         else:
             return after
-
-
-async def get_sensor(client: aiokatcp.Client, name: str) -> Any:
-    """Get the value of a sensor.
-
-    .. todo:
-
-       This should probably be implemented in aiokatcp.
-    """
-    # This is not a complete list of sensor types. Extend as necessary.
-    sensor_types = {
-        b"integer": int,
-        b"float": float,
-        b"boolean": bool,
-        b"discrete": str,  # Gets the string name of the enum
-        b"string": str,  # Allows passing through arbitrary values even if not UTF-8
-    }
-
-    _reply, informs = await client.request("sensor-list", name)
-    assert len(informs) == 1
-    sensor_type = sensor_types.get(informs[0].arguments[3], bytes)
-    _reply, informs = await client.request("sensor-value", name)
-    assert len(informs) == 1
-    assert informs[0].arguments[3] in {b"nominal", b"warn", b"error"}
-    return aiokatcp.decode(sensor_type, informs[0].arguments[4])
 
 
 def unpackbits(data: NDArray[np.uint8], sample_bits: int = DIG_SAMPLE_BITS) -> np.ndarray:

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,7 +1,7 @@
 # noqa: D104
 
 ################################################################################
-# Copyright (c) 2020-2023, National Research Foundation (SARAO)
+# Copyright (c) 2020-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/dsim/test_server.py
+++ b/test/dsim/test_server.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2021-2022, National Research Foundation (SARAO)
+# Copyright (c) 2021-2022, 2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/dsim/test_server.py
+++ b/test/dsim/test_server.py
@@ -31,7 +31,6 @@ from katgpucbf.dsim.signal import parse_signals
 from katgpucbf.send import DescriptorSender
 from katgpucbf.spead import DIGITISER_STATUS_SATURATION_COUNT_SHIFT, DIGITISER_STATUS_SATURATION_FLAG_BIT
 
-from .. import get_sensor
 from .conftest import ADC_SAMPLE_RATE, SIGNAL_HEAPS
 
 
@@ -71,12 +70,12 @@ async def katcp_client(katcp_server: DeviceServer) -> AsyncGenerator[aiokatcp.Cl
 
 async def test_sensors(katcp_server: DeviceServer, katcp_client: aiokatcp.Client) -> None:
     """Test the initial sensor values."""
-    assert await get_sensor(katcp_client, "signals-orig") == "cw(0.2, 123); cw(0.3, 456);"
-    assert await get_sensor(katcp_client, "signals") == "cw(0.2, 123); cw(0.3, 456);"
-    assert await get_sensor(katcp_client, "adc-sample-rate") == ADC_SAMPLE_RATE
-    assert await get_sensor(katcp_client, "sample-bits") == DIG_SAMPLE_BITS
-    assert await get_sensor(katcp_client, "max-period") == DIG_HEAP_SAMPLES * SIGNAL_HEAPS
-    assert await get_sensor(katcp_client, "period") == SIGNAL_HEAPS
+    assert await katcp_client.sensor_value("signals-orig", str) == "cw(0.2, 123); cw(0.3, 456);"
+    assert await katcp_client.sensor_value("signals", str) == "cw(0.2, 123); cw(0.3, 456);"
+    assert await katcp_client.sensor_value("adc-sample-rate") == ADC_SAMPLE_RATE
+    assert await katcp_client.sensor_value("sample-bits") == DIG_SAMPLE_BITS
+    assert await katcp_client.sensor_value("max-period") == DIG_HEAP_SAMPLES * SIGNAL_HEAPS
+    assert await katcp_client.sensor_value("period") == SIGNAL_HEAPS
 
 
 @pytest.mark.parametrize("period", [8192, None])
@@ -98,8 +97,7 @@ async def test_signals(
         args.append(period)
     reply, _ = await katcp_client.request("signals", *args)
     assert reply == [b"1234567"]
-    _, informs = await katcp_client.request("sensor-value", "steady-state-timestamp")
-    assert informs[0].arguments[4] == b"1234567"
+    assert await katcp_client.sensor_value("steady-state-timestamp", int) == 1234567
     set_heaps.assert_called_once_with(heap_sets[0])
     # Check that pol 0 is now indeed all zeros (and pol 1 is not).
     payload = heap_sets[0].data["payload"]
@@ -118,9 +116,9 @@ async def test_signals(
         # saturation flag consistency test is not vacuous.
         assert not np.all(status.isel(pol=1).data & (1 << DIGITISER_STATUS_SATURATION_FLAG_BIT))
     # Check that sensors were updated
-    assert await get_sensor(katcp_client, "signals-orig") == signals_str
-    assert await get_sensor(katcp_client, "period") == (period or DIG_HEAP_SAMPLES * SIGNAL_HEAPS)
-    assert parse_signals(await get_sensor(katcp_client, "signals")) == parse_signals(signals_str)
+    assert await katcp_client.sensor_value("signals-orig", str) == signals_str
+    assert await katcp_client.sensor_value("period") == (period or DIG_HEAP_SAMPLES * SIGNAL_HEAPS)
+    assert parse_signals(await katcp_client.sensor_value("signals", str)) == parse_signals(signals_str)
 
 
 @pytest.mark.parametrize(

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -1065,8 +1065,7 @@ class TestEngine:
                 counter += 1
                 if counter == 12:
                     await engine_client.request(*request)
-                    _, informs = await engine_client.request("sensor-value", "steady-state-timestamp")
-                    timestamp.append(int(informs[0].arguments[4]))
+                    timestamp.append(await engine_client.sensor_value("steady-state-timestamp", int))
             return await orig_fill_in(self)
 
         orig_fill_in = Pipeline._fill_in

--- a/test/fgpu/test_katcp_interface.py
+++ b/test/fgpu/test_katcp_interface.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2023, National Research Foundation (SARAO)
+# Copyright (c) 2020-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/fgpu/test_katcp_interface.py
+++ b/test/fgpu/test_katcp_interface.py
@@ -214,8 +214,8 @@ class TestKatcpRequests:
 
         for pol in range(N_POLS):
             sensor_reading = await engine_client.sensor_value(f"wideband.input{pol}.delay", str)
-            sensor_values = sensor_reading[1:-1].split(",")[1:]  # Drop the timestamp
-            sensor_values = (float(field.strip()) for field in sensor_values)
+            sensor_values_str = sensor_reading[1:-1].split(",")[1:]  # Drop the timestamp
+            sensor_values = (float(field.strip()) for field in sensor_values_str)
 
             for actual_value, expected_value in zip(sensor_values, parse_delay_string(correct_delay_strings[pol])):
                 assert actual_value == pytest.approx(expected=expected_value)

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -38,7 +38,7 @@ from katgpucbf.xbgpu.engine import BPipeline, RxQueueItem, XBEngine, XPipeline
 from katgpucbf.xbgpu.main import make_engine, parse_args, parse_beam, parse_corrprod
 from katgpucbf.xbgpu.output import BOutput, XOutput
 
-from .. import PromDiff, get_sensor
+from .. import PromDiff
 from . import test_parameters
 from .test_recv import gen_heap
 
@@ -1118,8 +1118,7 @@ class TestEngine:
             counter += 1
             if counter == count:
                 await client.request(*request)
-                _, informs = await client.request("sensor-value", "steady-state-timestamp")
-                timestamp.append(int(informs[0].arguments[4]))
+                timestamp.append(await client.sensor_value("steady-state-timestamp", int))
             return await orig_get_rx_item(self)
 
         monkeypatch.setattr(BPipeline, "_get_rx_item", get_rx_item)
@@ -1152,7 +1151,7 @@ class TestEngine:
         request_factory: Callable[[str, int], tuple],
     ):
         """Test that the steady-state-timestamp sensor works."""
-        assert (await get_sensor(client, "steady-state-timestamp")) == 0
+        assert (await client.sensor_value("steady-state-timestamp")) == 0
 
         timestamp_step = n_samples_between_spectra * n_spectra_per_heap
 


### PR DESCRIPTION
Replace them with aiokatcp.Client.sensor_value. This is not yet released; see https://github.com/ska-sa/aiokatcp/pull/86.

Note that in a number of places I needed to explicitly set the type as `str`, because the default in aiokatcp for string sensors is `bytes`.

Closes NGC-1035.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
- [x] Make a new aiokatcp release
- [x] Run a qualification test to make sure it still works.