### PR TITLE
Update python-dateutil to the latest

### DIFF
--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -307,7 +307,7 @@ pytest-custom-exit-code==0.3.0
     #   katgpucbf (setup.cfg)
 pytest-reportlog==0.4.0
     # via katgpucbf (setup.cfg)
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -306,7 +306,7 @@ pytest-mock==3.12.0
     # via katgpucbf (setup.cfg)
 pytest-xdist==3.5.0
     # via -r requirements-dev.in
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -c requirements.txt
     #   pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -133,7 +133,7 @@ pygelf==0.4.2
     # via katsdpservices
 pyparsing==3.0.9
     # via katgpucbf (setup.cfg)
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via pandas
 pytools==2023.1.1
     # via pycuda

--- a/scratch/benchmarks/requirements.txt
+++ b/scratch/benchmarks/requirements.txt
@@ -92,7 +92,7 @@ pycparser==2.21
     # via
     #   -c scratch/benchmarks/../../requirements.txt
     #   cffi
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -c scratch/benchmarks/../../qualification/requirements.txt
     #   -c scratch/benchmarks/../../requirements-dev.txt


### PR DESCRIPTION
On Python 3.12 the tests are printing warnings because the old version uses a deprecated API (datetime.utcfromtimestamp).

See NGC-1324.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] (n/a) Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
