### PR TITLE
Tweak xbgpu's test_saturation

### DIFF
--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -1157,9 +1157,13 @@ class TestEngine:
             await xbengine.stop()
 
         n_vis = n_channels_per_substream * n_baselines
-        assert prom_diff.get_sample_diff("output_x_visibilities_total", {"stream": "bcp1"}) == n_vis
-        assert prom_diff.get_sample_diff("output_x_clipped_visibilities_total", {"stream": "bcp1"}) == n_vis
-        assert xbengine.sensors["bcp1.xeng-clip-cnt"].value == n_vis
+        for corrprod_output in corrprod_outputs:
+            assert prom_diff.get_sample_diff("output_x_visibilities_total", {"stream": corrprod_output.name}) == n_vis
+            assert (
+                prom_diff.get_sample_diff("output_x_clipped_visibilities_total", {"stream": corrprod_output.name})
+                == n_vis
+            )
+            assert xbengine.sensors[f"{corrprod_output.name}.xeng-clip-cnt"].value == n_vis
 
     def _patch_get_rx_item(
         self, monkeypatch: pytest.MonkeyPatch, count: int, client: aiokatcp.Client, *request


### PR DESCRIPTION
Specifically to validate values for all corrprod-outputs, not just one.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1315.
