### PR TITLE
Fix fgpu test_compute

### DIFF
--- a/test/fgpu/test_compute.py
+++ b/test/fgpu/test_compute.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2023, National Research Foundation (SARAO)
+# Copyright (c) 2020-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -36,13 +36,13 @@ def test_compute(context: AbstractContext, command_queue: AbstractCommandQueue, 
     decimation = 8
     ddc_taps = 128
     pfb_taps = 4
-    spectra_per_heap = 256
+    spectra_per_heap = 32
     subsampling = decimation
-    nb_spectra = 256
+    nb_spectra = 64
 
-    if mode == "wide":
+    if mode == "wideband":
         narrowband: compute.NarrowbandConfig | None = None
-        spectra = 1280
+        spectra = 160
         internal_channels = channels
     else:
         narrowband = compute.NarrowbandConfig(


### PR DESCRIPTION
A typo meant that the wideband version of the test never actually ran. Additionally, reduce `spectra_per_heap` and `spectra` to make the test use less memory, to improve on NGC-1281.

With this change, unit tests are able to run in 3GB of GPU memory. Test test/xbgpu/test_engine.py::TestEngine::test_engine_end_to_end[NVIDIA GeForce RTX 2060 (CUDA)-80-8192-1048576-0-heap_accumulation_threshold147] (basically the big test) runs out with 2GB.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match