### PR TITLE
Downgrade pytest back to 7.4.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
             'pandas-stubs==2.1.4.231227',
             'prometheus-client==0.19.0',
             'pyparsing==3.0.9',
-            'pytest==8.0.2',
+            'pytest==7.4.3',
             'redis==5.0.1',  # Indirect dependency of katsdptelstate
             'spead2==4.3.1',
             'types-decorator==5.1.1',

--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
   }
 
   options {
-    timeout(time: 23, unit: 'HOURS')
+    timeout(time: 8, unit: 'HOURS')
   }
 
   stages {

--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
   }
 
   options {
-    timeout(time: 5, unit: 'HOURS')
+    timeout(time: 23, unit: 'HOURS')
   }
 
   stages {

--- a/qualification/requirements.in
+++ b/qualification/requirements.in
@@ -1,2 +1,9 @@
 -c ../requirements.txt
 -c ../requirements-dev.txt
+# As per https://github.com/pytest-dev/pytest/issues/12328, the pytest 8
+# upgrade resulted in significantly more correlator configurations being
+# launched for a qualification run - i.e. correlator fixtures were not being
+# reused effectively. This, in turn, resulted in a much lengthier run time
+# (~12 hours) and, on balance, does not warrant the version upgrade. We hold
+# this version limit until the issue is resolved.
+pytest<8

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -289,6 +289,7 @@ pyparsing==3.0.9
 pytest==7.4.3
     # via
     #   -c qualification/../requirements-dev.txt
+    #   -r qualification/requirements.in
     #   katgpucbf (setup.cfg)
     #   pytest-asyncio
     #   pytest-check

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -281,7 +281,7 @@ pyparsing==3.0.9
     #   -c qualification/../requirements.txt
     #   katgpucbf (setup.cfg)
     #   matplotlib
-pytest==8.0.2
+pytest==7.4.3
     # via
     #   -c qualification/../requirements-dev.txt
     #   katgpucbf (setup.cfg)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -284,7 +284,7 @@ pyparsing==3.0.9
     #   katgpucbf (setup.cfg)
 pyproject-hooks==1.0.0
     # via build
-pytest==8.0.2
+pytest==7.4.3
     # via
     #   katgpucbf (setup.cfg)
     #   pytest-asyncio

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ test =
     katsdpsigproc[CUDA]
     async-solipsism
     async-timeout
-    pytest==7.4.3
+    pytest
     pytest-asyncio>=0.18,<0.22
     pytest-custom_exit_code
     pytest-mock

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ test =
     katsdpsigproc[CUDA]
     async-solipsism
     async-timeout
-    pytest>=8.0.0
+    pytest==7.4.3
     pytest-asyncio>=0.18,<0.22
     pytest-custom_exit_code
     pytest-mock

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -496,18 +496,6 @@ def verify_beam_sensors(
         ]
 
 
-def accum_warning_filter(record_tuple: tuple[str, int, str]) -> bool:
-    """Filter for accumulation warnings from the X-engine.
-
-    The record tuple format is (<logger-name>, <log-level>, <log-message>).
-    """
-    return record_tuple == (
-        "katgpucbf.xbgpu.engine",
-        WARNING,
-        "All Antennas had a break in data during this accumulation",
-    )
-
-
 class TestEngine:
     r"""Grouping of unit tests for :class:`.XBEngine`\'s various functionality."""
 
@@ -1044,14 +1032,15 @@ class TestEngine:
             )
             last_timestamp = batch_end_index2 * timestamp_step
 
-        # TODO: NGC-1308 Update this check to not be a subset of the warnings filtered
-        assert list(filter(accum_warning_filter, caplog.record_tuples))[: len(corrprod_outputs)] == [
+        # TODO: NGC-1308 Update this check to be an exact match on the number
+        # of logged messages.
+        assert caplog.record_tuples.count(
             (
                 "katgpucbf.xbgpu.engine",
                 WARNING,
                 "All Antennas had a break in data during this accumulation",
-            ),
-        ] * len(corrprod_outputs)
+            )
+        ) >= len(corrprod_outputs)
 
         verify_corrprod_data(
             corrprod_outputs=corrprod_outputs,

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -1021,31 +1021,31 @@ class TestEngine:
                 await client.request("beam-quant-gains", output.name, quant_gains[i])
                 await client.request("beam-delays", output.name, *[f"{d[0]}:{d[1]}" for d in delays[i]])
 
-            with caplog.filtering(AccumWarningFilter()):
-                corrprod_results, beam_results, acc_indices = await self._send_data(
-                    mock_recv_streams,
-                    mock_send_stream,
-                    corrprod_outputs=corrprod_outputs,
-                    beam_outputs=beam_outputs,
-                    batch_indices=test_batch_indices,
-                    heap_factory=heap_factory,
-                    timestamp_step=timestamp_step,
-                    n_ants=n_ants,
-                    n_channels_per_substream=n_channels_per_substream,
-                    frequency=frequency,
-                    n_spectra_per_heap=n_spectra_per_heap,
-                    missing_antennas=missing_antennas,
-                )
+            # with caplog.filtering(AccumWarningFilter()):
+            corrprod_results, beam_results, acc_indices = await self._send_data(
+                mock_recv_streams,
+                mock_send_stream,
+                corrprod_outputs=corrprod_outputs,
+                beam_outputs=beam_outputs,
+                batch_indices=test_batch_indices,
+                heap_factory=heap_factory,
+                timestamp_step=timestamp_step,
+                n_ants=n_ants,
+                n_channels_per_substream=n_channels_per_substream,
+                frequency=frequency,
+                n_spectra_per_heap=n_spectra_per_heap,
+                missing_antennas=missing_antennas,
+            )
             last_timestamp = batch_end_index2 * timestamp_step
 
         # TODO: NGC-1308 Update this check to not be a subset of the warnings filtered
-        assert caplog.record_tuples[: len(corrprod_outputs)] == [
-            (
-                "katgpucbf.xbgpu.engine",
-                WARNING,
-                "All Antennas had a break in data during this accumulation",
-            ),
-        ] * len(corrprod_outputs)
+        # assert caplog.record_tuples[: len(corrprod_outputs)] == [
+        #     (
+        #         "katgpucbf.xbgpu.engine",
+        #         WARNING,
+        #         "All Antennas had a break in data during this accumulation",
+        #     ),
+        # ] * len(corrprod_outputs)
 
         verify_corrprod_data(
             corrprod_outputs=corrprod_outputs,


### PR DESCRIPTION
As https://github.com/pytest-dev/pytest/issues/12328 mentions, the recent upgrade to pytest 8.x.x
resulted in the qualification tests taking forever and a day to complete (well, ~12 hours). 
This PR rolls the version back to the last known working iteration and updates the pytest
8 feature usage. 

There is also a note in `qualification/requirements.in` to support the reasoning to keep its pytest version
below 8. At least for now, until there is a new release of pytest with the fix for the issue raised by @bmerry.

Lastly, there is a corresponding tweak to the Jenkins Qualification pipeline to start the qualification run
at 11pm SAST. With the 8 hour timeout, that should take it through to a reasonable hour before the team
checks in.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1318.
