### PR TITLE
Make report generator work with skipped tests

### DIFF
--- a/qualification/report/generate_pdf.py
+++ b/qualification/report/generate_pdf.py
@@ -617,7 +617,7 @@ def parse(input_data: list[dict]) -> tuple[TestConfiguration, list[Result]]:
         # If teardown fails, the whole test should be seen as failing
         if report.outcome != "passed" or report.when == "call":
             result.outcome = report.outcome
-            if report.outcome == "skipped" and report.wasxfail is not None:
+            if report.outcome == "skipped" and getattr(report, "wasxfail", None) is not None:
                 result.outcome = "xfail"
                 result.xfail_reason = report.wasxfail
         # The test duration will be the sum of setup, call and teardown.


### PR DESCRIPTION
It seems that the `wasxfail` attribute that is written with the reason for an xfail test, does not even exist for skipped tests.

We don't expect any skipped tests in normal operation, but I threw in a pytest.skip just while debugging and it broke the report generation.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
