### PR TITLE
Set fixed number of Jones vectors per F-engine output batch

### DIFF
--- a/doc/control.rst
+++ b/doc/control.rst
@@ -146,7 +146,6 @@ instance on ``host2``::
     user@host1:~/katgpucbf/src/tools$ spead2_net_raw ./fsim --interface <100GbE NIC IP> --ibv \
                                       --array-size 4 --channels 4096 \
                                       --channels-per-substream 512 \
-                                      --spectra-per-heap 256 \
                                       239.10.10.10+1:7148
     .
     .
@@ -159,7 +158,7 @@ instance on ``host2``::
                                         --dst-interface <100GbE interface name or IP address> \
                                         --src-ibv --dst-ibv \
                                         --adc-sample-rate 1712e6 --array-size 4 \
-                                        --channels 4096 --spectra-per-heap 256 \
+                                        --channels 4096 \
                                         --channels-per-substream 512 \
                                         --samples-between-spectra 8192 \
                                         --katcp-port 7150 \

--- a/doc/fgpu.design.rst
+++ b/doc/fgpu.design.rst
@@ -372,7 +372,7 @@ The remaining steps are to
  1. Compute the real Fourier transform from several complex-to-complex
     transforms (see the previous section).
  2. Apply gains and fine delays.
- 3. Do a partial transpose, so that *spectra-per-heap* (256 by default) spectra
+ 3. Do a partial transpose, so that *spectra-per-heap* spectra
     are stored contiguously for each channel (the Nyquist frequencies are also
     discarded at this point).
  4. Convert to integer.

--- a/doc/xbgpu.design.x.rst
+++ b/doc/xbgpu.design.x.rst
@@ -67,10 +67,10 @@ Parameters and constants
 - 8 means the real and imaginary components are signed bytes.
 - 16 means half-precision float.
 
-:c:macro:`N_SAMPLES_PER_CHANNEL` is the number of samples in time processed in
+:c:macro:`NR_SAMPLES_PER_CHANNEL` is the number of samples in time processed in
 a single call to the kernel. These are divided into groups of
-:c:macro:`N_TIMES_PER_BLOCK`, which is the number loaded into shared memory at
-a time before computing with them. Changing :c:macro:`N_TIMES_PER_BLOCK` would
+:c:macro:`NR_TIMES_PER_BLOCK`, which is the number loaded into shared memory at
+a time before computing with them. Changing :c:macro:`NR_TIMES_PER_BLOCK` would
 require substantial changes to the loading code: the fetches are hard-coded to
 use a certain number of bits of the thread ID to index this dimension.
 Increasing it significantly (e.g., to match the 256 that is native to MeerKAT)
@@ -275,9 +275,24 @@ The timestamp difference between two consecutive heaps from the same F-Engine is
 A :dfn:`batch` of heaps is a collection of heaps from different F-Engines with the same
 timestamp. A :dfn:`chunk` consists of multiple consecutive batches (the number is given
 by the option :option:`!--heaps-per-fengine-per-chunk`). Correlation generally occurs on
-a chunk at a time, accumulating results, with the batches of the chunk being
-processed in parallel.  To avoid race conditions in accumulation, there are
-multiple accumulators, and batch *i* of a chunk uses accumulator *i*.
+a chunk at a time, accumulating results. The correlation kernel is modified in
+several ways to support this:
+
+- The :cpp:class:`!FetchData` class splits the time index into a batch index
+  and an offset within the batch, so that the rest of the code can be
+  oblivious to batches, and just work in time "blocks"
+  (:c:macro:`NR_TIMES_PER_BLOCK` spectra).
+
+- The various functions take a runtime range of blocks to process.
+
+- To provide more parallelism (important when each engine is processing only a
+  few channels), the grid has an extra Z dimension. The time
+  blocks to be processed are divided amongst the values of ``blockIdx.z``.
+  There is a trade-off here: one wants to serially accumulate over as many
+  blocks as possible to reduce the final global memory traffic for writing
+  back results. To avoid race conditions in accumulation, each value of
+  ``blockIdx.z`` uses a separate global-memory accumulator.
+
 An accumulation period is called an :dfn:`accumulation` and the data output
 from that accumulation is normally called a :dfn:`dump` — the terms are used
 interchangeably. Once all the data for a dump has been correlated, the separate

--- a/doc/xbgpu.design.x.rst
+++ b/doc/xbgpu.design.x.rst
@@ -264,13 +264,19 @@ Accumulations, Dumps and Output Data
 The input data is accumulated before being output. For every output heap,
 multiple input heaps are received.
 
-A heap from a single F-Engine consists of a set number of spectra indicated by
-the :option:`!--spectra-per-heap` flag, where the spectra are time samples. Each of
-these time samples is part of a different spectrum, meaning that the timestamp
-difference per sample is equal to the value of :option:`!--samples-between-spectra`.
-The timestamp difference between two consecutive heaps from the same F-Engine is equal to:
+A heap from a single F-Engine consists of a set number of spectra, referred to as
+``spectra_per_heap``, where the spectra are time samples.
+Each of these time samples is part of a different spectrum, meaning that the
+timestamp difference per sample is equal to the value of
+:option:`!--samples-between-spectra`.  The timestamp difference between two
+consecutive heaps from the same F-Engine is equal to:
 
   `heap_timestamp_step = spectra_per_heap * samples_between_spectra`.
+
+The value of ``spectra_per_heap`` is not set explicitly on the command line,
+but rather inferred from the :option:`!--jones-per-batch` argument. The latter
+is the product of ``spectra_per_heap`` and the stream's channel count (and
+thus, the number of Jones vectors in an F-engine output batch).
 
 A :dfn:`batch` of heaps is a collection of heaps from different F-Engines with the same
 timestamp. A :dfn:`chunk` consists of multiple consecutive batches (the number is given

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ known_local_folder = ["noisy_search", "remote", "sighandler"]
 [tool.pytest.ini_options]
 testpaths = "test"
 addopts = "--cov-context=test --cov-report html --import-mode=prepend"
-markers = ["mask_timestamp", "use_vkgdr", "cmdline_args"]
+markers = ["mask_timestamp", "use_vkgdr", "cmdline_args", "spectra_per_heap"]
 asyncio_mode = "auto"
 
 [tool.coverage.run]

--- a/scratch/xbgpu/benchmarks/beamform_bench.py
+++ b/scratch/xbgpu/benchmarks/beamform_bench.py
@@ -31,7 +31,7 @@ def main():
         "--channels-per-substream", type=int, default=16, help="Channels processed by one engine [%(default)s]"
     )
     parser.add_argument("--spectra-per-heap", type=int, default=256, help="Spectra in each frame [%(default)s]")
-    parser.add_argument("--heaps-per-fengine-per-chunk", type=int, default=5, help="Frames per chunk [%(default)s]")
+    parser.add_argument("--heaps-per-fengine-per-chunk", type=int, default=32, help="Frames per chunk [%(default)s]")
     parser.add_argument("--beams", type=int, default=4, help="Number of dual-pol beams [%(default)s]")
     parser.add_argument("--passes", type=int, default=10000, help="Number of times to repeat the test [%(default)s]")
     args = parser.parse_args()

--- a/scratch/xbgpu/benchmarks/correlate_bench.py
+++ b/scratch/xbgpu/benchmarks/correlate_bench.py
@@ -30,7 +30,7 @@ def main():
         "--channels-per-substream", type=int, default=16, help="Channels processed by one engine [%(default)s]"
     )
     parser.add_argument("--spectra-per-heap", type=int, default=256, help="Spectra in each frame [%(default)s]")
-    parser.add_argument("--heaps-per-fengine-per-chunk", type=int, default=5, help="Frames per chunk [%(default)s]")
+    parser.add_argument("--heaps-per-fengine-per-chunk", type=int, default=32, help="Frames per chunk [%(default)s]")
     parser.add_argument("--passes", type=int, default=10000, help="Number of times to repeat the test [%(default)s]")
     args = parser.parse_args()
 

--- a/scratch/xbgpu/run-fsim.sh
+++ b/scratch/xbgpu/run-fsim.sh
@@ -34,5 +34,5 @@ exec spead2_net_raw ../../src/tools/fsim \
     --adc-sample-rate ${adc_sample_rate:-1712000000} \
     --channels ${channels:-32768} \
     --channels-per-substream ${channels_per_substream:-512} \
-    --spectra-per-heap ${spectra_per_heap:-256} \
+    --jones-per-batch ${jones_per_batch:-1048576} \
     $mcast

--- a/scratch/xbgpu/run-xbgpu.sh
+++ b/scratch/xbgpu/run-xbgpu.sh
@@ -9,7 +9,8 @@ channels=${channels:-32768}
 channels_per_substream=${channels_per_substream:-512}
 int_time=${int_time:-0.5}
 adc_sample_rate=${adc_sample_rate:-1712000000.0}
-spectra_per_heap=${spectra_per_heap:-256}
+jones_per_batch=${jones_per_batch:-1048576}
+spectra_per_heap=$((jones_per_batch / channels))
 samples_between_spectra=${samples_between_spectra:-$((channels*2))}
 heap_accumulation_threshold=$(python -c "print(round($int_time * $adc_sample_rate / $samples_between_spectra / $spectra_per_heap))")
 
@@ -77,8 +78,8 @@ exec schedrr spead2_net_raw numactl -C $other_affinity xbgpu \
     "${beam_args[@]}" \
     --adc-sample-rate ${adc_sample_rate} \
     --array-size ${array_size:-64} \
-    --spectra-per-heap ${spectra_per_heap} \
-    --heaps-per-fengine-per-chunk ${heaps_per_fengine_per_chunk:-5} \
+    --jones-per-batch ${jones_per_batch} \
+    --heaps-per-fengine-per-chunk ${heaps_per_fengine_per_chunk:-32} \
     --channels $channels \
     --channels-per-substream $channels_per_substream \
     --samples-between-spectra $samples_between_spectra \

--- a/src/katgpucbf/__init__.py
+++ b/src/katgpucbf/__init__.py
@@ -39,6 +39,7 @@ DEFAULT_PACKET_PAYLOAD_BYTES: Final = 8192
 DEFAULT_TTL: Final = 4  #: Default TTL for spead multicast transmission
 DEFAULT_KATCP_HOST: Final = ""  # All interfaces
 DEFAULT_KATCP_PORT: Final = 7147
+DEFAULT_JONES_PER_BATCH: Final = 2**20
 DIG_HEAP_SAMPLES: Final = 4096
 DIG_SAMPLE_BITS: Final = 10
 #: Minimum update period (in seconds) for katcp sensors where the underlying

--- a/src/katgpucbf/__init__.py
+++ b/src/katgpucbf/__init__.py
@@ -1,7 +1,7 @@
 # noqa: D104
 
 ################################################################################
-# Copyright (c) 2020-2022, National Research Foundation (SARAO)
+# Copyright (c) 2020-2022, 2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2023, National Research Foundation (SARAO)
+# Copyright (c) 2020-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -38,6 +38,7 @@ from katsdpsigproc.abc import AbstractContext
 from katsdptelstate.endpoint import Endpoint, endpoint_list_parser
 
 from .. import (
+    DEFAULT_JONES_PER_BATCH,
     DEFAULT_KATCP_HOST,
     DEFAULT_KATCP_PORT,
     DEFAULT_PACKET_PAYLOAD_BYTES,
@@ -109,6 +110,7 @@ class OutputDict(TypedDict, total=False):
 
     name: str
     channels: int
+    jones_per_batch: int
     dst: list[Endpoint]
     taps: int
     w_cutoff: float
@@ -152,7 +154,7 @@ def _parse_stream(value: str, kws: _OD, field_callback: Callable[[_OD, str, str]
                         raise ValueError(f"{key} specified twice")
                     case "name":
                         kws[key] = data
-                    case "channels" | "taps":
+                    case "channels" | "taps" | "jones_per_batch":
                         kws[key] = int(data)
                     case "w_cutoff":
                         kws[key] = float(data)
@@ -185,10 +187,15 @@ def parse_wideband(value: str) -> WidebandOutput:
     try:
         kws: WidebandOutputDict = {}
         _parse_stream(value, kws, field_callback)
-        kws = {"taps": DEFAULT_TAPS, "w_cutoff": DEFAULT_W_CUTOFF, **kws}  # type: ignore
+        kws = {
+            "taps": DEFAULT_TAPS,
+            "w_cutoff": DEFAULT_W_CUTOFF,
+            "jones_per_batch": DEFAULT_JONES_PER_BATCH,
+            **kws,
+        }
+        return WidebandOutput(**kws)
     except ValueError as exc:
         raise ValueError(f"--wideband: {exc}") from exc
-    return WidebandOutput(**kws)
 
 
 def parse_narrowband(value: str) -> NarrowbandOutput:
@@ -226,13 +233,14 @@ def parse_narrowband(value: str) -> NarrowbandOutput:
         kws = {
             "taps": DEFAULT_TAPS,
             "w_cutoff": DEFAULT_W_CUTOFF,
+            "jones_per_batch": DEFAULT_JONES_PER_BATCH,
             "weight_pass": DEFAULT_WEIGHT_PASS,
             "ddc_taps": DEFAULT_DDC_TAPS_RATIO * kws["decimation"],
-            **kws,  # type: ignore[misc]
+            **kws,
         }
+        return NarrowbandOutput(**kws)
     except ValueError as exc:
         raise ValueError(f"--narrowband: {exc}") from exc
-    return NarrowbandOutput(**kws)
 
 
 def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
@@ -375,11 +383,11 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         help="The number of antennas in the array. [%(default)s]",
     )
     parser.add_argument(
-        "--spectra-per-heap",
+        "--jones-per-batch",
         type=int,
-        default=256,
-        metavar="SPECTRA",
-        help="Spectra in each output heap [%(default)s]",
+        default=DEFAULT_JONES_PER_BATCH,
+        metavar="SAMPLES",
+        help="Jones vectors in each output batch [%(default)s]",
     )
     parser.add_argument(
         "--src-chunk-samples",
@@ -394,7 +402,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         default=2**23,
         metavar="VECTORS",
         help="Number of Jones vectors in output chunks. If not a multiple of "
-        "channels*spectra-per-heap, it will be rounded up to the next multiple. [%(default)s]",
+        "jones-per-batch, it will be rounded up to the next multiple. [%(default)s]",
     )
     parser.add_argument(
         "--max-delay-diff",
@@ -484,8 +492,8 @@ def make_engine(ctx: AbstractContext, args: argparse.Namespace) -> tuple[Engine,
     else:
         monitor = NullMonitor()
 
-    channels_lcm = math.lcm(*(output.channels for output in args.outputs))
-    chunk_jones = accel.roundup(args.dst_chunk_jones, channels_lcm * args.spectra_per_heap)
+    batch_jones_lcm = math.lcm(*(output.jones_per_batch for output in args.outputs))
+    chunk_jones = accel.roundup(args.dst_chunk_jones, batch_jones_lcm)
     engine = Engine(
         katcp_host=args.katcp_host,
         katcp_port=args.katcp_port,
@@ -511,7 +519,6 @@ def make_engine(ctx: AbstractContext, args: argparse.Namespace) -> tuple[Engine,
         num_ants=args.array_size,
         chunk_samples=args.src_chunk_samples,
         chunk_jones=chunk_jones,
-        spectra_per_heap=args.spectra_per_heap,
         dig_sample_bits=args.dig_sample_bits,
         dst_sample_bits=args.dst_sample_bits,
         max_delay_diff=args.max_delay_diff,

--- a/src/katgpucbf/fgpu/output.py
+++ b/src/katgpucbf/fgpu/output.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2023, National Research Foundation (SARAO)
+# Copyright (c) 2023-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katgpucbf/fgpu/output.py
+++ b/src/katgpucbf/fgpu/output.py
@@ -29,9 +29,21 @@ class Output(ABC):
 
     name: str
     channels: int
+    jones_per_batch: int
     taps: int
     w_cutoff: float
     dst: list[Endpoint]
+
+    def __post_init__(self) -> None:
+        if self.channels % len(self.dst) != 0:
+            raise ValueError("channels must be a multiple of the number of destinations")
+        if self.jones_per_batch % self.channels != 0:
+            raise ValueError("jones_per_batch must be a multiple of channels")
+
+    @property
+    def spectra_per_heap(self) -> int:
+        """Number of spectra in each output heap."""
+        return self.jones_per_batch // self.channels
 
     @property
     @abstractmethod
@@ -117,6 +129,7 @@ class NarrowbandOutput(Output):
     weight_pass: float
 
     def __post_init__(self) -> None:
+        super().__post_init__()
         if self.decimation % 2 != 0:
             raise ValueError("decimation factor must be even")
 

--- a/src/katgpucbf/xbgpu/correlation.py
+++ b/src/katgpucbf/xbgpu/correlation.py
@@ -95,7 +95,7 @@ class CorrelationTemplate:
         # each block as two int4's, which is 256 bits (the extra factor of 2
         # is because input_sample_bits only counts the real part of a complex
         # number).
-        n_times_per_block = 128 // self.input_sample_bits
+        self.n_times_per_block = 128 // self.input_sample_bits
 
         valid_bitwidths = [4, 8, 16]
         if self.input_sample_bits not in valid_bitwidths:
@@ -108,22 +108,18 @@ class CorrelationTemplate:
                 "will eventually be supported but has not yet been implemented."
             )
 
-        if self.n_spectra_per_heap % n_times_per_block != 0:
-            raise ValueError(f"spectra_per_heap must be divisible by {n_times_per_block}.")
+        if self.n_spectra_per_heap % self.n_times_per_block != 0:
+            raise ValueError(f"spectra_per_heap must be divisible by {self.n_times_per_block}.")
 
+        n_blocks_1d = accel.divup(self.n_ants, self._n_ants_per_block)
         if self._n_ants_per_block in {32, 48}:
-            self.n_blocks = int(
-                ((self.n_ants + self._n_ants_per_block - 1) // self._n_ants_per_block)
-                * ((self.n_ants + self._n_ants_per_block - 1) // self._n_ants_per_block + 1)
-                // 2
-            )
+            self.n_blocks = n_blocks_1d * (n_blocks_1d + 1) // 2
         elif self._n_ants_per_block == 64:
-            self.n_blocks = int(
-                ((self.n_ants + self._n_ants_per_block - 1) // self._n_ants_per_block)
-                * ((self.n_ants + self._n_ants_per_block - 1) // self._n_ants_per_block)
-            )
+            self.n_blocks = n_blocks_1d * n_blocks_1d
         else:
-            raise ValueError(f"ants_per_block must equal either 64 or 48, currently equal to {self._n_ants_per_block}.")
+            raise ValueError(
+                f"ants_per_block must equal either 32, 48 or 64, currently equal to {self._n_ants_per_block}."
+            )
 
         source = (importlib.resources.files(__package__) / "kernels" / "tensor_core_correlation_kernel.cu").read_text()
         program = context.compile(
@@ -192,6 +188,15 @@ class Correlation(accel.Operation):
         super().__init__(command_queue)
         self.template = template
 
+        # Determine how many accumulators to use. Fewer is better for both
+        # memory usage and I/O throughput, but too few means there will not
+        # be enough parallelism to saturate the GPU. Aim for 1024-2048
+        # work-groups, while sticking to powers of 2 since that's likely to
+        # give an even division of work across them.
+        n_mid = 1
+        while n_mid * self.template.n_channels * self.template.n_blocks < 1024:
+            n_mid *= 2
+
         input_data_dimensions = (
             accel.Dimension(n_batches),
             accel.Dimension(self.template.n_ants, exact=True),
@@ -201,7 +206,7 @@ class Correlation(accel.Operation):
             accel.Dimension(COMPLEX, exact=True),
         )
         mid_data_dimensions = (
-            accel.Dimension(n_batches),
+            accel.Dimension(n_mid),
             accel.Dimension(self.template.n_channels, exact=True),
             accel.Dimension(self.template.n_baselines * N_POLS * N_POLS, exact=True),
             accel.Dimension(COMPLEX, exact=True),
@@ -227,17 +232,33 @@ class Correlation(accel.Operation):
         """Run the correlation kernel and add the generated values to internal buffer."""
         if not 0 <= self.first_batch < self.last_batch <= self.n_batches:
             raise ValueError("Invalid batch range")
-        n_batches = self.last_batch - self.first_batch  # Number of batches for this launch
         in_samples_buffer = self.buffer("in_samples")
         mid_visibilities_buffer = self.buffer("mid_visibilities")
+        n_z = mid_visibilities_buffer.shape[0]
+
+        n_batches = self.last_batch - self.first_batch  # Number of batches for this launch
+        n_time_blocks_per_batch = self.template.n_spectra_per_heap // self.template.n_times_per_block
+        n_time_blocks = n_batches * n_time_blocks_per_batch
+        n_time_blocks_per_z = accel.divup(n_time_blocks, n_z)
+        # The rounding up of n_time_blocks_per_z may leave some z values with
+        # no work. So recompute n_z to avoid launching them at all.
+        n_z = accel.divup(n_time_blocks, n_time_blocks_per_z)
+        first_time_block = self.first_batch * n_time_blocks_per_batch
+
         self.command_queue.enqueue_kernel(
             self.template.correlate_kernel,
-            [mid_visibilities_buffer.buffer, in_samples_buffer.buffer, np.uint32(self.first_batch)],
+            [
+                mid_visibilities_buffer.buffer,
+                in_samples_buffer.buffer,
+                np.uint32(first_time_block),
+                np.uint32(n_time_blocks),
+                np.uint32(n_time_blocks_per_z),
+            ],
             # NOTE: Even though we are using CUDA, we follow OpenCL's grid/block
             # conventions. As such we need to multiply the number of
             # blocks(global_size) by the block size(local_size) in order to
             # specify global threads not global blocks.
-            global_size=(32 * self.template.n_blocks, 2 * self.template.n_channels, 2 * n_batches),
+            global_size=(32 * self.template.n_blocks, 2 * self.template.n_channels, 2 * n_z),
             local_size=(32, 2, 2),
         )
 
@@ -255,7 +276,7 @@ class Correlation(accel.Operation):
                 out_visibilities_buffer.buffer,
                 out_saturated_buffer.buffer,
                 mid_visibilities_buffer.buffer,
-                np.uint32(self.n_batches),
+                np.uint32(mid_visibilities_buffer.shape[0]),
             ],
             global_size=(accel.roundup(int(np.prod(out_visibilities_buffer.shape)), wgs), 1, 1),
             local_size=(wgs, 1, 1),

--- a/src/katgpucbf/xbgpu/kernels/tensor_core_correlation_kernel.cu
+++ b/src/katgpucbf/xbgpu/kernels/tensor_core_correlation_kernel.cu
@@ -85,6 +85,7 @@ extern "C++" {
 #if NR_SAMPLES_PER_CHANNEL % NR_TIMES_PER_BLOCK != 0
 #error NR_SAMPLES_PER_CHANNEL should be a multiple of NR_TIMES_PER_BLOCK
 #endif
+#define NR_BLOCKS_PER_BATCH (NR_SAMPLES_PER_CHANNEL / NR_TIMES_PER_BLOCK)
 
 #define MIN(A,B) ((A)<(B)?(A):(B))
 
@@ -168,7 +169,7 @@ inline __device__ Visibility operator += (Visibility &a, Visibility b)
 }
 
 
-typedef Sample Samples[NR_RECEIVERS][NR_CHANNELS][NR_SAMPLES_PER_CHANNEL / NR_TIMES_PER_BLOCK][NR_TIMES_PER_BLOCK][NR_POLARIZATIONS];
+typedef Sample Samples[NR_RECEIVERS][NR_CHANNELS][NR_BLOCKS_PER_BATCH][NR_TIMES_PER_BLOCK][NR_POLARIZATIONS];
 
 #if !defined CUSTOM_STORE_VISIBILITY
 typedef Visibility Visibilities[NR_CHANNELS][NR_BASELINES][NR_POLARIZATIONS][NR_POLARIZATIONS];
@@ -246,12 +247,14 @@ template <typename T> struct FetchData
   {
   }
 
-  __device__ void load(const Samples samples, unsigned channel, unsigned time, unsigned firstReceiver, bool skipLoadCheck = NR_RECEIVERS % NR_RECEIVERS_PER_BLOCK == 0)
+  __device__ void load(const Samples *samples, unsigned channel, unsigned time, unsigned firstReceiver, bool skipLoadCheck = NR_RECEIVERS % NR_RECEIVERS_PER_BLOCK == 0)
   {
     if (skipLoadCheck || firstReceiver + loadRecv < NR_RECEIVERS)
     {
-      data = * (T *) &samples[firstReceiver + loadRecv][channel][time][loadTime][0];
-      //memcpy(&data, &samples[firstReceiver + loadRecv][channel][time][loadTime][0], sizeof(T));
+      unsigned outerTime = time / NR_BLOCKS_PER_BATCH;
+      unsigned innerTime = time % NR_BLOCKS_PER_BATCH;
+      data = * (T *) &samples[outerTime][firstReceiver + loadRecv][channel][innerTime][loadTime][0];
+      //memcpy(&data, &samples[outerTime][firstReceiver + loadRecv][channel][innerTime][loadTime][0], sizeof(T));
     }
   }
 
@@ -409,7 +412,7 @@ template <bool add>__device__ inline void storeVisibilities(Visibilities visibil
 
 #if NR_RECEIVERS_PER_BLOCK == 64
 
-template <bool add, bool fullTriangle> __device__ void doCorrelateTriangle(Visibilities visibilities, const Samples samples, unsigned firstReceiver, unsigned warp, unsigned tid, SharedData<>::Bsamples &bSamples, ScratchSpace scratchSpace[NR_WARPS])
+template <bool add, bool fullTriangle> __device__ void doCorrelateTriangle(Visibilities visibilities, const Samples *samples, unsigned firstReceiver, unsigned warp, unsigned tid, unsigned firstBlock, unsigned nrBlocks, SharedData<>::Bsamples &bSamples, ScratchSpace scratchSpace[NR_WARPS])
 {
   const unsigned nrFragmentsX = 24 / NR_RECEIVERS_PER_TCM_X;
   const unsigned nrFragmentsY = 24 / NR_RECEIVERS_PER_TCM_Y;
@@ -433,10 +436,10 @@ template <bool add, bool fullTriangle> __device__ void doCorrelateTriangle(Visib
   FetchData<int4> tmp0((tid >> 2)                             , 32 / NR_BITS * (tid & 3));
   FetchData<int4> tmp1((tid >> 2) + NR_RECEIVERS_PER_BLOCK / 2, 32 / NR_BITS * (tid & 3));
 
-  tmp0.load(samples, channel, 0, firstReceiver, fullTriangle);
-  tmp1.load(samples, channel, 0, firstReceiver, fullTriangle);
+  tmp0.load(samples, channel, firstBlock, firstReceiver, fullTriangle);
+  tmp1.load(samples, channel, firstBlock, firstReceiver, fullTriangle);
 
-  for (unsigned majorTime = 0; majorTime < NR_SAMPLES_PER_CHANNEL / NR_TIMES_PER_BLOCK; majorTime ++) {
+  for (unsigned majorTime = 0; majorTime < nrBlocks; majorTime ++) {
     unsigned buffer = majorTime % NR_SHARED_BUFFERS;
 
     tmp0.storeB(bSamples[buffer]);
@@ -444,9 +447,9 @@ template <bool add, bool fullTriangle> __device__ void doCorrelateTriangle(Visib
 
     unsigned majorReadTime = majorTime + READ_AHEAD;
 
-    if (majorReadTime < NR_SAMPLES_PER_CHANNEL / NR_TIMES_PER_BLOCK) {
-      tmp0.load(samples, channel, majorReadTime, firstReceiver, fullTriangle);
-      tmp1.load(samples, channel, majorReadTime, firstReceiver, fullTriangle);
+    if (majorReadTime < nrBlocks) {
+      tmp0.load(samples, channel, firstBlock + majorReadTime, firstReceiver, fullTriangle);
+      tmp1.load(samples, channel, firstBlock + majorReadTime, firstReceiver, fullTriangle);
     }
 
     __syncthreads();
@@ -500,7 +503,7 @@ template <bool add, bool fullTriangle> __device__ void doCorrelateTriangle(Visib
 #endif
 
 
-template <bool add, unsigned nrFragmentsY, unsigned nrFragmentsX, bool skipLoadYcheck, bool skipLoadXcheck, bool skipStoreYcheck, bool skipStoreXcheck> __device__ void doCorrelateRectangle(Visibilities visibilities, const Samples samples, unsigned firstReceiverY, unsigned firstReceiverX, SharedData<>::Asamples &aSamples, SharedData<NR_RECEIVERS_PER_BLOCK_X>::Bsamples &bSamples, ScratchSpace scratchSpace[NR_WARPS])
+template <bool add, unsigned nrFragmentsY, unsigned nrFragmentsX, bool skipLoadYcheck, bool skipLoadXcheck, bool skipStoreYcheck, bool skipStoreXcheck> __device__ void doCorrelateRectangle(Visibilities visibilities, const Samples *samples, unsigned firstReceiverY, unsigned firstReceiverX, unsigned firstBlock, unsigned nrBlocks, SharedData<>::Asamples &aSamples, SharedData<NR_RECEIVERS_PER_BLOCK_X>::Bsamples &bSamples, ScratchSpace scratchSpace[NR_WARPS])
 {
   Sum sum[nrFragmentsY][nrFragmentsX];
 
@@ -523,16 +526,16 @@ template <bool add, unsigned nrFragmentsY, unsigned nrFragmentsX, bool skipLoadY
   FetchData<int4> tmpY1((tid >> 2) + 32, 32 / NR_BITS * (tid & 3));
 #endif
 
-  tmpY0.load(samples, channel, 0, firstReceiverY, skipLoadYcheck);
+  tmpY0.load(samples, channel, firstBlock, firstReceiverY, skipLoadYcheck);
 #if NR_RECEIVERS_PER_BLOCK == 48 || NR_RECEIVERS_PER_BLOCK == 64
-  tmpY1.load(samples, channel, 0, firstReceiverY, skipLoadYcheck);
+  tmpY1.load(samples, channel, firstBlock, firstReceiverY, skipLoadYcheck);
 #endif
-  tmpX0.load(samples, channel, 0, firstReceiverX, skipLoadXcheck);
+  tmpX0.load(samples, channel, firstBlock, firstReceiverX, skipLoadXcheck);
 #if NR_RECEIVERS_PER_BLOCK == 48
-  tmpX1.load(samples, channel, 0, firstReceiverX, skipLoadXcheck);
+  tmpX1.load(samples, channel, firstBlock, firstReceiverX, skipLoadXcheck);
 #endif
 
-  for (unsigned majorTime = 0; majorTime < NR_SAMPLES_PER_CHANNEL / NR_TIMES_PER_BLOCK; majorTime ++) {
+  for (unsigned majorTime = 0; majorTime < nrBlocks; majorTime ++) {
     unsigned buffer = majorTime % NR_SHARED_BUFFERS;
 
     tmpY0.storeA(aSamples[buffer]);
@@ -546,14 +549,14 @@ template <bool add, unsigned nrFragmentsY, unsigned nrFragmentsX, bool skipLoadY
 
     unsigned majorReadTime = majorTime + READ_AHEAD;
 
-    if (majorReadTime < NR_SAMPLES_PER_CHANNEL / NR_TIMES_PER_BLOCK) {
-      tmpY0.load(samples, channel, majorReadTime, firstReceiverY, skipLoadYcheck);
+    if (majorReadTime < nrBlocks) {
+      tmpY0.load(samples, channel, firstBlock + majorReadTime, firstReceiverY, skipLoadYcheck);
 #if NR_RECEIVERS_PER_BLOCK == 48 || NR_RECEIVERS_PER_BLOCK == 64
-      tmpY1.load(samples, channel, majorReadTime, firstReceiverY, skipLoadYcheck);
+      tmpY1.load(samples, channel, firstBlock + majorReadTime, firstReceiverY, skipLoadYcheck);
 #endif
-      tmpX0.load(samples, channel, majorReadTime, firstReceiverX, skipLoadXcheck);
+      tmpX0.load(samples, channel, firstBlock + majorReadTime, firstReceiverX, skipLoadXcheck);
 #if NR_RECEIVERS_PER_BLOCK == 48
-      tmpX1.load(samples, channel, majorReadTime, firstReceiverX, skipLoadXcheck);
+      tmpX1.load(samples, channel, firstBlock + majorReadTime, firstReceiverX, skipLoadXcheck);
 #endif
     }
 
@@ -610,7 +613,7 @@ union shared {
 };
 
 
-template <bool add> __device__ void doCorrelate(Visibilities visibilities, const Samples samples, union shared &u)
+template <bool add> __device__ void doCorrelate(Visibilities visibilities, const Samples *samples, unsigned firstBlock, unsigned nrBlocks, union shared &u)
 {
   constexpr unsigned nrFragmentsX = NR_RECEIVERS_PER_BLOCK_X / NR_RECEIVERS_PER_TCM_X / 2;
   constexpr unsigned nrFragmentsY = NR_RECEIVERS_PER_BLOCK   / NR_RECEIVERS_PER_TCM_Y / 2;
@@ -635,19 +638,19 @@ template <bool add> __device__ void doCorrelate(Visibilities visibilities, const
 
   if (firstReceiverX == firstReceiverY)
 #if NR_RECEIVERS_PER_BLOCK == 32 || NR_RECEIVERS_PER_BLOCK == 48
-    doCorrelateRectangle<add, nrFragmentsY, nrFragmentsX, NR_RECEIVERS % NR_RECEIVERS_PER_BLOCK == 0, NR_RECEIVERS % NR_RECEIVERS_PER_BLOCK == 0, false, NR_RECEIVERS % NR_RECEIVERS_PER_BLOCK == 0>(visibilities, samples, firstReceiverY, firstReceiverX, u.rectangle.aSamples, u.rectangle.bSamples, u.scratchSpace); // TODO: smaller nrFragments[XY]
+    doCorrelateRectangle<add, nrFragmentsY, nrFragmentsX, NR_RECEIVERS % NR_RECEIVERS_PER_BLOCK == 0, NR_RECEIVERS % NR_RECEIVERS_PER_BLOCK == 0, false, NR_RECEIVERS % NR_RECEIVERS_PER_BLOCK == 0>(visibilities, samples, firstReceiverY, firstReceiverX, firstBlock, nrBlocks, u.rectangle.aSamples, u.rectangle.bSamples, u.scratchSpace); // TODO: smaller nrFragments[XY]
 #elif NR_RECEIVERS_PER_BLOCK == 64
     if (NR_RECEIVERS % NR_RECEIVERS_PER_BLOCK != 0 && (NR_RECEIVERS < NR_RECEIVERS_PER_BLOCK || firstReceiverX >= NR_RECEIVERS / NR_RECEIVERS_PER_BLOCK * NR_RECEIVERS_PER_BLOCK))
-      doCorrelateTriangle<add, false>(visibilities, samples, firstReceiverX, 2 * threadIdx.z + threadIdx.y, 64 * threadIdx.z + 32 * threadIdx.y + threadIdx.x, u.triangle.samples, u.scratchSpace);
+      doCorrelateTriangle<add, false>(visibilities, samples, firstReceiverX, 2 * threadIdx.z + threadIdx.y, 64 * threadIdx.z + 32 * threadIdx.y + threadIdx.x, firstBlock, nrBlocks, u.triangle.samples, u.scratchSpace);
     else
-      doCorrelateTriangle<add, true>(visibilities, samples, firstReceiverX, 2 * threadIdx.z + threadIdx.y, 64 * threadIdx.z + 32 * threadIdx.y + threadIdx.x, u.triangle.samples, u.scratchSpace);
+      doCorrelateTriangle<add, true>(visibilities, samples, firstReceiverX, 2 * threadIdx.z + threadIdx.y, 64 * threadIdx.z + 32 * threadIdx.y + threadIdx.x, firstBlock, nrBlocks, u.triangle.samples, u.scratchSpace);
 #endif
 #if NR_RECEIVERS % NR_RECEIVERS_PER_BLOCK_X != 0
   else if (firstReceiverX >= NR_RECEIVERS / NR_RECEIVERS_PER_BLOCK_X * NR_RECEIVERS_PER_BLOCK_X)
-    doCorrelateRectangle<add, nrFragmentsY, (NR_RECEIVERS % NR_RECEIVERS_PER_BLOCK_X + 2 * NR_RECEIVERS_PER_TCM_X - 1) / (2 * NR_RECEIVERS_PER_TCM_X), true, false, true, NR_RECEIVERS % (2 * NR_RECEIVERS_PER_TCM_X) == 0>(visibilities, samples, firstReceiverY, firstReceiverX, u.rectangle.aSamples, u.rectangle.bSamples, u.scratchSpace);
+    doCorrelateRectangle<add, nrFragmentsY, (NR_RECEIVERS % NR_RECEIVERS_PER_BLOCK_X + 2 * NR_RECEIVERS_PER_TCM_X - 1) / (2 * NR_RECEIVERS_PER_TCM_X), true, false, true, NR_RECEIVERS % (2 * NR_RECEIVERS_PER_TCM_X) == 0>(visibilities, samples, firstReceiverY, firstReceiverX, firstBlock, nrBlocks, u.rectangle.aSamples, u.rectangle.bSamples, u.scratchSpace);
 #endif
   else
-    doCorrelateRectangle<add, nrFragmentsY, nrFragmentsX, true, true, true, true>(visibilities, samples, firstReceiverY, firstReceiverX, u.rectangle.aSamples, u.rectangle.bSamples, u.scratchSpace);
+    doCorrelateRectangle<add, nrFragmentsY, nrFragmentsX, true, true, true, true>(visibilities, samples, firstReceiverY, firstReceiverX, firstBlock, nrBlocks, u.rectangle.aSamples, u.rectangle.bSamples, u.scratchSpace);
 
 #if 0
   if (threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0) {
@@ -672,13 +675,12 @@ void correlate(Visibilities *visibilities, const Samples *samples, unsigned batc
   union shared &u = (union shared &) rawbuffer;
 
   unsigned batch = batchOffset + blockIdx.z;
-  visibilities += batch;
-  samples += batch;
+  visibilities += blockIdx.z;
 
   if (add)
-    doCorrelate<true>(*visibilities, *samples, u);
+    doCorrelate<true>(*visibilities, samples, batch * NR_BLOCKS_PER_BATCH, NR_BLOCKS_PER_BATCH, u);
   else
-    doCorrelate<false>(*visibilities, *samples, u);
+    doCorrelate<false>(*visibilities, samples, batch * NR_BLOCKS_PER_BATCH, NR_BLOCKS_PER_BATCH, u);
 }
 
 

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -46,7 +46,14 @@ from katsdptelstate.endpoint import Endpoint, endpoint_parser
 
 from katgpucbf.xbgpu.engine import XBEngine
 
-from .. import DEFAULT_KATCP_HOST, DEFAULT_KATCP_PORT, DEFAULT_PACKET_PAYLOAD_BYTES, DEFAULT_TTL, __version__
+from .. import (
+    DEFAULT_JONES_PER_BATCH,
+    DEFAULT_KATCP_HOST,
+    DEFAULT_KATCP_PORT,
+    DEFAULT_PACKET_PAYLOAD_BYTES,
+    DEFAULT_TTL,
+    __version__,
+)
 from ..monitor import FileMonitor, Monitor, NullMonitor
 from ..spead import DEFAULT_PORT
 from ..utils import add_gc_stats, add_signal_handlers, parse_source
@@ -260,10 +267,10 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         "[%(default)s]",
     )
     parser.add_argument(
-        "--spectra-per-heap",
+        "--jones-per-batch",
         type=int,
-        default=256,
-        help="Number of packed spectra in every received channel. [%(default)s]",
+        default=DEFAULT_JONES_PER_BATCH,
+        help="Number of antenna-channelised-voltage Jones vectors in each F-engine batch. [%(default)s]",
     )
     parser.add_argument(
         "--sample-bits",
@@ -275,7 +282,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--heaps-per-fengine-per-chunk",
         type=int,
-        default=5,
+        default=32,
         help="A batch is a collection of heaps from different F-Engines with "
         "the same timestamp. This parameter specifies the number of "
         "consecutive batches to store in the same chunk. The higher this "
@@ -352,6 +359,8 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("src", type=parse_source, help="Multicast address data is received from.")
 
     args = parser.parse_args(arglist)
+    if args.jones_per_batch % args.channels != 0:
+        parser.error(f"--jones-per-batch ({args.jones_per_batch}) must be a multiple of --channels ({args.channels})")
 
     if args.bandwidth is None:
         args.bandwidth = args.adc_sample_rate / args.samples_between_spectra * args.channels
@@ -396,7 +405,7 @@ def make_engine(context: AbstractContext, args: argparse.Namespace) -> tuple[XBE
         n_channels_total=args.channels,
         n_channels_per_substream=args.channels_per_substream,
         n_samples_between_spectra=args.samples_between_spectra,
-        n_spectra_per_heap=args.spectra_per_heap,
+        n_spectra_per_heap=args.jones_per_batch // args.channels,
         sample_bits=args.sample_bits,
         sync_epoch=args.sync_epoch,
         channel_offset_value=args.channel_offset_value,

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -47,7 +47,7 @@ pytestmark = [pytest.mark.cuda_only]
 # Command-line arguments
 SYNC_EPOCH = 1632561921
 CHANNELS = 1024
-SPECTRA_PER_HEAP = 256
+JONES_PER_BATCH = 262144
 # Lower than the default to make tests quicker
 # TODO: use a number that's not a multiple of the number of channels,
 # once _send_data can handle partial chunks.
@@ -58,19 +58,28 @@ PACKET_SAMPLES = 4096
 TAPS = 16
 FENG_ID = 42
 ADC_SAMPLE_RATE = 1712e6
+DSTS = 16
 
-WIDEBAND_ARGS = f"name=test_wideband,dst=239.10.11.0+15:7149,taps={TAPS}"
+WIDEBAND_ARGS = f"name=test_wideband,dst=239.10.11.0+{DSTS - 1}:7149,taps={TAPS}"
 # Centre frequency is not a multiple of the channel width, but it does ensure
 # that the two copies of the same data in test_missing are separated by a
 # whole number of cycles.
 NARROWBAND_ARGS = (
-    f"name=test_narrowband,dst=239.10.12.0+15:7149,taps={TAPS},decimation=8,centre_frequency=408173015.5944824"
+    f"name=test_narrowband,dst=239.10.12.0+{DSTS - 1}:7149,taps={TAPS},decimation=8,centre_frequency=408173015.5944824"
 )
 
 
 @pytest.fixture
 def channels() -> int:
     return CHANNELS
+
+
+@pytest.fixture
+def jones_per_batch(channels: int, request: pytest.FixtureRequest) -> int:
+    if marker := request.node.get_closest_marker("spectra_per_heap"):
+        return marker.args[0] * channels
+    else:
+        return JONES_PER_BATCH
 
 
 @dataclass
@@ -128,14 +137,14 @@ class TestEngine:
     r"""Grouping of unit tests for :class:`.Engine`\'s various functionality."""
 
     @pytest.fixture
-    def wideband_args(self, channels: int) -> str:
+    def wideband_args(self, channels: int, jones_per_batch: int) -> str:
         """Arguments to pass to the command-line parser for the wideband output."""
-        return f"{WIDEBAND_ARGS},channels={channels}"
+        return f"{WIDEBAND_ARGS},channels={channels},jones_per_batch={jones_per_batch}"
 
     @pytest.fixture
-    def narrowband_args(self, channels: int) -> str:
+    def narrowband_args(self, channels: int, jones_per_batch: int) -> str:
         """Arguments to pass to the command-line parser for the narrowband output."""
-        return f"{NARROWBAND_ARGS},channels={channels}"
+        return f"{NARROWBAND_ARGS},channels={channels},jones_per_batch={jones_per_batch}"
 
     @pytest.fixture(params=["wideband", "narrowband"])
     def output(self, wideband_args: str, narrowband_args: str, request: pytest.FixtureRequest) -> Output:
@@ -223,7 +232,6 @@ class TestEngine:
             f"--src-chunk-samples={CHUNK_SAMPLES}",
             f"--dst-chunk-jones={CHUNK_JONES}",
             f"--max-delay-diff={MAX_DELAY_DIFF}",
-            f"--spectra-per-heap={SPECTRA_PER_HEAP}",
             f"--src-packet-samples={PACKET_SAMPLES}",
             f"--feng-id={FENG_ID}",
             f"--adc-sample-rate={ADC_SAMPLE_RATE}",
@@ -295,8 +303,6 @@ class TestEngine:
         expected_first_timestamp: int | None = None,
         src_present: np.ndarray | None = None,
         dst_present: int | np.ndarray | None = None,
-        channels: int = CHANNELS,
-        spectra_per_heap: int = SPECTRA_PER_HEAP,
     ) -> tuple[np.ndarray, np.ndarray]:
         """Send a contiguous stream of data to the engine and retrieve results.
 
@@ -326,11 +332,6 @@ class TestEngine:
             particular, it will not be correct if there are non-zero delays).
 
             Missing frames still take space in the output but are zeroed out.
-        channels
-            Number of channels used by the engine, overriding ``CHANNELS``.
-        spectra_per_heap
-            Number of spectra per heap used by the engine, overriding
-            ``SPECTRA_PER_HEAP``.
 
         Returns
         -------
@@ -341,6 +342,8 @@ class TestEngine:
         """
         # Reshape into heap-size pieces (now has indices pol, heap, offset)
         src_layout = engine.src_layout
+        channels = output.channels
+        spectra_per_heap = output.spectra_per_heap
         n_samples = dig_data.shape[1]
         assert dig_data.shape[0] == N_POLS
         assert n_samples % src_layout.chunk_samples == 0, "samples must be a whole number of chunks"
@@ -492,7 +495,7 @@ class TestEngine:
         # Don't send the first chunk, to avoid complications with the step
         # change in the delay at SYNC_EPOCH.
         src_layout = engine_server.src_layout
-        heap_samples = output.spectra_samples * SPECTRA_PER_HEAP
+        heap_samples = output.spectra_samples * output.spectra_per_heap
         first_timestamp = roundup(src_layout.chunk_samples, heap_samples)
         n_samples = 20 * src_layout.chunk_samples
         tone_timestamps = np.arange(n_samples) + first_timestamp
@@ -507,7 +510,7 @@ class TestEngine:
             # The first output heap would require data from before the first
             # timestamp, so it does not get produced
             expected_first_timestamp += heap_samples
-            expected_spectra -= SPECTRA_PER_HEAP
+            expected_spectra -= output.spectra_per_heap
         out_data, _ = await self._send_data(
             mock_recv_stream,
             mock_send_stream,
@@ -516,7 +519,7 @@ class TestEngine:
             dig_data,
             first_timestamp=first_timestamp,
             expected_first_timestamp=expected_first_timestamp,
-            dst_present=expected_spectra // SPECTRA_PER_HEAP,
+            dst_present=expected_spectra // output.spectra_per_heap,
         )
 
         # Check for the tones
@@ -646,7 +649,7 @@ class TestEngine:
         coeffs = [f"0.0,{dr}:0.0,{pr}" for dr, pr in zip(delay_rate, phase_rate)]
         await engine_client.request("delays", output.name, SYNC_EPOCH, *coeffs)
 
-        first_timestamp = roundup(100 * src_layout.chunk_samples, output.spectra_samples * SPECTRA_PER_HEAP)
+        first_timestamp = roundup(100 * src_layout.chunk_samples, output.spectra_samples * output.spectra_per_heap)
         end_delay = round(min(delay_rate) * n_samples)
         expected_spectra = (n_samples + end_delay - output.window) // output.spectra_samples
         tone_timestamps = np.arange(n_samples) + first_timestamp
@@ -661,8 +664,8 @@ class TestEngine:
             first_timestamp=first_timestamp,
             # The first output heap would require data from before first_timestamp, so
             # is omitted.
-            expected_first_timestamp=first_timestamp + output.spectra_samples * SPECTRA_PER_HEAP,
-            dst_present=expected_spectra // SPECTRA_PER_HEAP - 1,
+            expected_first_timestamp=first_timestamp + output.spectra_samples * output.spectra_per_heap,
+            dst_present=expected_spectra // output.spectra_per_heap - 1,
         )
         # Add a polarisation dimension to timestamps to simplify some
         # broadcasting computations below.
@@ -783,7 +786,7 @@ class TestEngine:
         src_layout = engine_server.src_layout
         # Don't send the first chunk, to avoid complications with the step
         # change in the delay at SYNC_EPOCH.
-        heap_samples = output.spectra_samples * SPECTRA_PER_HEAP
+        heap_samples = output.spectra_samples * output.spectra_per_heap
         first_timestamp = roundup(src_layout.chunk_samples, heap_samples)
         n_samples = 20 * src_layout.chunk_samples
         tone_timestamps = np.arange(n_samples) + first_timestamp
@@ -810,7 +813,7 @@ class TestEngine:
             # The first output heap would require data from before the first
             # timestamp, so it does not get produced
             expected_first_timestamp += heap_samples
-            expected_spectra -= SPECTRA_PER_HEAP
+            expected_spectra -= output.spectra_per_heap
         out_data, _ = await self._send_data(
             mock_recv_stream,
             mock_send_stream,
@@ -819,7 +822,7 @@ class TestEngine:
             dig_data,
             first_timestamp=first_timestamp,
             expected_first_timestamp=expected_first_timestamp,
-            dst_present=expected_spectra // SPECTRA_PER_HEAP,
+            dst_present=expected_spectra // output.spectra_per_heap,
         )
 
         # Ensure we haven't saturated
@@ -835,11 +838,12 @@ class TestEngine:
 
     # Test with spectra_samples less than, equal to and greater than src-packet-samples
     @pytest.mark.parametrize("channels", [64, 2048, 8192])
-    # Use small spectra-per-heap to get finer-grained testing of which spectra
+    # Use small jones-per-batch to get finer-grained testing of which spectra
     # were ditched. Fewer would be better, but there are internal alignment
     # requirements. --src-chunk-samples needs to be increased (from
     # CHUNK_SAMPLES) to ensure narrowband windows fit.
-    @pytest.mark.cmdline_args("--spectra-per-heap=32", "--src-chunk-samples=4194304")
+    @pytest.mark.spectra_per_heap(32)
+    @pytest.mark.cmdline_args("--src-chunk-samples=4194304")
     async def test_missing_heaps(
         self,
         mock_recv_stream: spead2.InprocQueue,
@@ -855,7 +859,7 @@ class TestEngine:
         It then checks that the heaps successfully received in the first half match
         the heaps in the second half.
         """
-        spectra_per_heap = 32
+        spectra_per_heap = output.spectra_per_heap
         chunk_samples = engine_server.src_layout.chunk_samples
         n_samples = 16 * chunk_samples
         # Half-open ranges of input heaps that are missing
@@ -898,8 +902,6 @@ class TestEngine:
                 expected_first_timestamp=0,
                 src_present=src_present,
                 dst_present=dst_present,
-                channels=channels,
-                spectra_per_heap=spectra_per_heap,
             )
         # Position in dst_present corresponding to the second half of dig_data.
         middle = (n_samples // 2) // (output.spectra_samples * spectra_per_heap)
@@ -1083,7 +1085,7 @@ class TestEngine:
         monkeypatch,
     ) -> None:
         """Test that the ``steady-state-timestamp`` is updated correctly after ``?gain``."""
-        n_samples = max(16 * CHUNK_SAMPLES, output.spectra_samples * SPECTRA_PER_HEAP * 3)
+        n_samples = max(16 * CHUNK_SAMPLES, output.spectra_samples * output.spectra_per_heap * 3)
         rng = np.random.default_rng(1)
         dig_data = rng.integers(-255, 255, size=(2, n_samples), dtype=np.int16)
 
@@ -1118,7 +1120,7 @@ class TestEngine:
         monkeypatch,
     ) -> None:
         """Test that the ``steady-state-timestamp`` is updated correctly after ``?delays``."""
-        n_samples = max(16 * CHUNK_SAMPLES, output.spectra_samples * SPECTRA_PER_HEAP * 3)
+        n_samples = max(16 * CHUNK_SAMPLES, output.spectra_samples * output.spectra_per_heap * 3)
         tone = CW(frac_channel=frac_channel(output, CHANNELS // 2), magnitude=100)
         dig_data = self._make_tone(np.arange(n_samples), tone, 0)
 

--- a/test/fgpu/test_main.py
+++ b/test/fgpu/test_main.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2023, National Research Foundation (SARAO)
+# Copyright (c) 2023-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/fgpu/test_main.py
+++ b/test/fgpu/test_main.py
@@ -21,6 +21,7 @@ from katsdptelstate.endpoint import Endpoint
 
 from katgpucbf.fgpu.main import (
     DEFAULT_DDC_TAPS_RATIO,
+    DEFAULT_JONES_PER_BATCH,
     DEFAULT_TAPS,
     DEFAULT_W_CUTOFF,
     DEFAULT_WEIGHT_PASS,
@@ -80,13 +81,14 @@ class TestParseNarrowband:
             taps=DEFAULT_TAPS,
             ddc_taps=DEFAULT_DDC_TAPS_RATIO * 8,
             w_cutoff=DEFAULT_W_CUTOFF,
+            jones_per_batch=DEFAULT_JONES_PER_BATCH,
         )
 
     def test_maximal(self) -> None:
         """Test with all valid arguments."""
         assert parse_narrowband(
             "name=foo,channels=1024,centre_frequency=400e6,decimation=8,taps=8,"
-            "w_cutoff=0.5,dst=239.1.2.3+1:7148,ddc_taps=128,weight_pass=0.3"
+            "w_cutoff=0.5,dst=239.1.2.3+1:7148,ddc_taps=128,weight_pass=0.3,jones_per_batch=262144"
         ) == NarrowbandOutput(
             name="foo",
             channels=1024,
@@ -97,6 +99,7 @@ class TestParseNarrowband:
             dst=[Endpoint("239.1.2.3", 7148), Endpoint("239.1.2.4", 7148)],
             ddc_taps=128,
             weight_pass=0.3,
+            jones_per_batch=262144,
         )
 
     @pytest.mark.parametrize(
@@ -130,11 +133,11 @@ class TestParseArgs:
             "--dst-interface=lo",
             "--adc-sample-rate=1712000000.0",
             "--sync-epoch=0",
-            "--wideband=name=wideband,dst=239.0.3.0+1:7148,channels=1024,taps=64,w_cutoff=0.9",
+            "--wideband=name=wideband,dst=239.0.3.0+1:7148,channels=1024,taps=64,w_cutoff=0.9,jones_per_batch=262144",
             (
                 "--narrowband=name=nb0,dst=239.1.0.0+1,channels=32768,"
                 "centre_frequency=400e6,decimation=8,taps=4,w_cutoff=0.8,"
-                "ddc_taps=64,weight_pass=0.3"
+                "ddc_taps=64,weight_pass=0.3,jones_per_batch=524288"
             ),
             "--narrowband=name=nb1,dst=239.2.0.0+0:7149,channels=8192,centre_frequency=300e6,decimation=16",
             "239.0.1.0+15:7148",
@@ -147,6 +150,7 @@ class TestParseArgs:
                 channels=1024,
                 taps=64,
                 w_cutoff=0.9,
+                jones_per_batch=262144,
             ),
             NarrowbandOutput(
                 name="nb0",
@@ -158,6 +162,7 @@ class TestParseArgs:
                 w_cutoff=0.8,
                 ddc_taps=64,
                 weight_pass=0.3,
+                jones_per_batch=524288,
             ),
             NarrowbandOutput(
                 name="nb1",
@@ -169,5 +174,6 @@ class TestParseArgs:
                 w_cutoff=DEFAULT_W_CUTOFF,
                 ddc_taps=DEFAULT_DDC_TAPS_RATIO * 16,
                 weight_pass=DEFAULT_WEIGHT_PASS,
+                jones_per_batch=DEFAULT_JONES_PER_BATCH,
             ),
         ]

--- a/test/xbgpu/test_bsend.py
+++ b/test/xbgpu/test_bsend.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2023, National Research Foundation (SARAO)
+# Copyright (c) 2023-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/xbgpu/test_bsend.py
+++ b/test/xbgpu/test_bsend.py
@@ -188,17 +188,17 @@ class TestBSend:
                 np.testing.assert_equal(items["bf_raw"].value, data[j, i, ...])
 
     @pytest.mark.combinations(
-        "num_engines, num_channels, num_spectra_per_heap",
+        "num_engines, num_channels, num_jones_per_batch",
         [4, 128, 512],
         test_parameters.num_channels,
-        test_parameters.num_spectra_per_heap,
+        test_parameters.num_jones_per_batch,
     )
     async def test_send_simple(
         self,
         context: AbstractContext,
         num_engines: int,
         num_channels: int,
-        num_spectra_per_heap: int,
+        num_jones_per_batch: int,
         outputs: Sequence[BOutput],
         time_converter: TimeConverter,
         sensors: SensorSet,
@@ -217,8 +217,8 @@ class TestBSend:
             Total number of engines required to process this array configuration.
         num_channels
             Total number of channels processed by a (theoretical) F-engine.
-        num_spectra_per_heap
-            Total number of packed spectra in every recevied channel.
+        num_jones_per_batch
+            Total number of Jones vectors in every batch sent by the F-engine.
         outputs, time_converter, sensors
             Fixtures.
         """
@@ -227,9 +227,10 @@ class TestBSend:
         # it satisfies all values of `num_engines`, which can be as small as 4.
         engine_id = 3
 
-        # TODO: We don't do channels * 2 anymore, but n-samples-between-spectra
-        heap_timestamp_step = num_channels * 2 * num_spectra_per_heap
         n_channels_per_substream = num_channels // num_engines
+        n_spectra_per_heap = num_jones_per_batch // num_channels
+        # TODO: We don't do channels * 2 anymore, but n-samples-between-spectra
+        heap_timestamp_step = num_channels * 2 * n_spectra_per_heap
         channel_offset = n_channels_per_substream * engine_id
         queues = [spead2.InprocQueue() for _ in outputs]
         send_stream = BSend(
@@ -238,7 +239,7 @@ class TestBSend:
             n_tx_items=N_TX_ITEMS,
             n_channels=num_channels,
             n_channels_per_substream=n_channels_per_substream,
-            spectra_per_heap=num_spectra_per_heap,
+            spectra_per_heap=n_spectra_per_heap,
             adc_sample_rate=time_converter.adc_sample_rate,
             timestamp_step=heap_timestamp_step,
             send_rate_factor=0.0,  # Send as fast as possible
@@ -255,7 +256,7 @@ class TestBSend:
             sensors,
             send_stream,
             n_channels_per_substream,
-            num_spectra_per_heap,
+            n_spectra_per_heap,
             heap_timestamp_step,
         )
         for queue in queues:
@@ -268,6 +269,6 @@ class TestBSend:
             engine_id,
             channel_offset,
             n_channels_per_substream,
-            num_spectra_per_heap,
+            n_spectra_per_heap,
             heap_timestamp_step,
         )

--- a/test/xbgpu/test_correlation.py
+++ b/test/xbgpu/test_correlation.py
@@ -18,7 +18,7 @@
 import numpy as np
 import pytest
 from katsdpsigproc.abc import AbstractCommandQueue, AbstractContext
-from katsdpsigproc.accel import DeviceArray
+from katsdpsigproc.accel import DeviceArray, roundup
 from numba import njit, prange
 
 from katgpucbf.xbgpu.correlation import Correlation, CorrelationTemplate, device_filter
@@ -93,28 +93,30 @@ def fill_random(rng: np.random.Generator, buf: DeviceArray, command_queue: Abstr
 
 
 @pytest.mark.combinations(
-    "num_ants, num_channels, num_spectra_per_heap",
+    "num_ants, num_channels, num_jones_per_batch",
     test_parameters.array_size,
     test_parameters.num_channels,
-    test_parameters.num_spectra_per_heap,
+    test_parameters.num_jones_per_batch,
 )
 def test_correlator(
     context: AbstractContext,
     command_queue: AbstractCommandQueue,
     num_ants: int,
-    num_spectra_per_heap: int,
+    num_jones_per_batch: int,
     num_channels: int,
 ) -> None:
     """Test the Tensor Core correlation kernel for correctness."""
     n_chans_per_stream = num_channels // num_ants
     n_batches = 7
+    # The kernel requires it to be a multiple of 16
+    n_spectra_per_heap = roundup(num_jones_per_batch // num_channels, 16)
     batch_ranges = [(1, 5), (3, 4), (0, 7)]
 
     template = CorrelationTemplate(
         context,
         n_ants=num_ants,
         n_channels=n_chans_per_stream,
-        n_spectra_per_heap=num_spectra_per_heap,
+        n_spectra_per_heap=n_spectra_per_heap,
         input_sample_bits=8,
     )
 
@@ -144,9 +146,12 @@ def test_correlator(
     fill_random(rng, buf_visibilities_device, command_queue)
 
     # Calculate expected values
-    calculated_visibilities_host = np.zeros(buf_visibilities_host.shape, buf_visibilities_host.dtype)
+    calculated_visibilities_host = np.zeros(buf_visibilities_host.shape, np.int64)
     for first_batch, last_batch in batch_ranges:
         calculated_visibilities_host += correlate_host(buf_samples_host[first_batch:last_batch])
+    calculated_visibilities_host = np.clip(
+        calculated_visibilities_host, -np.iinfo(np.int32).max, np.iinfo(np.int32).max
+    )
 
     # Calculate using the kernel
     buf_samples_device.set(command_queue, buf_samples_host)

--- a/test/xbgpu/test_parameters.py
+++ b/test/xbgpu/test_parameters.py
@@ -21,8 +21,7 @@
 # run.
 array_size = [1, 3, 4, 19, 33, 64, 80]
 
-# This is always set to 256 for the MeerKAT case.
-num_spectra_per_heap = [256]
+num_jones_per_batch = [2**20]
 
 # Number of FFT channels out of the F-Engine
 num_channels = [1024, 8192, 32768]

--- a/test/xbgpu/test_parameters.py
+++ b/test/xbgpu/test_parameters.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2023, National Research Foundation (SARAO)
+# Copyright (c) 2020-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy


### PR DESCRIPTION
Previously spectra-per-heap was fixed (at 256), but this leads to problems because the heap size scales with the channel count. Small heaps don't amortise the per-heap overheads well (leading to reduced performance with 1K channels) while large heaps can cause problems with memory usage.

Replace it by fixing "jones-per-batch": the number of Jones vectors (dual-pol, complex sample) in each F-engine output batch aka spectra-per-heap * channels. The default is set to 2^20, so that 4K-channel correlators have the same integration time resolution as MeerKAT (and >4K-channel correlators have more resolution). I also took the opportunity to make `jones_per_batch` a per-output argument of fgpu, rather than a global argument (spectra-per-heap should always have been per-output, but I never got around to it).

The reduction in spectra-per-heap for 32K-channel correlation showed some performance limitations in correlate.py, because it always parallelised over batches rather than summing in registers across batches; as a result, it used far too much global memory bandwidth. The TCC kernel code has been modified so that the parallelisation granularity is independent of the batch size. This not only allows parallelism to be reduced for 32K (where the number of channels provides ample parallelism); it also allows it to be increased when channel count is low (parallel within a batch).

The kernel code change also decouples the number of intermediate accumulators from the number of batches per chunk. That allows the `--heaps-per-fengine-per-batch` default to be increased to 32, since it no longer causes excessive memory usage from the intermediate accumulators.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
- [ ] Merge together with matching katsdpcontroller PR: https://github.com/ska-sa/katsdpcontroller/pull/725

Closes NGC-1121.
