### PR TITLE
Force garbage collection between tests

### DIFF
--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -28,6 +28,7 @@ import spead2
 import spead2.recv.asyncio
 import spead2.send
 import spead2.send.asyncio
+import vkgdr
 from katsdpsigproc.abc import AbstractContext
 from numba import njit
 
@@ -833,11 +834,12 @@ class TestEngine:
     async def xbengine(
         self,
         context: AbstractContext,
+        vkgdr_handle: vkgdr.Vkgdr,
         engine_arglist: list[str],
     ) -> AsyncGenerator[XBEngine, None]:
         """Create and start an engine based on the fixture values."""
         args = parse_args(engine_arglist)
-        xbengine, _ = make_engine(context, args)
+        xbengine, _ = make_engine(context, vkgdr_handle, args)
         await xbengine.start()
 
         yield xbengine


### PR DESCRIPTION
This reduces GPU memory usage, and should hopefully allow multiple jobs to be tested in parallel again.

Closes NGC-1281.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
