### PR TITLE
Bump aiohttp to the latest version

### DIFF
--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -9,7 +9,7 @@ aioconsole==0.7.0
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   aiomonitor
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ aioconsole==0.7.0
     # via
     #   -c requirements.txt
     #   aiomonitor
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   -c requirements.txt
     #   aiomonitor

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 aioconsole==0.7.0
     # via aiomonitor
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   aiomonitor
     #   prometheus-async

--- a/scratch/benchmarks/requirements.txt
+++ b/scratch/benchmarks/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=scratch/benchmarks/requirements.txt scratch/benchmarks/requirements.in
 #
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   -c scratch/benchmarks/../../qualification/requirements.txt
     #   -c scratch/benchmarks/../../requirements-dev.txt


### PR DESCRIPTION
To keep dependabot happy. We're not actually affected by the security issue (it only affects the server side of aiohttp, and only for serving static content).

<!-- Add a description of your change here -->

Checklist is N/A.