### PR TITLE
Add qual test for beam-weights/beam-quant-gains linearity

### DIFF
--- a/qualification/tied_array_channelised_voltage/test_linearity.py
+++ b/qualification/tied_array_channelised_voltage/test_linearity.py
@@ -1,0 +1,137 @@
+################################################################################
+# Copyright (c) 2024, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Test linearity of gains and weights."""
+
+from typing import Awaitable, Callable
+
+import aiokatcp
+import numpy as np
+import pytest
+from matplotlib.figure import Figure
+
+from .. import CBFRemoteControl, TiedArrayChannelisedVoltageReceiver
+from ..reporter import Reporter
+
+
+async def test_linearity(
+    cbf: CBFRemoteControl,
+    receiver: TiedArrayChannelisedVoltageReceiver,
+    pdf_report: Reporter,
+    fixed: str,
+    variable: str,
+    set_fixed: Callable[[aiokatcp.Client, str, float], Awaitable],
+    set_variable: Callable[[aiokatcp.Client, str, float], Awaitable],
+) -> None:
+    client = cbf.product_controller_client
+    beam_name = receiver.stream_names[0]
+    n_sources = len(receiver.source_indices[0])
+
+    # Small amplitude so that we don't saturate in the time domain.
+    period = receiver.n_spectra_per_heap * receiver.n_samples_between_spectra
+    await cbf.dsim_gaussian(16.0, pdf_report, period=period)
+
+    pdf_report.step(f"Set {fixed} to 1/antennas")
+    await set_fixed(client, beam_name, 1.0 / n_sources)
+    pdf_report.detail(f"Set {fixed} on {beam_name} to 1/{n_sources}")
+
+    pdf_report.step("Measure total power responses")
+    scales = np.logspace(-2.0, 2.0, 41)  # Note: n is chosen to ensure 1.0 is included
+    middle = np.searchsorted(scales, 1.0)
+    assert scales[middle] == pytest.approx(1.0)
+    powers = np.zeros_like(scales)
+    for i, scale in enumerate(scales):
+        await set_variable(client, beam_name, scale)
+        _, data = await receiver.next_complete_chunk()
+        powers[i] = np.sum(np.square(data[0].astype(np.float64)))
+        pdf_report.detail(f"Set {variable} to {scale}; power is {powers[i]}")
+
+    # Normalise power
+    powers /= powers[middle]
+
+    fig = Figure()
+    ax = fig.add_subplot()
+    ax.set_title(f"Normalised power relative to {variable}")
+    ax.set_xlabel(f"{variable} (dB)")
+    ax.set_ylabel("power (dB)")
+    scales_db = 20 * np.log10(scales)
+    powers_db = 10 * np.log10(powers)
+    ax.plot(scales_db, scales_db, label="Reference")
+    ax.plot(scales_db, powers_db, label="Measured")
+    ax.legend()
+    pdf_report.figure(fig)
+
+
+@pytest.mark.requirements("CBF-REQ-0123")
+async def test_weight_linearity(
+    cbf: CBFRemoteControl,
+    receive_tied_array_channelised_voltage: TiedArrayChannelisedVoltageReceiver,
+    pdf_report: Reporter,
+) -> None:
+    """Test linearity of the weight coefficients.
+
+    Verification method
+    -------------------
+    Verification by means of test. Configure the dsim with Gaussian noise with
+    a period of one heap. Set the weights for all inputs to a range of values,
+    and measure the total power (for one beam) in each case.
+
+    Large weights are expected to have non-linear response due to saturation,
+    and small weights are expected to have non-linear response due to
+    quantisation.
+    """
+    receiver = receive_tied_array_channelised_voltage
+    n_sources = len(receiver.source_indices[0])
+    await test_linearity(
+        cbf,
+        receiver,
+        pdf_report,
+        "quantisation gain",
+        "weight",
+        lambda client, stream, gain: client.request("beam-quant-gains", stream, gain),
+        lambda client, stream, weight: client.request("beam-weights", stream, *([weight] * n_sources)),
+    )
+
+
+@pytest.mark.requirements("CBF-REQ-0117")
+async def test_gain_linearity(
+    cbf: CBFRemoteControl,
+    receive_tied_array_channelised_voltage: TiedArrayChannelisedVoltageReceiver,
+    pdf_report: Reporter,
+) -> None:
+    """Test linearity of the quantisation gains.
+
+    Verification method
+    -------------------
+    Verification by means of test. Configure the dsim with Gaussian noise with
+    a period of one heap. Set the gain to a range of values, and measure the
+    total power (for one beam) in each case.
+
+    Large gains are expected to have non-linear response due to saturation,
+    and small gains are expected to have non-linear response due to
+    quantisation.
+    """
+    receiver = receive_tied_array_channelised_voltage
+    n_sources = len(receiver.source_indices[0])
+    await test_linearity(
+        cbf,
+        receiver,
+        pdf_report,
+        "weight",
+        "quantisation gain",
+        lambda client, stream, weight: client.request("beam-weights", stream, *([weight] * n_sources)),
+        lambda client, stream, gain: client.request("beam-quant-gains", stream, gain),
+    )

--- a/qualification/tied_array_channelised_voltage/test_linearity.py
+++ b/qualification/tied_array_channelised_voltage/test_linearity.py
@@ -40,8 +40,8 @@ async def _test_linearity(
     beam_name = receiver.stream_names[0]
     n_sources = len(receiver.source_indices[0])
 
-    # Small amplitude so that we don't saturate in the time domain.
     period = receiver.n_spectra_per_heap * receiver.n_samples_between_spectra
+    # Small amplitude so that we don't saturate in the time domain.
     await cbf.dsim_gaussian(16.0, pdf_report, period=period)
 
     pdf_report.step(f"Set {fixed} to 1/antennas")
@@ -56,7 +56,8 @@ async def _test_linearity(
     for i, scale in enumerate(scales):
         await set_variable(client, beam_name, scale)
         _, data = await receiver.next_complete_chunk()
-        powers[i] = np.sum(np.square(data[0].astype(np.float64)))
+        data = data[0]  # Use only the first beam
+        powers[i] = np.sum(np.square(data.astype(np.float64)))
         pdf_report.detail(f"Set {variable} to {scale}; power is {powers[i]}")
 
     # Normalise power

--- a/qualification/tied_array_channelised_voltage/test_linearity.py
+++ b/qualification/tied_array_channelised_voltage/test_linearity.py
@@ -27,7 +27,7 @@ from .. import CBFRemoteControl, TiedArrayChannelisedVoltageReceiver
 from ..reporter import Reporter
 
 
-async def test_linearity(
+async def _test_linearity(
     cbf: CBFRemoteControl,
     receiver: TiedArrayChannelisedVoltageReceiver,
     pdf_report: Reporter,
@@ -95,7 +95,7 @@ async def test_weight_linearity(
     """
     receiver = receive_tied_array_channelised_voltage
     n_sources = len(receiver.source_indices[0])
-    await test_linearity(
+    await _test_linearity(
         cbf,
         receiver,
         pdf_report,
@@ -126,7 +126,7 @@ async def test_gain_linearity(
     """
     receiver = receive_tied_array_channelised_voltage
     n_sources = len(receiver.source_indices[0])
-    await test_linearity(
+    await _test_linearity(
         cbf,
         receiver,
         pdf_report,

--- a/qualification/tied_array_channelised_voltage/test_weights.py
+++ b/qualification/tied_array_channelised_voltage/test_weights.py
@@ -18,6 +18,7 @@
 
 import numpy as np
 import pytest
+from matplotlib.figure import Figure
 from pytest_check import check
 
 from .. import CBFRemoteControl, TiedArrayChannelisedVoltageReceiver
@@ -97,3 +98,61 @@ async def test_weight_mapping(
         with check:
             assert np.all(np.abs(data[test_beam, channel]) < 2.0)
             pdf_report.detail("All other data is close to zero.")
+
+
+@pytest.mark.requirements("CBF-REQ-0123")
+async def test_weight_linearity(
+    cbf: CBFRemoteControl,
+    receive_tied_array_channelised_voltage: TiedArrayChannelisedVoltageReceiver,
+    pdf_report: Reporter,
+) -> None:
+    """Test linearity of the weight coefficients.
+
+    Verification method
+    -------------------
+    Verification by means of test. Configure the dsim with Gaussian noise with
+    a period of one heap. Set the weights for all inputs to a range of values,
+    and measure the total power (for one beam) in each case.
+
+    Large weights are expected to have non-linear response due to saturation,
+    and small weights are expected to have non-linear response due to
+    quantisation.
+    """
+    receiver = receive_tied_array_channelised_voltage
+    client = cbf.product_controller_client
+    beam_name = receiver.stream_names[0]
+    n_sources = len(receiver.source_indices[0])
+
+    # Small amplitude so that we don't saturate in the time domain.
+    period = receiver.n_spectra_per_heap * receiver.n_samples_between_spectra
+    await cbf.dsim_gaussian(16.0, pdf_report, period=period)
+
+    pdf_report.step("Set quantiser gain to 1/antennas")
+    await client.request("beam-quant-gains", beam_name, 1.0 / n_sources)
+    pdf_report.detail(f"Set beam-quant-gains on {beam_name} to 1/{n_sources}")
+
+    pdf_report.step("Measure total power responses")
+    weights = np.logspace(-2.0, 2.0, 41)  # Note: n is chosen to ensure 1.0 is included
+    middle = np.searchsorted(weights, 1.0)
+    assert weights[middle] == pytest.approx(1.0)
+    powers = np.zeros_like(weights)
+    for i, weight in enumerate(weights):
+        await client.request("beam-weights", beam_name, *([weight] * n_sources))
+        _, data = await receiver.next_complete_chunk()
+        powers[i] = np.sum(np.square(data[0].astype(np.float64)))
+        pdf_report.detail(f"Set weights to {weight}; power is {powers[i]}")
+
+    # Normalise power
+    powers /= powers[middle]
+
+    fig = Figure()
+    ax = fig.add_subplot()
+    ax.set_title("Normalised power relative to weight")
+    ax.set_xlabel("Weight (dB)")
+    ax.set_ylabel("Power (dB)")
+    weights_db = 20 * np.log10(weights)
+    powers_db = 10 * np.log10(powers)
+    ax.plot(weights_db, weights_db, label="Reference")
+    ax.plot(weights_db, powers_db, label="Measured")
+    ax.legend()
+    pdf_report.figure(fig)


### PR DESCRIPTION
Closes NGC-1256 and NGC-1257.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report: [report.pdf](https://github.com/ska-sa/katgpucbf/files/15109094/report.pdf)
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
