### PR TITLE
Extract some repeated code for sending

### DIFF
--- a/doc/katgpucbf.xbgpu.rst
+++ b/doc/katgpucbf.xbgpu.rst
@@ -14,6 +14,7 @@ Submodules
    katgpucbf.xbgpu.main
    katgpucbf.xbgpu.output
    katgpucbf.xbgpu.recv
+   katgpucbf.xbgpu.send
    katgpucbf.xbgpu.xsend
 
 Module contents

--- a/doc/katgpucbf.xbgpu.send.rst
+++ b/doc/katgpucbf.xbgpu.send.rst
@@ -1,0 +1,7 @@
+katgpucbf.xbgpu.send module
+===========================
+
+.. automodule:: katgpucbf.xbgpu.send
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/katgpucbf/fgpu/send.py
+++ b/src/katgpucbf/fgpu/send.py
@@ -29,6 +29,7 @@ from katsdptelstate.endpoint import Endpoint
 from prometheus_client import Counter
 
 from .. import COMPLEX, N_POLS
+from ..send import send_rate
 from ..spead import (
     FENG_ID_ID,
     FENG_RAW_ID,
@@ -262,10 +263,18 @@ def make_streams(
     """
     dtype = chunks[0].data.dtype  # Type for each complex value
     memory_regions: list[object] = [chunk.data for chunk in chunks]
-    # Send a bit faster than nominal rate to account for header overheads
-    rate = N_POLS * bandwidth * dtype.itemsize * send_rate_factor / len(interfaces)
+    heap_payload = sum(chunk.data.nbytes for chunk in chunks) // n_data_heaps
+    # Work backwards from payload byte rate to get heap payload rate
+    heap_interval = heap_payload / (N_POLS * bandwidth * dtype.itemsize)
     config = spead2.send.StreamConfig(
-        rate=rate,
+        rate=send_rate(
+            packet_header=PREAMBLE_SIZE,
+            packet_payload=packet_payload,
+            heap_payload=heap_payload,
+            heap_interval=heap_interval,
+            send_rate_factor=send_rate_factor,
+        )
+        / len(interfaces),
         max_packet_size=packet_payload + PREAMBLE_SIZE,
         # Adding len(endpoints) to accommodate descriptors sent for each substream
         max_heaps=n_data_heaps + len(endpoints),

--- a/src/katgpucbf/send.py
+++ b/src/katgpucbf/send.py
@@ -97,3 +97,34 @@ class DescriptorSender:
             except asyncio.TimeoutError:
                 pass
             t = self._interval
+
+
+def send_rate(
+    packet_header: int,
+    packet_payload: int,
+    heap_payload: int,
+    heap_interval: float,
+    send_rate_factor: float,
+) -> float:
+    """Compute the send rate (in bytes per second) to pass to spead2.
+
+    Parameters
+    ----------
+    packet_header
+        Overhead bytes in each SPEAD packet, including the SPEAD header (but
+        excluding UDP/IP etc headers)
+    packet_payload
+        Number of payload bytes that should be included in each packet
+    heap_payload
+        Number of payload bytes in each heap
+    heap_interval
+        Time (in seconds) between sending heaps (or 0 for as fast as possible)
+    send_rate_factor
+        Safety factor by which the transmission rate should exceed the
+        incoming data rate
+    """
+    if heap_interval == 0.0:
+        return 0.0
+    packets_per_heap = (heap_payload + packet_payload - 1) // packet_payload
+    heap_overhead = packets_per_heap * packet_header
+    return (heap_payload + heap_overhead) / heap_interval * send_rate_factor

--- a/src/katgpucbf/xbgpu/send.py
+++ b/src/katgpucbf/xbgpu/send.py
@@ -1,0 +1,51 @@
+################################################################################
+# Copyright (c) 2023-2024, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Common functionality between :class:`.XSend` and :class:`.BSend`."""
+
+from typing import Final
+
+import spead2.send.asyncio
+
+
+class Send:
+    """Common functionality between :class:`.XSend` and :class:`.BSend`."""
+
+    def __init__(
+        self,
+        *,
+        n_channels: int,
+        n_channels_per_substream: int,
+        channel_offset: int,
+        stream: "spead2.send.asyncio.AsyncStream",
+        descriptor_heap: spead2.send.Heap,
+    ) -> None:
+        if n_channels % n_channels_per_substream != 0:
+            raise ValueError("n_channels must be an integer multiple of n_channels_per_substream")
+        if channel_offset % n_channels_per_substream != 0:
+            raise ValueError("channel_offset must be an integer multiple of n_channels_per_substream")
+        self.n_channels: Final[int] = n_channels
+        self.n_channels_per_substream: Final[int] = n_channels_per_substream
+        self.channel_offset: Final[int] = channel_offset
+        self.stream = stream
+        self.descriptor_heap = descriptor_heap
+
+        # Set heap count sequence to allow a receiver to ingest multiple
+        # X/B-engine outputs, if they should so choose.
+        self.stream.set_cnt_sequence(
+            channel_offset // n_channels_per_substream,
+            n_channels // n_channels_per_substream,
+        )

--- a/src/katgpucbf/xbgpu/xsend.py
+++ b/src/katgpucbf/xbgpu/xsend.py
@@ -17,7 +17,6 @@
 """Module for sending baseline correlation products onto the network."""
 
 import asyncio
-import math
 from collections.abc import Callable, Sequence
 from typing import Final
 
@@ -29,8 +28,10 @@ from katsdpsigproc.abc import AbstractContext
 from prometheus_client import Counter
 
 from .. import COMPLEX, DEFAULT_PACKET_PAYLOAD_BYTES
+from ..send import send_rate
 from ..spead import FLAVOUR, FREQUENCY_ID, IMMEDIATE_FORMAT, TIMESTAMP_ID, XENG_RAW_ID, make_immediate
 from . import METRIC_NAMESPACE
+from .send import Send
 
 output_heaps_counter = Counter(
     "output_x_heaps", "number of X-engine heaps transmitted", ["stream"], namespace=METRIC_NAMESPACE
@@ -152,7 +153,7 @@ def make_stream(
     return stream
 
 
-class XSend:
+class XSend(Send):
     """
     Class for turning baseline correlation products into SPEAD heaps and transmitting them.
 
@@ -233,21 +234,12 @@ class XSend:
         if dump_interval_s < 0:
             raise ValueError("Dump interval must be 0 or greater.")
 
-        if n_channels % n_channels_per_substream != 0:
-            raise ValueError("n_channels must be an integer multiple of n_channels_per_substream")
-        if channel_offset % n_channels_per_substream != 0:
-            raise ValueError("channel_offset must be an integer multiple of n_channels_per_substream")
-
         self.output_name = output_name
         self.tx_enabled = tx_enabled
 
         # Array Configuration Parameters
         self.n_ants: Final[int] = n_ants
-        self.n_channels_per_substream: Final[int] = n_channels_per_substream
         n_baselines: Final[int] = (self.n_ants + 1) * (self.n_ants) * 2
-
-        # Multicast Stream Parameters
-        self.heap_payload_size_bytes = self.n_channels_per_substream * n_baselines * COMPLEX * SEND_DTYPE.itemsize
 
         self._heaps_queue: asyncio.Queue[Heap] = asyncio.Queue()
         buffers: list[accel.HostArray] = []
@@ -257,30 +249,17 @@ class XSend:
             self._heaps_queue.put_nowait(heap)
             buffers.append(heap.buffer)
 
-        # Transport-agnostic stream information
-        packets_per_heap = math.ceil(self.heap_payload_size_bytes / packet_payload)
-        packet_header_overhead_bytes = packets_per_heap * XSend.header_size
-
-        if dump_interval_s != 0:
-            send_rate_bytes_per_second = (
-                (self.heap_payload_size_bytes + packet_header_overhead_bytes) / dump_interval_s * send_rate_factor
-            )  # * send_rate_factor adds a buffer to the rate to compensate for any unexpected jitter
-        else:
-            # Pass zero to stream_config to send as fast as possible.
-            send_rate_bytes_per_second = 0
-
         stream_config = spead2.send.StreamConfig(
             max_packet_size=packet_payload + XSend.header_size,
             max_heaps=n_send_heaps_in_flight + 1,  # + 1 to allow for descriptors
             rate_method=spead2.send.RateMethod.AUTO,
-            rate=send_rate_bytes_per_second,
-        )
-        self.stream = stream_factory(stream_config, buffers)
-        # Set heap count sequence to allow a receiver to ingest multiple
-        # X-engine outputs, if they should so choose.
-        self.stream.set_cnt_sequence(
-            channel_offset // n_channels_per_substream,
-            n_channels // n_channels_per_substream,
+            rate=send_rate(
+                packet_header=XSend.header_size,
+                packet_payload=packet_payload,
+                heap_payload=n_channels_per_substream * n_baselines * COMPLEX * SEND_DTYPE.itemsize,
+                heap_interval=dump_interval_s,
+                send_rate_factor=send_rate_factor,
+            ),
         )
 
         item_group = spead2.send.ItemGroup(flavour=FLAVOUR)
@@ -306,7 +285,13 @@ class XSend:
             dtype=buffers[0].dtype,
         )
 
-        self.descriptor_heap = item_group.get_heap(descriptors="all", data="none")
+        super().__init__(
+            n_channels=n_channels,
+            n_channels_per_substream=n_channels_per_substream,
+            channel_offset=channel_offset,
+            stream=stream_factory(stream_config, buffers),
+            descriptor_heap=item_group.get_heap(descriptors="all", data="none"),
+        )
 
     def send_heap(self, heap: Heap) -> None:
         """Take in a buffer and send it as a SPEAD heap.

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -34,7 +34,7 @@ from numba import njit
 
 from katgpucbf import COMPLEX, N_POLS
 from katgpucbf.fgpu.send import PREAMBLE_SIZE
-from katgpucbf.xbgpu import METRIC_NAMESPACE, bsend
+from katgpucbf.xbgpu import METRIC_NAMESPACE, bsend, xsend
 from katgpucbf.xbgpu.correlation import Correlation, device_filter
 from katgpucbf.xbgpu.engine import BPipeline, InQueueItem, XBEngine, XPipeline
 from katgpucbf.xbgpu.main import make_engine, parse_args, parse_beam, parse_corrprod
@@ -384,9 +384,8 @@ def verify_corrprod_sensors(
                 incomplete_accs += 1
         assert prom_get("output_x_incomplete_accs_total") == incomplete_accs
         assert prom_get("output_x_heaps_total") == n_accumulations_completed
-        # Could manually calculate it here, but it's available inside the send_stream
         assert prom_get("output_x_bytes_total") == (
-            xpipeline.send_stream.heap_payload_size_bytes * n_accumulations_completed
+            n_channels_per_substream * n_baselines * COMPLEX * xsend.SEND_DTYPE.itemsize * n_accumulations_completed
         )
         assert prom_get("output_x_visibilities_total") == (
             n_channels_per_substream * n_baselines * n_accumulations_completed


### PR DESCRIPTION
- Create a common xbgpu.send.Send class
- Add a send_rate helper function to compute the send rate. In the case of fgpu, this now makes a correction to the send rate to account for the packet overheads, which was missing before. It still needs to be tested though.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1146.
