### PR TITLE
Make delay tests fail fast if data is missing

### DIFF
--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -22,7 +22,6 @@ from ast import literal_eval
 from collections.abc import Callable
 from typing import Sequence, cast
 
-import async_timeout
 import numpy as np
 import pytest
 from matplotlib.axes import Axes
@@ -79,7 +78,7 @@ async def test_delay_application_time(
         target_ts = round(receiver.time_converter.unix_to_adc(target))
         target_acc_ts = target_ts // receiver.timestamp_step * receiver.timestamp_step
         acc = None
-        async for timestamp, chunk in receiver.complete_chunks(min_timestamp=target_acc_ts):
+        async for timestamp, chunk in receiver.complete_chunks(min_timestamp=target_acc_ts, time_limit=10.0):
             with chunk:
                 pdf_report.detail(f"Received chunk with timestamp {timestamp}, target is {target_acc_ts}.")
                 total = np.sum(chunk.data[:, bl_idx, :], axis=0)  # Sum over channels
@@ -87,6 +86,8 @@ async def test_delay_application_time(
                     acc = total
                 if timestamp >= target_acc_ts:
                     break
+        else:
+            pdf_report.detail("Did not reach the target timestamp within 10s.")
         if acc is not None:
             break
 
@@ -662,30 +663,26 @@ async def test_group_delay(
         max_attempts = 5
         for attempt in range(max_attempts):
             pdf_report.detail(f"Attempt {attempt + 1}/{max_attempts} to receive contiguous data.")
-            try:
-                async with async_timeout.timeout(20.0) as timer:
-                    i = 0
-                    async for timestamp, chunk in receiver.complete_chunks():
-                        with chunk:
-                            if i == 0:
-                                first_timestamp = timestamp
-                            if timestamp != first_timestamp + i * chunk_timestamp_step:
-                                break
-                            start_spectrum = i * receiver.n_spectra_per_heap
-                            end_spectrum = (i + 1) * receiver.n_spectra_per_heap
-                            raw_data[:, start_spectrum:end_spectrum] = chunk.data[:2, channel]
-                        i += 1
-                        if i == n_chunks:
-                            break
-                    if i == n_chunks:
-                        pdf_report.detail("Received all chunks.")
+            i = 0
+            async for timestamp, chunk in receiver.complete_chunks(time_limit=20.0):
+                with chunk:
+                    if i == 0:
+                        first_timestamp = timestamp
+                    if timestamp != first_timestamp + i * chunk_timestamp_step:
+                        pdf_report.detail(f"Only received {i}/{n_chunks} chunks.")
                         break
-                    pdf_report.detail(f"Only received {i}/{n_chunks} chunks.")
-            except asyncio.TimeoutError:
-                if not timer.expired:
-                    raise  # Something other than our timer timed out
+                    start_spectrum = i * receiver.n_spectra_per_heap
+                    end_spectrum = (i + 1) * receiver.n_spectra_per_heap
+                    raw_data[:, start_spectrum:end_spectrum] = chunk.data[:2, channel]
+                i += 1
+                if i == n_chunks:
+                    pdf_report.detail("Received all chunks.")
+                    break
+            else:
+                # We get here if we reached time_limit
                 pdf_report.detail(f"Timed out after receiving {i}/{n_chunks} chunks.")
-
+            if i == n_chunks:
+                break
         else:
             pytest.fail(f"Did not receive {n_chunks} contiguous chunks after {max_attempts} attempts.")
 

--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -682,8 +682,10 @@ async def test_group_delay(
                         break
                     pdf_report.detail(f"Only received {i}/{n_chunks} chunks.")
             except asyncio.TimeoutError:
-                if timer.expired:
-                    pdf_report.detail(f"Timed out after receiving {i}/{n_chunks} chunks.")
+                if not timer.expired:
+                    raise  # Something other than our timer timed out
+                pdf_report.detail(f"Timed out after receiving {i}/{n_chunks} chunks.")
+
         else:
             pytest.fail(f"Did not receive {n_chunks} contiguous chunks after {max_attempts} attempts.")
 


### PR DESCRIPTION
Since it's using complete_chunks() directly instead of next_complete_chunk(), it doesn't have any timeout, and if complete chunks aren't arriving it can hang the test forever.

Also fixes a bug where if non-contiguous chunks are seen, it could hang things by not returning the chunk to the stream. It's possible that this is the real reason for NGC-1341.

Closes NGC-1341.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report: here's a report where I deliberately decreased the timeout to induce failures: 
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Sample qualification test reports: I haven't included the success case, because it looks like the same as before. Induced failures:

- test_group_delay: induce retries by decreasing the timeout: [report.pdf](https://github.com/ska-sa/katgpucbf/files/15416365/report.pdf)
- both: induce failure by issuing a capture-stop: [report2.pdf](https://github.com/ska-sa/katgpucbf/files/15417692/report2.pdf)