### PR TITLE
Compute correlation saturation on the GPU

### DIFF
--- a/src/katgpucbf/xbgpu/correlation.py
+++ b/src/katgpucbf/xbgpu/correlation.py
@@ -316,28 +316,3 @@ class Correlation(accel.Operation):
         if ant1 > ant2:
             raise ValueError("It is required that ant2 >= ant1 in all cases")
         return ant2 * (ant2 + 1) // 2 + ant1
-
-    @staticmethod
-    def get_baselines_for_missing_ants(present_ants: np.ndarray, n_ants: int) -> list[int]:
-        """Get all baselines for ants indicated as missing in `present_ants`.
-
-        Parameters
-        ----------
-        present_ants
-            Boolean array indicating whether an antenna had data present or not
-            during an accumulation period.
-        n_ants
-            The number of antennas used for this correlator configuration.
-
-        Returns
-        -------
-        baseline_list
-            List of baselines whose indices match the missing antennas.
-        """
-        baseline_list = []
-        for a2 in range(n_ants):
-            for a1 in range(a2 + 1):
-                if not present_ants[a1] or not present_ants[a2]:
-                    baseline_list.append(Correlation.get_baseline_index(a1, a2))
-
-        return baseline_list

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -63,13 +63,12 @@ from . import DEFAULT_BPIPELINE_NAME, DEFAULT_N_RX_ITEMS, DEFAULT_N_TX_ITEMS, DE
 from .beamform import BeamformTemplate
 from .bsend import BSend
 from .bsend import make_stream as make_bstream
-from .correlation import Correlation, CorrelationTemplate
+from .correlation import CorrelationTemplate
 from .output import BOutput, Output, XOutput
 from .xsend import XSend, incomplete_accum_counter
 from .xsend import make_stream as make_xstream
 
 logger = logging.getLogger(__name__)
-MISSING = np.array([-(2**31), 1], dtype=np.int32)
 _O = TypeVar("_O", bound=Output)
 _T = TypeVar("_T", bound=QueueItem)
 
@@ -116,11 +115,13 @@ class XTxQueueItem(QueueItem):
         buffer_device: accel.DeviceArray,
         saturated: accel.DeviceArray,
         present_ants: np.ndarray,
+        present_baselines: MappedArray,
         timestamp: int = 0,
     ) -> None:
         self.buffer_device = buffer_device
         self.saturated = saturated
         self.present_ants = present_ants
+        self.present_baselines = present_baselines
         super().__init__(timestamp)
 
     def reset(self, timestamp: int = 0) -> None:
@@ -128,6 +129,20 @@ class XTxQueueItem(QueueItem):
         super().reset(timestamp=timestamp)
         self.present_ants.fill(True)  # Assume they're fine until told otherwise
         self.batches = 0
+
+    def update_present_baselines(self) -> None:
+        """Recompute present_baselines from present_ants."""
+        # See Correlation.get_baseline_index for the ordering.
+        # We do a column of the triangle at a time for efficiency.
+        n_ants = len(self.present_ants)
+        offset = 0
+        for i in range(n_ants):
+            section = self.present_baselines.host[offset : offset + i + 1]
+            if self.present_ants[i]:
+                section[:] = self.present_ants[: i + 1]
+            else:
+                section[:] = 0
+            offset += len(section)
 
 
 class BTxQueueItem(QueueItem):
@@ -591,6 +606,7 @@ class XPipeline(Pipeline[XOutput, XTxQueueItem]):
         output: XOutput,
         engine: "XBEngine",
         context: AbstractContext,
+        vkgdr_handle: vkgdr.Vkgdr,
         init_tx_enabled: bool,
         name: str = DEFAULT_XPIPELINE_NAME,
     ) -> None:
@@ -620,7 +636,10 @@ class XPipeline(Pipeline[XOutput, XTxQueueItem]):
             buffer_device = self.correlation.slots["out_visibilities"].allocate(allocator, bind=False)
             saturated = self.correlation.slots["out_saturated"].allocate(allocator, bind=False)
             present_ants = np.zeros(shape=(engine.n_ants,), dtype=bool)
-            tx_item = XTxQueueItem(buffer_device, saturated, present_ants)
+            present_baselines = MappedArray.from_slot(
+                vkgdr_handle, context, self.correlation.slots["present_baselines"]
+            )
+            tx_item = XTxQueueItem(buffer_device, saturated, present_ants, present_baselines)
             self._tx_free_item_queue.put_nowait(tx_item)
 
         self.send_stream = XSend(
@@ -706,6 +725,7 @@ class XPipeline(Pipeline[XOutput, XTxQueueItem]):
         # Update the sync sensor (converting np.bool_ to Python bool)
         self.engine.sensors[f"{self.output.name}.rx.synchronised"].value = bool(tx_item.present_ants.all())
 
+        tx_item.update_present_baselines()
         self.correlation.reduce()
         tx_item.add_marker(self._proc_command_queue)
         self._tx_item_queue.put_nowait(tx_item)
@@ -715,7 +735,11 @@ class XPipeline(Pipeline[XOutput, XTxQueueItem]):
         tx_item = await self._tx_free_item_queue.get()
         await tx_item.async_wait_for_events()
         tx_item.reset(next_accum * self.timestamp_increment_per_accumulation)
-        self.correlation.bind(out_visibilities=tx_item.buffer_device, out_saturated=tx_item.saturated)
+        self.correlation.bind(
+            out_visibilities=tx_item.buffer_device,
+            out_saturated=tx_item.saturated,
+            present_baselines=tx_item.present_baselines.device,
+        )
         self.correlation.zero_visibilities()
         return tx_item
 
@@ -743,7 +767,11 @@ class XPipeline(Pipeline[XOutput, XTxQueueItem]):
 
         # Indicate that the timestamp still needs to be filled in.
         tx_item.timestamp = -1
-        self.correlation.bind(out_visibilities=tx_item.buffer_device, out_saturated=tx_item.saturated)
+        self.correlation.bind(
+            out_visibilities=tx_item.buffer_device,
+            out_saturated=tx_item.saturated,
+            present_baselines=tx_item.present_baselines.device,
+        )
         self.correlation.zero_visibilities()
         while True:
             # Get item from the receiver function.
@@ -854,21 +882,10 @@ class XPipeline(Pipeline[XOutput, XTxQueueItem]):
             event = self._download_command_queue.enqueue_marker()
             await katsdpsigproc.resource.async_wait_for_events([event])
 
-            if not np.any(item.present_ants):
-                # All Antennas have missed data at some point, mark the entire dump missing
-                logger.warning("All Antennas had a break in data during this accumulation")
-                heap.buffer[...] = MISSING
+            if not np.all(item.present_ants):
                 incomplete_accum_counter.labels(self.output.name).inc(1)
-            elif not item.present_ants.all():
-                affected_baselines = Correlation.get_baselines_for_missing_ants(item.present_ants, self.engine.n_ants)
-                for affected_baseline in affected_baselines:
-                    # Multiply by four as each baseline (antenna pair) has four
-                    # associated correlation components (polarisation pairs).
-                    affected_baseline_index = affected_baseline * 4
-                    heap.buffer[:, affected_baseline_index : affected_baseline_index + 4, :] = MISSING
-
-                incomplete_accum_counter.labels(self.output.name).inc(1)
-            # else: No F-Engines had a break in data for this accumulation
+                if not np.any(item.present_ants):
+                    logger.warning("All Antennas had a break in data during this accumulation")
 
             heap.timestamp = item.timestamp
             if self.send_stream.tx_enabled:
@@ -1124,18 +1141,18 @@ class XBEngine(DeviceServer):
         # RxQueueItems.
         self._active_in_sem = asyncio.BoundedSemaphore(1)
 
+        with context:
+            # We could quite easily make do with non-coherent mappings and
+            # explicit flushing, but since NVIDIA currently only provides
+            # host-coherent memory, this is a simpler option.
+            vkgdr_handle = vkgdr.Vkgdr.open_current_context(vkgdr.OpenFlags.REQUIRE_COHERENT_BIT)
+
         self._pipelines: list[Pipeline] = []
         x_outputs = [output for output in outputs if isinstance(output, XOutput)]
         b_outputs = [output for output in outputs if isinstance(output, BOutput)]
-        self._pipelines = [XPipeline(x_output, self, context, tx_enabled) for x_output in x_outputs]
+        self._pipelines = [XPipeline(x_output, self, context, vkgdr_handle, tx_enabled) for x_output in x_outputs]
         if b_outputs:
-            with context:
-                # We could quite easily make do with non-coherent mappings and
-                # explicit flushing, but since NVIDIA currently only provides
-                # host-coherent memory, this is a simpler option.
-                vkgdr_handle = vkgdr.Vkgdr.open_current_context(vkgdr.OpenFlags.REQUIRE_COHERENT_BIT)
             self._pipelines.append(BPipeline(b_outputs, self, context, vkgdr_handle, tx_enabled))
-
         self._upload_command_queue = context.create_command_queue()
 
         # This queue is extended in the monitor class, allowing for the


### PR DESCRIPTION
Apart from being more efficient, this fixes a bug where saturation counts were computed before flagging missing data, potentially causing incorrect saturation counts.

The present antennas are used to compute present baselines (on the CPU) and transferred to the GPU through a MappedArray. The reduction kernel checks this array to decide whether to saturate or to replace with the MISSING flag.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-830.
