### PR TITLE
Add a narrowband frequency resolution test

### DIFF
--- a/qualification/antenna_channelised_voltage/test_narrowband.py
+++ b/qualification/antenna_channelised_voltage/test_narrowband.py
@@ -1,0 +1,44 @@
+################################################################################
+# Copyright (c) 2024, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Test specific features of narrowband."""
+
+import pytest
+
+from katgpucbf.meerkat import BANDS
+
+
+@pytest.mark.requirements("CBF-REQ-0044")
+def test_narrowband_centre_frequency() -> None:
+    r"""Test the resolution of the narrowband centre frequency.
+
+    Verification method
+    -------------------
+    Verified by analysis. The F-engine converts the frequency of the DDC mixer
+    to a fixed-point representation with 32 fractional bits. The units are
+    cycles per output (decimated) sample. The resolution is thus
+    :math:`\frac{f}{2^{32} d}`
+    where :math:`f` is the ADC sample rate and :math:`d` is the decimation
+    factor. For Narrowband Fine L-band,
+    :math:`f = 1712 \text{MHz}` and :math:`d = 16`, giving
+    a resolution of 0.025 Hz.
+
+    The interfaces which set and report the centre frequency use IEEE-754
+    double precision, which has significantly more precision than this and
+    is not the limiting factor.
+    """
+    for band in ["u", "l"]:
+        assert BANDS[band].adc_sample_rate / 2**32 / 16 < 100.0

--- a/qualification/report/requirements_text/CBF-REQ-0044.tex
+++ b/qualification/report/requirements_text/CBF-REQ-0044.tex
@@ -1,0 +1,4 @@
+The CBF, when configured to produce the Imaging data product set and Narrowband
+Fine resolution channelisation, and receiving UHF- or L-band data, shall digitally
+down-convert the sub-bands with a programmable band selection frequency with a
+centre frequency resolution of $\le \SI{100}{\hertz}$ across the entire pass band.


### PR DESCRIPTION
It's done by analysis. The actual resolution is so much smaller than the channel width that I think it would be tough to measure, although possibly one could measure the long-term phase drift of a tone.

The requirement text is taken from the original MK requirements spec. MK actually ships with much coarser resolution, so we should be fine when the requirements are finalised.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report: [report.pdf](https://github.com/ska-sa/katgpucbf/files/15110115/report.pdf)
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-638.
