### PR TITLE
Extend timeout of qualification tests to 7 hours

### DIFF
--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
   }
 
   options {
-    timeout(time: 5, unit: 'HOURS')
+    timeout(time: 7, unit: 'HOURS')
   }
 
   stages {

--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
   }
 
   options {
-    timeout(time: 7, unit: 'HOURS')
+    timeout(time: 23, unit: 'HOURS')
   }
 
   stages {


### PR DESCRIPTION
See NGC-1318.

I also shifted the scheduled run two hours earlier (i.e. 01:00 SAST rather than the 03:00 that it previously was) to accommodate this.

I still want to get to the bottom of why it's suddenly not finishing inside the timeout, but if an extra two hours doesn't work then it's probably quite egregious.

