### PR TITLE
Qualification: speed up test with shutdown_delay

### DIFF
--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -312,9 +312,11 @@ async def _cbf_config_and_description(
     int_time: float,
     narrowband_decimation: int,
 ) -> tuple[dict, dict]:
+    # shutdown_delay is set to zero to speed up the test. We don't care
+    # that Prometheus might not get to scrape the final metric updates.
     config: dict = {
-        "version": "4.0",
-        "config": {},
+        "version": "4.1",
+        "config": {"shutdown_delay": 0.0},
         "inputs": {},
         "outputs": {},
     }


### PR DESCRIPTION
Uses ska-sa/katsdpcontroller#739 to eliminate the normal delay in shutting down a correlator.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a - report will be unchanged) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Relates to NGC-1343.
