### PR TITLE
Pass weight by keyword to remez

### DIFF
--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -135,7 +135,7 @@ def generate_ddc_weights(taps: int, subsampling: int, weight_pass: float) -> np.
         edges += [x, min(x + 0.5, 0.5 * subsampling)]
         desired.append(0.0)
         weights.append(1.0)
-    coeff = scipy.signal.remez(taps, edges, desired, weights, fs=subsampling, maxiter=1000)
+    coeff = scipy.signal.remez(taps, edges, desired, weight=weights, fs=subsampling, maxiter=1000)
     coeff *= np.sqrt(subsampling)
     return coeff.astype(np.float32)
 


### PR DESCRIPTION
A recent scipy has been warning that passing it by position is deprecated.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
