### PR TITLE
Globally rename sync_epoch to sync_time

### DIFF
--- a/doc/engines.rst
+++ b/doc/engines.rst
@@ -76,10 +76,9 @@ Stream Group
 
 Timestamp
     Timestamps are expressed in units of ADC (analogue-to-digital converter)
-    samples, measured from a configurable "sync epoch" (also known as the "sync
-    time"). When a timestamp is associated with a collection of data, it
-    generally reflects the timestamp of the *first* ADC sample that forms part
-    of that data.
+    samples, measured from a configurable "sync time". When a timestamp is
+    associated with a collection of data, it generally reflects the timestamp
+    of the *first* ADC sample that forms part of that data.
 
 Operation
 ---------

--- a/scratch/benchmarks/benchmark_fgpu.py
+++ b/scratch/benchmarks/benchmark_fgpu.py
@@ -171,7 +171,7 @@ def fgpu_factory(
         f"--adc-sample-rate={adc_sample_rate} "
         f"--katcp-port={katcp_port} "
         f"--prometheus-port={prometheus_port} "
-        f"--sync-epoch={sync_time} "
+        f"--sync-time={sync_time} "
         f"--feng-id={index} "
         f"{'--use-vkgdr --max-delay-diff=65536' if args.use_vkgdr else ''} "
         f"--wideband={wideband_arg} "

--- a/scratch/fgpu/run-fgpu-hbw.sh
+++ b/scratch/fgpu/run-fgpu-hbw.sh
@@ -32,7 +32,7 @@ exec spead2_net_raw taskset -c $other_affinity fgpu \
     --spectra-per-heap ${spectra_per_heap:-256} \
     --katcp-port $katcp_port \
     --prometheus-port $prom_port \
-    --sync-epoch 0 \
+    --sync-time 0 \
     --array-size ${array_size:-8} \
     --feng-id "$feng_id" \
     --wideband "name=wideband,channels=${channels:-32768},dst=$dst" \

--- a/scratch/fgpu/run-fgpu.sh
+++ b/scratch/fgpu/run-fgpu.sh
@@ -57,7 +57,7 @@ exec spead2_net_raw taskset -c $other_affinity fgpu \
     --spectra-per-heap ${spectra_per_heap:-256} \
     --katcp-port $katcp_port \
     --prometheus-port $prom_port \
-    --sync-epoch 0 \
+    --sync-time 0 \
     --array-size ${array_size:-8} \
     --feng-id "$feng_id" \
     --wideband "name=wideband,channels=${channels:-32768},dst=$dst" \

--- a/scratch/sim_correlator.py
+++ b/scratch/sim_correlator.py
@@ -58,7 +58,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         metavar="ADDRESS",
         help="Starting IP address for external digitisers",
     )
-    parser.add_argument("--sync-epoch", type=float, help="Digitiser sync epoch [current time]")
+    parser.add_argument("--sync-time", type=float, help="Digitiser sync time [current time]")
     parser.add_argument("--band", default="l", choices=BANDS.keys(), help="Band ID [%(default)s]")
     parser.add_argument("--adc-sample-rate", type=float, help="ADC sample rate in Hz [from --band]")
     parser.add_argument("--centre-frequency", type=float, help="Sky centre frequency in Hz [from --band]")
@@ -94,8 +94,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         args.narrowband_centre_frequency = args.adc_sample_rate / 4
     if args.digitisers is None:
         args.digitisers = args.antennas
-    if args.digitiser_address is not None and args.sync_epoch is None:
-        parser.error("--sync-epoch is required when specifying --digitiser-address")
+    if args.digitiser_address is not None and args.sync_time is None:
+        parser.error("--sync-time is required when specifying --digitiser-address")
     return args
 
 
@@ -122,12 +122,12 @@ def generate_digitisers(args: argparse.Namespace, config: dict) -> list[str]:
                     "centre_frequency": args.centre_frequency,
                     "antenna": f"m{number}, 0:0:0, 0:0:0, 0, 0",
                 }
-                if args.sync_epoch is not None:
-                    config["outputs"][name]["sync_epoch"] = args.sync_epoch
+                if args.sync_time is not None:
+                    config["outputs"][name]["sync_time"] = args.sync_time
             else:
                 config["inputs"][name] = {
                     "type": "dig.baseband_voltage",
-                    "sync_epoch": args.sync_epoch,
+                    "sync_time": args.sync_time,
                     "band": args.band,
                     "adc_sample_rate": args.adc_sample_rate,
                     "centre_frequency": args.centre_frequency,

--- a/scratch/xbgpu/run-xbgpu.sh
+++ b/scratch/xbgpu/run-xbgpu.sh
@@ -84,7 +84,7 @@ exec schedrr spead2_net_raw numactl -C $other_affinity xbgpu \
     --channels-per-substream $channels_per_substream \
     --samples-between-spectra $samples_between_spectra \
     --channel-offset-value $channel_offset \
-    --sync-epoch 0 \
+    --sync-time 0 \
     --katcp-port $katcp_port \
     --prometheus-port $prom_port \
     --tx-enabled \

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1111,7 +1111,7 @@ class Engine(aiokatcp.DeviceServer):
         Maximum supported difference between delays across polarisations (in samples).
     gain
         Initial eq gain for all channels.
-    sync_epoch
+    sync_time
         UNIX time at which the digitisers were synced.
     mask_timestamp
         Mask off bottom bits of timestamp (workaround for broken digitiser).
@@ -1161,7 +1161,7 @@ class Engine(aiokatcp.DeviceServer):
         dst_sample_bits: int,
         max_delay_diff: int,
         gain: complex,
-        sync_epoch: float,
+        sync_time: float,
         mask_timestamp: bool,
         use_vkgdr: bool,
         use_peerdirect: bool,
@@ -1192,7 +1192,7 @@ class Engine(aiokatcp.DeviceServer):
         self.n_ants = num_ants
         self.chunk_jones = chunk_jones
         self.default_gain = gain
-        self.time_converter = TimeConverter(sync_epoch, adc_sample_rate)
+        self.time_converter = TimeConverter(sync_time, adc_sample_rate)
         self.monitor = monitor
         self.use_vkgdr = use_vkgdr
         self.use_peerdirect = use_peerdirect
@@ -1601,7 +1601,7 @@ class Engine(aiokatcp.DeviceServer):
         # then we'd need to compensate for that here.
         start_sample_count = round(self.time_converter.unix_to_adc(start_time))
         if start_sample_count < 0:
-            raise aiokatcp.FailReply("Start time cannot be prior to the sync epoch")
+            raise aiokatcp.FailReply("Start time cannot be prior to the sync time")
 
         # Collect them in a temporary until they're all validated
         new_linear_models = []

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -391,7 +391,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--gain", type=float, default=1.0, help="Initial eq gains [%(default)s]")
     parser.add_argument(
-        "--sync-epoch",
+        "--sync-time",
         type=float,
         required=True,
         help="UNIX time at which digitisers were synced.",
@@ -486,7 +486,7 @@ def make_engine(ctx: AbstractContext, args: argparse.Namespace) -> tuple[Engine,
         dst_sample_bits=args.dst_sample_bits,
         max_delay_diff=args.max_delay_diff,
         gain=args.gain,
-        sync_epoch=args.sync_epoch,
+        sync_time=args.sync_time,
         mask_timestamp=args.mask_timestamp,
         use_vkgdr=args.use_vkgdr,
         use_peerdirect=args.use_peerdirect,

--- a/src/katgpucbf/utils.py
+++ b/src/katgpucbf/utils.py
@@ -350,7 +350,7 @@ class TimeConverter:
 
     Parameters
     ----------
-    sync_epoch
+    sync_time
         UNIX timestamp corresponding to ADC timestamp 0
     adc_sample_rate
         Number of ADC samples per second
@@ -360,17 +360,17 @@ class TimeConverter:
        This does not yet handle leap-seconds correctly.
     """
 
-    def __init__(self, sync_epoch: float, adc_sample_rate: float) -> None:
-        self.sync_epoch = sync_epoch
+    def __init__(self, sync_time: float, adc_sample_rate: float) -> None:
+        self.sync_time = sync_time
         self.adc_sample_rate = adc_sample_rate
 
     def unix_to_adc(self, timestamp: float) -> float:
         """Convert a UNIX timestamp to an ADC sample count."""
-        return (timestamp - self.sync_epoch) * self.adc_sample_rate
+        return (timestamp - self.sync_time) * self.adc_sample_rate
 
     def adc_to_unix(self, samples: float) -> float:
         """Convert an ADC sample count to a UNIX timstamp."""
-        return samples / self.adc_sample_rate + self.sync_epoch
+        return samples / self.adc_sample_rate + self.sync_time
 
 
 def gaussian_dtype(bits: int) -> np.dtype:

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -323,7 +323,7 @@ class BPipeline(Pipeline[BOutput, BTxQueueItem]):
             n_ants=engine.n_ants,
             n_channels=engine.n_channels_per_substream,
             n_spectra_per_frame=engine.src_layout.n_spectra_per_heap,
-            seed=int(engine.time_converter.sync_epoch),
+            seed=int(engine.time_converter.sync_time),
             sequence_first=engine.channel_offset_value,
             sequence_step=engine.n_channels_total,
         )
@@ -950,7 +950,7 @@ class XBEngine(DeviceServer):
         The number of time samples received per frequency channel.
     sample_bits
         The number of bits per sample. Only 8 bits is supported at the moment.
-    sync_epoch
+    sync_time
         UNIX time corresponding to timestamp zero
     channel_offset_value
         The index of the first channel in the subset of channels processed by
@@ -1020,7 +1020,7 @@ class XBEngine(DeviceServer):
         n_samples_between_spectra: int,
         n_spectra_per_heap: int,
         sample_bits: int,
-        sync_epoch: float,
+        sync_time: float,
         channel_offset_value: int,
         outputs: list[Output],
         src: list[tuple[str, int]],  # It's a list but it should be length 1 in xbgpu case.
@@ -1051,7 +1051,7 @@ class XBEngine(DeviceServer):
         # Array configuration parameters
         self.adc_sample_rate_hz = adc_sample_rate_hz
         self.bandwidth_hz = bandwidth_hz
-        self.time_converter = TimeConverter(sync_epoch, adc_sample_rate_hz)
+        self.time_converter = TimeConverter(sync_time, adc_sample_rate_hz)
         self.n_ants = n_ants
         self.n_channels_total = n_channels_total
         self.n_channels_per_substream = n_channels_per_substream

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -298,7 +298,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         "and still be accepted. [%(default)s]",
     )
     parser.add_argument(
-        "--sync-epoch",
+        "--sync-time",
         type=float,
         required=True,
         help="UNIX time at which digitisers were synced.",
@@ -407,7 +407,7 @@ def make_engine(context: AbstractContext, args: argparse.Namespace) -> tuple[XBE
         n_samples_between_spectra=args.samples_between_spectra,
         n_spectra_per_heap=args.jones_per_batch // args.channels,
         sample_bits=args.sample_bits,
-        sync_epoch=args.sync_epoch,
+        sync_time=args.sync_time,
         channel_offset_value=args.channel_offset_value,
         outputs=args.outputs,
         src=args.src,

--- a/test/fgpu/test_katcp_interface.py
+++ b/test/fgpu/test_katcp_interface.py
@@ -30,7 +30,7 @@ from katgpucbf.fgpu.engine import Engine
 pytestmark = [pytest.mark.cuda_only]
 
 CHANNELS = 4096
-SYNC_EPOCH = 1632561921
+SYNC_TIME = 1632561921
 GAIN = 0.125  # Exactly representable to avoid some rounding issues
 
 
@@ -60,7 +60,7 @@ class TestKatcpRequests:
             "--katcp-port=0",
             "--src-interface=lo",
             "--dst-interface=lo",
-            f"--sync-epoch={SYNC_EPOCH}",
+            f"--sync-time={SYNC_TIME}",
             f"--gain={GAIN}",
             "--adc-sample-rate=1.712e9",
             f"--wideband=name=wideband,dst=239.10.11.0+15:7149,channels={CHANNELS}",
@@ -201,7 +201,7 @@ class TestKatcpRequests:
             phase, phase_rate = (float(value) for value in phase_str.split(","))
             return delay, delay_rate, wrap_angle(phase), phase_rate
 
-        start_time = SYNC_EPOCH
+        start_time = SYNC_TIME
         await engine_client.request(
             "delays", "wideband", start_time, correct_delay_strings[0], correct_delay_strings[1]
         )
@@ -237,7 +237,7 @@ class TestKatcpRequests:
 
         We test for various combinations of malformations of the delay string.
         """
-        start_time = SYNC_EPOCH + 10
+        start_time = SYNC_TIME + 10
         with pytest.raises(aiokatcp.FailReply):
             await engine_client.request(
                 "delays", "wideband", start_time, malformed_delay_string, malformed_delay_string
@@ -250,15 +250,15 @@ class TestKatcpRequests:
             await engine_client.request("delays", "wideband", "3.76,0.12:7.322,1.91")
         with pytest.raises(aiokatcp.FailReply):
             # Only one of the two models
-            await engine_client.request("delays", "wideband", SYNC_EPOCH, "3.76,0.12:7.322,1.91")
+            await engine_client.request("delays", "wideband", SYNC_TIME, "3.76,0.12:7.322,1.91")
 
     async def test_delay_model_update_too_many_arguments(self, engine_client: aiokatcp.Client) -> None:
         """Test that a delay request with too many arguments is rejected."""
         coeffs = "3.76,0.12:7.322,1.91"
         with pytest.raises(aiokatcp.FailReply):
-            await engine_client.request("delays", "wideband", SYNC_EPOCH, coeffs, coeffs, coeffs)
+            await engine_client.request("delays", "wideband", SYNC_TIME, coeffs, coeffs, coeffs)
 
-    async def test_delay_model_update_before_sync_epoch(self, engine_client: aiokatcp.Client) -> None:
-        """Test that a delay model loaded prior to the sync epoch is rejected."""
+    async def test_delay_model_update_before_sync_time(self, engine_client: aiokatcp.Client) -> None:
+        """Test that a delay model loaded prior to the sync time is rejected."""
         with pytest.raises(aiokatcp.FailReply):
-            await engine_client.request("delays", "wideband", SYNC_EPOCH - 1.0, "0,0:0,0", "0,0:0,0")
+            await engine_client.request("delays", "wideband", SYNC_TIME - 1.0, "0,0:0,0", "0,0:0,0")

--- a/test/fgpu/test_main.py
+++ b/test/fgpu/test_main.py
@@ -99,7 +99,7 @@ class TestParseArgs:
             "--src-interface=lo",
             "--dst-interface=lo",
             "--adc-sample-rate=1712000000.0",
-            "--sync-epoch=0",
+            "--sync-time=0",
             "--wideband=name=wideband,dst=239.0.3.0+1:7148,channels=1024,taps=64,w_cutoff=0.9,jones_per_batch=262144",
             (
                 "--narrowband=name=nb0,dst=239.1.0.0+1,channels=32768,"

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -760,7 +760,7 @@ class TestEngine:
             f"--channel-offset-value={frequency}",
             f"--jones-per-batch={n_jones_per_batch}",
             f"--heaps-per-fengine-per-chunk={HEAPS_PER_FENGINE_PER_CHUNK}",
-            "--sync-epoch=1234567890",
+            "--sync-time=1234567890",
             "--src-interface=lo",
             "--dst-interface=lo",
             "--tx-enabled",


### PR DESCRIPTION
This makes everything consistent. This will need a matching katsdpcontroller change to pass the correct command-line arguments.

See SPR1-3072.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
