### PR TITLE
Fix qualification/tacv/test_channels for narrowband

### DIFF
--- a/qualification/tied_array_channelised_voltage/test_channels.py
+++ b/qualification/tied_array_channelised_voltage/test_channels.py
@@ -48,7 +48,10 @@ async def test_channels(
 
     pdf_report.step("Configure dsim")
     amplitude = 0.05
-    signal = " + ".join(f"cw({amplitude}, {c / receiver.n_chans * receiver.bandwidth})" for c in channels)
+    freqs = [
+        (c - receiver.n_chans / 2) / receiver.n_chans * receiver.bandwidth + receiver.center_freq for c in channels
+    ]
+    signal = " + ".join(f"cw({amplitude}, {freq})" for freq in freqs)
     await cbf.dsim_clients[0].request("signals", f"common = {signal}; common; common;")
 
     pdf_report.step("Set F-engine gain")


### PR DESCRIPTION
It wasn't taking into account the narrowband centre frequency when computing the frequencies for the tones.

Closes NGC-1329.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report: [report.pdf](https://github.com/ska-sa/katgpucbf/files/15330769/report.pdf)
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
