### PR TITLE
dev-setup.sh: install the pinned version of wheel

### DIFF
--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ################################################################################
-# Copyright (c) 2020-2022, National Research Foundation (SARAO)
+# Copyright (c) 2020-2022, 2024 National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -24,7 +24,7 @@ echo "Activating the virtual env"
 source .venv/bin/activate
 
 pip install --upgrade pip # stops pip from complaining
-pip install wheel # Makes the process a bit slicker.
+pip install -c requirements-dev.txt wheel # Makes the process a bit slicker.
 echo "Installing requirements for running and development"
 pip install -r requirements.txt -r requirements-dev.txt
 


### PR DESCRIPTION
Install the version of wheel pinned by requirements-dev.txt, so that the next step doesn't uninstall it and replace it with a different version.

Closes NGC-1309.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [ ] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [ ] If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [ ] Ensure copyright notices are present and up-to-date
- [ ] If qualification tests are changed: attach a sample qualification report
- [ ] If design has changed: ensure documentation is up to date
- [ ] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-xxxx.
