### PR TITLE
Add XBReceiver.channel_frequency helper

### DIFF
--- a/qualification/__init__.py
+++ b/qualification/__init__.py
@@ -372,6 +372,26 @@ class XBReceiver:
                     return chunks
         raise RuntimeError(f"stream was shut down before we received {n} complete chunk(s)")
 
+    @overload
+    def channel_frequency(self, channel: float) -> float:
+        ...
+
+    @overload
+    def channel_frequency(self, channel: np.ndarray) -> np.ndarray:
+        ...
+
+    def channel_frequency(self, channel):
+        """Compute the frequency (in Hz) for a given channel.
+
+        The channel number may be a real value to select a frequency that is
+        not at the centre of a channel bin. Integral values correspond to bin
+        centres. This is the frequency of the signal received from the
+        digitiser rather than sky frequency.
+
+        Either a scalar or a numpy array may be used.
+        """
+        return (channel - self.n_chans / 2) * self.bandwidth / self.n_chans + self.center_freq
+
     def compute_tone_gain(self, amplitude: float, target_voltage: float) -> float:
         """Compute F-Engine gain.
 

--- a/qualification/antenna_channelised_voltage/__init__.py
+++ b/qualification/antenna_channelised_voltage/__init__.py
@@ -122,8 +122,7 @@ async def sample_tone_response(
     for i in range(0, len(receiver.input_labels), 2):
         corrs.append(receiver.bls_ordering.index((receiver.input_labels[i], receiver.input_labels[i + 1])))
 
-    channel_width = receiver.bandwidth / receiver.n_chans
-    freqs = receiver.center_freq + (np.asarray(rel_freqs) - receiver.n_chans / 2) * channel_width
+    freqs = receiver.channel_frequency(np.asarray(rel_freqs))
     amplitude = np.asarray(amplitude)
     out_shape = np.broadcast_shapes(freqs.shape, amplitude.shape) + (receiver.n_chans,)
     out = np.empty(out_shape, np.float64)

--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -144,7 +144,7 @@ async def test_delay_enable_disable(
 
     receiver = receive_baseline_correlation_products
     channel = 3 * receiver.n_chans // 4
-    freq = receiver.center_freq + receiver.bandwidth / 4
+    freq = receiver.channel_frequency(channel)
     signal = f"cw(0.1, {freq})"
     gain = receiver.compute_tone_gain(0.1, 100)
     bl_idx = receiver.bls_ordering.index((receiver.input_labels[0], receiver.input_labels[1]))
@@ -608,7 +608,7 @@ async def test_group_delay(
     pdf_report.step("Choose a channel.")
     # Channel is largely arbitrary, although we should avoid the DC frequency
     channel = receiver.n_chans // 5
-    cfreq = (channel - receiver.n_chans / 2) / receiver.n_chans * receiver.bandwidth + receiver.center_freq
+    cfreq = receiver.channel_frequency(channel)
     pdf_report.detail(f"Using channel {channel}.")
 
     pdf_report.step("Determine dsim frequency resolution.")

--- a/qualification/tied_array_channelised_voltage/test_channels.py
+++ b/qualification/tied_array_channelised_voltage/test_channels.py
@@ -48,9 +48,7 @@ async def test_channels(
 
     pdf_report.step("Configure dsim")
     amplitude = 0.05
-    freqs = [
-        (c - receiver.n_chans / 2) / receiver.n_chans * receiver.bandwidth + receiver.center_freq for c in channels
-    ]
+    freqs = [receiver.channel_frequency(c) for c in channels]
     signal = " + ".join(f"cw({amplitude}, {freq})" for freq in freqs)
     await cbf.dsim_clients[0].request("signals", f"common = {signal}; common; common;")
 

--- a/qualification/tied_array_channelised_voltage/test_weights.py
+++ b/qualification/tied_array_channelised_voltage/test_weights.py
@@ -48,8 +48,7 @@ async def test_weight_mapping(
 
     rng = np.random.default_rng()
     channels = rng.integers(1, receiver.n_chans, size=2)
-    channel_width = receiver.bandwidth / receiver.n_chans
-    freqs = receiver.center_freq + (channels - receiver.n_chans / 2) * channel_width
+    freqs = receiver.channel_frequency(channels)
     amplitude = 0.5  # Will probably saturate the PFB, but we don't care
     signals = f"cw({amplitude}, {freqs[0]}); cw({amplitude}, {freqs[1]});"
 


### PR DESCRIPTION
This centralises the formula to convert channel to frequency.

Relates to NGC-1329.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [ ] If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
