### PR TITLE
Correct BSend.header_size

### DIFF
--- a/src/katgpucbf/xbgpu/bsend.py
+++ b/src/katgpucbf/xbgpu/bsend.py
@@ -367,7 +367,7 @@ class BSend:
     """
 
     descriptor_heap: spead2.send.Heap
-    header_size: Final[int] = 64
+    header_size: Final[int] = 72
 
     def __init__(
         self,


### PR DESCRIPTION
It didn't get updated in #738, which added a new item pointer. That means the data was being transmitted slightly slower than desired, and that the heap payload size was 8 bytes smaller than requested.

Fixes NGC-1346.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
