### PR TITLE
Add a label restriction to qualification/Jenkinsfile

### DIFF
--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -30,6 +30,8 @@
 def COMMIT_ID = 'unknown'
 pipeline {
   agent {
+    label 'qualification-katgpucbf'
+
     dockerfile {
       registryCredentialsId 'dockerhub'  // Supply credentials to avoid rate limit
 


### PR DESCRIPTION
Force it to run only on agents with qualification-katgpucbf label.

See NGC-1043.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
