### PR TITLE
Support for product-configure schema version 4

### DIFF
--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -311,7 +311,7 @@ async def _cbf_config_and_description(
     narrowband_decimation: int,
 ) -> tuple[dict, dict]:
     config: dict = {
-        "version": "3.5",
+        "version": "4.0",
         "config": {},
         "inputs": {},
         "outputs": {},

--- a/scratch/sim_correlator.py
+++ b/scratch/sim_correlator.py
@@ -58,6 +58,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         metavar="ADDRESS",
         help="Starting IP address for external digitisers",
     )
+    parser.add_argument("--sync-epoch", type=float, help="Digitiser sync epoch [current time]")
     parser.add_argument("--band", default="l", choices=BANDS.keys(), help="Band ID [%(default)s]")
     parser.add_argument("--adc-sample-rate", type=float, help="ADC sample rate in Hz [from --band]")
     parser.add_argument("--centre-frequency", type=float, help="Sky centre frequency in Hz [from --band]")
@@ -93,6 +94,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         args.narrowband_centre_frequency = args.adc_sample_rate / 4
     if args.digitisers is None:
         args.digitisers = args.antennas
+    if args.digitiser_address is not None and args.sync_epoch is None:
+        parser.error("--sync-epoch is required when specifying --digitiser-address")
     return args
 
 
@@ -119,9 +122,12 @@ def generate_digitisers(args: argparse.Namespace, config: dict) -> list[str]:
                     "centre_frequency": args.centre_frequency,
                     "antenna": f"m{number}, 0:0:0, 0:0:0, 0, 0",
                 }
+                if args.sync_epoch is not None:
+                    config["outputs"][name]["sync_epoch"] = args.sync_epoch
             else:
                 config["inputs"][name] = {
                     "type": "dig.baseband_voltage",
+                    "sync_epoch": args.sync_epoch,
                     "band": args.band,
                     "adc_sample_rate": args.adc_sample_rate,
                     "centre_frequency": args.centre_frequency,
@@ -204,7 +210,7 @@ def generate_sdp(args: argparse.Namespace, outputs: dict) -> None:
 def generate_config(args: argparse.Namespace) -> dict:
     """Produce the configuration dict from the parsed command-line arguments."""
     config: dict = {
-        "version": "3.5",
+        "version": "4.0",
         "config": {},
         "inputs": {},
         "outputs": {},

--- a/src/katgpucbf/dsim/main.py
+++ b/src/katgpucbf/dsim/main.py
@@ -239,16 +239,17 @@ async def async_main() -> None:
     # a separate process for the signal service that shouldn't inherit this.
     if args.main_affinity >= 0:
         os.sched_setaffinity(0, [args.main_affinity])
+
+    if args.sync_time is None:
+        args.sync_time = time.time()
+    server.sensors["sync-time"].value = args.sync_time
     await server.start()
 
     add_signal_handlers(server)
     add_gc_stats()
 
-    now = time.time()
-    if args.sync_time is None:
-        args.sync_time = now
     time_converter = TimeConverter(args.sync_time, args.adc_sample_rate)
-    timestamp = first_timestamp(time_converter, now, args.max_period)
+    timestamp = first_timestamp(time_converter, time.time(), args.max_period)
     start_time = time_converter.adc_to_unix(timestamp)
 
     logger.info("First timestamp will be %#x", timestamp)

--- a/src/katgpucbf/dsim/server.py
+++ b/src/katgpucbf/dsim/server.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2021-2023, National Research Foundation (SARAO)
+# Copyright (c) 2021-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katgpucbf/dsim/server.py
+++ b/src/katgpucbf/dsim/server.py
@@ -154,6 +154,15 @@ class DeviceServer(aiokatcp.DeviceServer):
                 default=sample_bits,
             )
         )
+        # The value of sync-time is initialised later by main.py
+        self.sensors.add(
+            aiokatcp.Sensor(
+                float,
+                "sync-time",
+                "The UNIX time corresponding to timestamp 0",
+                "s",
+            )
+        )
 
     async def on_stop(self) -> None:  # noqa: D102
         self.sender.halt()

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -392,7 +392,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--gain", type=float, default=1.0, help="Initial eq gains [%(default)s]")
     parser.add_argument(
         "--sync-epoch",
-        type=int,  # AFAIK, the digitisers sync on PPS signals, so it makes sense for this to be an int.
+        type=float,
         required=True,
         help="UNIX time at which digitisers were synced.",
     )
@@ -486,7 +486,7 @@ def make_engine(ctx: AbstractContext, args: argparse.Namespace) -> tuple[Engine,
         dst_sample_bits=args.dst_sample_bits,
         max_delay_diff=args.max_delay_diff,
         gain=args.gain,
-        sync_epoch=float(args.sync_epoch),  # CLI arg is an int, but SDP can handle a float downstream.
+        sync_epoch=args.sync_epoch,
         mask_timestamp=args.mask_timestamp,
         use_vkgdr=args.use_vkgdr,
         use_peerdirect=args.use_peerdirect,


### PR DESCRIPTION
- Allow `--sync-epoch` to be specified as float to fgpu (it was already allowed for dsim and xbgpu)
- Add `sync-time` sensor to dsim
- Use [schema version 4](https://docs.google.com/document/d/15ZIyuBf4Vk4ESIEdKsQxdSBoLEwh85eyKeDJouLRAZY/edit#heading=h.bxv6wohps6p4) in qualification and in sim_correlator.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
- [x] Merge together with https://github.com/ska-sa/katsdpcontroller/pull/731

Relates to SPR1-3072.
