### PR TITLE
Specify build-backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = [
 	"setuptools>=45",
 	"setuptools_scm[toml]>=6.0",
 ]
+build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 


### PR DESCRIPTION
I've been seeing warnings saying
```
WARNING: Missing build requirements in pyproject.toml for file:///home/jenkins/workspace/qualification_katgpucbf.
WARNING: The project does not specify a build backend, and pip cannot fall back to setuptools without 'wheel'.
```

Hopefully this will resolve it.
