### PR TITLE
Bump jinja2 to 3.1.4

### DIFF
--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -138,7 +138,7 @@ janus==1.0.0
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   aiomonitor
-jinja2==3.1.3
+jinja2==3.1.4
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -140,7 +140,7 @@ janus==1.0.0
     #   aiomonitor
 jedi==0.19.1
     # via ipython
-jinja2==3.1.3
+jinja2==3.1.4
     # via
     #   -c requirements.txt
     #   aiomonitor

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ importlib-metadata==7.0.0
     # via dask
 janus==1.0.0
     # via aiomonitor
-jinja2==3.1.3
+jinja2==3.1.4
     # via aiomonitor
 katsdpservices==1.3
     # via katgpucbf (setup.cfg)


### PR DESCRIPTION
To keep dependabot happy (CVE-2024-34064). It's very unlikely that we're affected by the issue though.
