### PR TITLE
Bump fgpu default --src-buffer to 128MiB

### DIFF
--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -287,9 +287,9 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--src-buffer",
         type=int,
-        default=64 * 1024 * 1024,
+        default=128 * 1024 * 1024,
         metavar="BYTES",
-        help="Size of network receive buffer [64MiB]",
+        help="Size of network receive buffer [128MiB]",
     )
     parser.add_argument(
         "--dst-interface", type=comma_split(get_interface_address), required=True, help="Name of output network device"


### PR DESCRIPTION
See NGC-1289.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
