### PR TITLE
Reduce memory usage for beamformer

### DIFF
--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -51,7 +51,6 @@ from .. import (
     __version__,
 )
 from .. import recv as base_recv
-from ..curand_helpers import RandomStateBuilder
 from ..mapped_array import MappedArray
 from ..monitor import Monitor
 from ..queue_item import QueueItem
@@ -141,13 +140,11 @@ class BTxQueueItem(QueueItem):
     def __init__(
         self,
         buffer_device: accel.DeviceArray,
-        rand_states: accel.DeviceArray,
         weights: MappedArray,
         delays: MappedArray,
         timestamp: int = 0,
     ) -> None:
         self.buffer_device = buffer_device
-        self.rand_states = rand_states
         self.weights = weights
         self.delays = delays
         #: Version of weights and delays (for comparison to BPipeline._weights_version)
@@ -311,32 +308,22 @@ class BPipeline(Pipeline[BOutput, BTxQueueItem]):
             n_ants=engine.n_ants,
             n_channels=engine.n_channels_per_substream,
             n_spectra_per_frame=engine.src_layout.n_spectra_per_heap,
+            seed=int(engine.time_converter.sync_epoch),
+            sequence_first=engine.channel_offset_value,
+            sequence_step=engine.n_channels_total,
         )
         allocator = accel.DeviceAllocator(context=context)
-        assert isinstance(context, katsdpsigproc.cuda.Context)
-        builder = RandomStateBuilder(context)
-        for i in range(self.n_tx_items):
+        for _ in range(self.n_tx_items):
             buffer_device = self._beamform.slots["out"].allocate(allocator=allocator, bind=False)
-            assert isinstance(self._beamform.slots["rand_states"], accel.IOSlot)
-            # sequence_first and sequence_step are chosen to ensure unique
-            # sequence numbers across all BTxItems in all instances of the
-            # engine.
-            # The seed uses the sync epoch so that it's reproducible while still
-            # changing over time.
-            rand_states = builder.make_states(
-                self._beamform.slots["rand_states"].shape,
-                seed=int(engine.time_converter.sync_epoch),
-                sequence_first=i * engine.n_channels_total + engine.channel_offset_value,
-                sequence_step=self.n_tx_items * engine.n_channels_total,
-            )
             # TODO: bring it back once support is inplemented
             # saturated = accel.DeviceArray(
             #     context, shape=(engine.heaps_per_fengine_per_chunk, n_beams), dtype=np.uint32
             # )
             weights = MappedArray.from_slot(vkgdr_handle, context, self._beamform.slots["weights"])
             delays = MappedArray.from_slot(vkgdr_handle, context, self._beamform.slots["delays"])
-            tx_item = BTxQueueItem(buffer_device, rand_states, weights, delays)
+            tx_item = BTxQueueItem(buffer_device, weights, delays)
             self._tx_free_item_queue.put_nowait(tx_item)
+
         # These are the original weights, delays and gains as provided by the
         # user, rather than the processed values passed to the kernel.
         self._weights = np.ones((len(outputs), engine.n_ants), np.float64)
@@ -483,7 +470,6 @@ class BPipeline(Pipeline[BOutput, BTxQueueItem]):
                     "out": tx_item.buffer_device,
                     "weights": tx_item.weights.device,
                     "delays": tx_item.delays.device,
-                    "rand_states": tx_item.rand_states,
                 }
             )
             self._beamform()

--- a/test/xbgpu/test_beamform.py
+++ b/test/xbgpu/test_beamform.py
@@ -16,14 +16,12 @@
 
 """Test the :mod:`katgpucbf.xbgpu.beamform` module."""
 
-import katsdpsigproc
 import numba
 import numpy as np
 import pytest
 from katsdpsigproc.abc import AbstractCommandQueue, AbstractContext
 
 from katgpucbf import COMPLEX, N_POLS
-from katgpucbf.curand_helpers import RandomStateBuilder
 from katgpucbf.xbgpu.beamform import BeamformTemplate
 
 
@@ -80,13 +78,7 @@ def test_beamform(
     n_beams = len(beam_pols)
 
     template = BeamformTemplate(context, beam_pols)
-    fn = template.instantiate(command_queue, n_frames, n_antennas, n_channels, n_times)
-
-    # Initialise the random states
-    assert isinstance(context, katsdpsigproc.cuda.Context)
-    assert isinstance(fn.slots["rand_states"], katsdpsigproc.accel.IOSlot)  # keep mypy happy
-    builder = RandomStateBuilder(context)
-    fn.bind(rand_states=builder.make_states(fn.slots["rand_states"].shape, seed=321, sequence_first=0))
+    fn = template.instantiate(command_queue, n_frames, n_antennas, n_channels, n_times, seed=321, sequence_first=0)
 
     fn.ensure_all_bound()
     h_in = fn.buffer("in").empty_like()


### PR DESCRIPTION
For some reason I previously made an array of random states per BTxItem, but there is no reason these need to be scoped that way since they're never transferred on or off the GPU. Change Beamform to allocate the random states internally, which also logically simplifies the structure since the caller doesn't need to worry about building the random states.

Closes NGC-1303.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
