### PR TITLE
Privatise OutputDicts

### DIFF
--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -54,7 +54,7 @@ from .engine import Engine
 from .output import NarrowbandOutput, WidebandOutput
 
 _T = TypeVar("_T")
-_OD = TypeVar("_OD", bound="OutputDict")
+_OD = TypeVar("_OD", bound="_OutputDict")
 logger = logging.getLogger(__name__)
 DEFAULT_TAPS = 16
 DEFAULT_W_CUTOFF = 1.0
@@ -63,7 +63,7 @@ DEFAULT_DDC_TAPS_RATIO = 12
 DEFAULT_WEIGHT_PASS = 0.005
 
 
-class OutputDict(TypedDict, total=False):
+class _OutputDict(TypedDict, total=False):
     """Configuration options for an output stream.
 
     Unlike :class:`WidebandOutput` or :class:`NarrowbandOutput`, all the fields
@@ -79,19 +79,19 @@ class OutputDict(TypedDict, total=False):
     w_cutoff: float
 
 
-class WidebandOutputDict(OutputDict, total=False):
+class _WidebandOutputDict(_OutputDict, total=False):
     """Configuration options for a wideband output.
 
-    See :class:`OutputDict` for further information.
+    See :class:`_OutputDict` for further information.
     """
 
     pass
 
 
-class NarrowbandOutputDict(OutputDict, total=False):
+class _NarrowbandOutputDict(_OutputDict, total=False):
     """Configuration options for a narrowband output.
 
-    See :class:`OutputDict` for further information.
+    See :class:`_OutputDict` for further information.
     """
 
     centre_frequency: float
@@ -144,11 +144,11 @@ def parse_wideband(value: str) -> WidebandOutput:
     - dst
     """
 
-    def field_callback(kws: WidebandOutputDict, key: str, data: str) -> None:
+    def field_callback(kws: _WidebandOutputDict, key: str, data: str) -> None:
         raise ValueError(f"unknown key {key}")
 
     try:
-        kws: WidebandOutputDict = {}
+        kws: _WidebandOutputDict = {}
         _parse_stream(value, kws, field_callback)
         kws = {
             "taps": DEFAULT_TAPS,
@@ -175,7 +175,7 @@ def parse_narrowband(value: str) -> NarrowbandOutput:
     - dst
     """
 
-    def field_callback(kws: NarrowbandOutputDict, key: str, data: str) -> None:
+    def field_callback(kws: _NarrowbandOutputDict, key: str, data: str) -> None:
         match key:
             case "centre_frequency" | "weight_pass":
                 kws[key] = float(data)
@@ -185,7 +185,7 @@ def parse_narrowband(value: str) -> NarrowbandOutput:
                 raise ValueError(f"unknown key {key}")
 
     try:
-        kws: NarrowbandOutputDict = {}
+        kws: _NarrowbandOutputDict = {}
         _parse_stream(value, kws, field_callback)
         for key in ["centre_frequency", "decimation"]:
             if key not in kws:
@@ -421,7 +421,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     if args.src_ibv and len(args.src_affinity) != len(args.src_comp_vector):
         parser.error("--src-comp-vector must have same length as --src-affinity")
 
-    # Convert from *OutputDict to *Output
+    # Convert from _*OutputDict to *Output
     used_names = set()
     args.outputs = []
     for output_group in [args.wideband, args.narrowband]:

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -60,11 +60,11 @@ from ..utils import add_gc_stats, add_signal_handlers, parse_source
 from .correlation import device_filter
 from .output import BOutput, XOutput
 
-_OD = TypeVar("_OD", bound="OutputDict")
+_OD = TypeVar("_OD", bound="_OutputDict")
 logger = logging.getLogger(__name__)
 
 
-class OutputDict(TypedDict, total=False):
+class _OutputDict(TypedDict, total=False):
     """Configuration options for an output stream.
 
     Unlike :class:`BOutput` or :class:`XOutput`, all the fields are optional,
@@ -76,19 +76,19 @@ class OutputDict(TypedDict, total=False):
     dst: Endpoint
 
 
-class BOutputDict(OutputDict, total=False):
+class _BOutputDict(_OutputDict, total=False):
     """Configuration options for a beam output.
 
-    See :class:`OutputDict` for further information.
+    See :class:`_OutputDict` for further information.
     """
 
     pol: int
 
 
-class XOutputDict(OutputDict, total=False):
+class _XOutputDict(_OutputDict, total=False):
     """Configuration options for a baseline-correlation output.
 
-    See :class:`OutputDict` for further information.
+    See :class:`_OutputDict` for further information.
     """
 
     heap_accumulation_threshold: int
@@ -134,7 +134,7 @@ def parse_beam(value: str) -> BOutput:
     - pol
     """
 
-    def _field_callback(kws: BOutputDict, key: str, data: str) -> None:
+    def _field_callback(kws: _BOutputDict, key: str, data: str) -> None:
         match key:
             case "pol":
                 kws[key] = int(data)
@@ -144,7 +144,7 @@ def parse_beam(value: str) -> BOutput:
                 raise ValueError(f"unknown key {key}")
 
     try:
-        kws: BOutputDict = {}
+        kws: _BOutputDict = {}
         _parse_stream(value, kws, _field_callback)
         if "pol" not in kws:
             raise ValueError("pol is missing")
@@ -165,7 +165,7 @@ def parse_corrprod(value: str) -> XOutput:
     - heap_accumulation_threshold
     """
 
-    def _field_callback(kws: XOutputDict, key: str, data: str) -> None:
+    def _field_callback(kws: _XOutputDict, key: str, data: str) -> None:
         match key:
             case "heap_accumulation_threshold":
                 kws[key] = int(data)
@@ -173,7 +173,7 @@ def parse_corrprod(value: str) -> XOutput:
                 raise ValueError(f"unknown key {key}")
 
     try:
-        kws: XOutputDict = {}
+        kws: _XOutputDict = {}
         _parse_stream(value, kws, _field_callback)
         if "heap_accumulation_threshold" not in kws:
             raise ValueError("heap_accumulation_threshold is missing")


### PR DESCRIPTION
These were not intended to be part of any public API. This commit makes them explicitly "private".

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (NA) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-988.