### PR TITLE
Share more code in setting up heaps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,6 +72,7 @@ repos:
             'types-docutils==0.20.0.3',
             'types-setuptools==65.6.0.3',  # Indirect dependency
             'types-six==1.16.0',
+            'typing-extensions==4.12.0',
         ]
   - repo: https://github.com/jazzband/pip-tools
     rev: 7.3.0

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -374,13 +374,14 @@ trafaret==2.1.1
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   aiomonitor
-typing-extensions==4.8.0
+typing-extensions==4.12.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   aiokatcp
     #   aiomonitor
     #   janus
+    #   katgpucbf (setup.cfg)
     #   katsdpsigproc
 tzdata==2023.3
     # via

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -410,12 +410,13 @@ traitlets==5.14.0
     # via
     #   ipython
     #   matplotlib-inline
-typing-extensions==4.8.0
+typing-extensions==4.12.0
     # via
     #   -c requirements.txt
     #   aiokatcp
     #   aiomonitor
     #   janus
+    #   katgpucbf (setup.cfg)
     #   katsdpsigproc
     #   pytools
 tzdata==2023.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -161,11 +161,12 @@ toolz==0.12.0
     #   partd
 trafaret==2.1.1
     # via aiomonitor
-typing-extensions==4.8.0
+typing-extensions==4.12.0
     # via
     #   aiokatcp
     #   aiomonitor
     #   janus
+    #   katgpucbf (setup.cfg)
     #   katsdpsigproc
     #   pytools
 tzdata==2023.3

--- a/scratch/benchmarks/requirements.txt
+++ b/scratch/benchmarks/requirements.txt
@@ -125,7 +125,7 @@ tomli==2.0.1 ; python_version < "3.11"
     #   -c scratch/benchmarks/../../qualification/requirements.txt
     #   -c scratch/benchmarks/../../requirements-dev.txt
     #   -r scratch/benchmarks/requirements.in
-typing-extensions==4.8.0
+typing-extensions==4.12.0
     # via
     #   -c scratch/benchmarks/../../qualification/requirements.txt
     #   -c scratch/benchmarks/../../requirements-dev.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
     pyparsing>=3.0.0
     scipy
     spead2>=4.3.1
+    typing-extensions
     xarray
 python_requires = >=3.10
 

--- a/src/katgpucbf/xbgpu/bsend.py
+++ b/src/katgpucbf/xbgpu/bsend.py
@@ -32,16 +32,7 @@ from katsdptelstate.endpoint import Endpoint
 from prometheus_client import Counter
 
 from .. import COMPLEX, DEFAULT_PACKET_PAYLOAD_BYTES
-from ..spead import (
-    BEAM_ANTS_ID,
-    BF_RAW_ID,
-    FLAVOUR,
-    FREQUENCY_ID,
-    IMMEDIATE_DTYPE,
-    IMMEDIATE_FORMAT,
-    TIMESTAMP_ID,
-    make_immediate,
-)
+from ..spead import BEAM_ANTS_ID, BF_RAW_ID, FLAVOUR, FREQUENCY_ID, IMMEDIATE_DTYPE, IMMEDIATE_FORMAT, TIMESTAMP_ID
 from ..utils import TimeConverter
 from . import METRIC_NAMESPACE
 from .output import BOutput
@@ -63,6 +54,40 @@ logger = logging.getLogger(__name__)
 # NOTE: ICD suggests `beng_out_bits_per_sample`,
 # MK correlator doesn't make this configurable.
 SEND_DTYPE = np.dtype(np.int8)
+
+
+def make_item_group(bf_raw_shape: tuple[int, ...]) -> spead2.send.ItemGroup:
+    """Create an item group (with no values)."""
+    item_group = spead2.send.ItemGroup(flavour=FLAVOUR)
+    item_group.add_item(
+        FREQUENCY_ID,
+        "frequency",  # Misleading name, but it's what the ICD specifies
+        "Value of the first channel in collections stored here.",
+        shape=[],
+        format=IMMEDIATE_FORMAT,
+    )
+    item_group.add_item(
+        TIMESTAMP_ID,
+        "timestamp",
+        "Timestamp provided by the MeerKAT digitisers and scaled to the digitiser sampling rate.",
+        shape=[],
+        format=IMMEDIATE_FORMAT,
+    )
+    item_group.add_item(
+        BEAM_ANTS_ID,
+        "beam_ants",
+        "Count of antennas included in the beam sum.",
+        shape=[],
+        format=IMMEDIATE_FORMAT,
+    )
+    item_group.add_item(
+        BF_RAW_ID,
+        "bf_raw",
+        "Beamformer output for frequency-domain beam.",
+        shape=bf_raw_shape,
+        dtype=SEND_DTYPE,
+    )
+    return item_group
 
 
 class Batch:
@@ -97,22 +122,15 @@ class Batch:
         self.heaps: list[spead2.send.Heap] = []
         self.data = data
         n_substreams = data.shape[0]
+
+        item_group = make_item_group(data.shape[1:])  # Get rid of the 'beam' dimension
+        item_group[FREQUENCY_ID].value = channel_offset
+        item_group[TIMESTAMP_ID].value = timestamp
+        item_group[BEAM_ANTS_ID].value = present_ants
         for i in range(n_substreams):
-            heap = spead2.send.Heap(flavour=FLAVOUR)
+            item_group[BF_RAW_ID].value = self.data[i, ...]
+            heap = item_group.get_heap(descriptors="none", data="all")
             heap.repeat_pointers = True
-            heap.add_item(make_immediate(FREQUENCY_ID, channel_offset))
-            heap.add_item(make_immediate(TIMESTAMP_ID, timestamp))
-            heap.add_item(make_immediate(BEAM_ANTS_ID, present_ants))
-            heap.add_item(
-                spead2.Item(
-                    BF_RAW_ID,
-                    "bf_raw",
-                    "",
-                    shape=data.shape[1:],  # Get rid of the 'beam' dimension
-                    dtype=data.dtype,
-                    value=self.data[i, ...],
-                )
-            )
             self.heaps.append(heap)
         self.tx_enabled_version = -1
         self.tx_heaps = spead2.send.HeapReferenceList([])
@@ -435,36 +453,7 @@ class BSend:
             n_channels // n_channels_per_substream,
         )
 
-        item_group = spead2.send.ItemGroup(flavour=FLAVOUR)
-        item_group.add_item(
-            FREQUENCY_ID,
-            "frequency",  # Misleading name, but it's what the ICD specifies
-            "Value of the first channel in collections stored here.",
-            shape=[],
-            format=IMMEDIATE_FORMAT,
-        )
-        item_group.add_item(
-            TIMESTAMP_ID,
-            "timestamp",
-            "Timestamp provided by the MeerKAT digitisers and scaled to the digitiser sampling rate.",
-            shape=[],
-            format=IMMEDIATE_FORMAT,
-        )
-        item_group.add_item(
-            BEAM_ANTS_ID,
-            "beam_ants",
-            "Count of antennas included in the beam sum.",
-            shape=[],
-            format=IMMEDIATE_FORMAT,
-        )
-        item_group.add_item(
-            BF_RAW_ID,
-            "bf_raw",
-            "Beamformer output for frequency-domain beam.",
-            shape=buffers[0].shape[2:],
-            dtype=buffers[0].dtype,
-        )
-
+        item_group = make_item_group(buffers[0].shape[2:])
         self.descriptor_heap = item_group.get_heap(descriptors="all", data="none")
 
     def enable_substream(self, stream_id: int, enable: bool = True) -> None:


### PR DESCRIPTION
Give each send module a `make_item_group` helper function to set up an item group with all the items, and utilise it to create either data heaps or descriptor heaps.

I haven't tried to implement this for dsim, because it has a more complicated way of setting up data heaps and I'm worried that trying to make it follow this pattern will have performance or memory usage implications.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1156.
