### PR TITLE
Replace 524288 with a CHUNK_SAMPLES

### DIFF
--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1094,8 +1094,7 @@ class Engine(aiokatcp.DeviceServer):
     dst_buffer
         Size of the network send buffer.
     outputs
-        Output streams to generate. At present this must be a single
-        WidebandOutput.
+        Output streams to generate.
     adc_sample_rate
         Digitiser sampling rate (in Hz), used to determine transmission rate.
     send_rate_factor

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -957,7 +957,7 @@ class TestEngine:
             dig_data,
         )
         time_converter = TimeConverter(SYNC_TIME, ADC_SAMPLE_RATE)
-        expected_timestamps = [time_converter.adc_to_unix(t * 524288) for t in range(1, 10)]
+        expected_timestamps = [time_converter.adc_to_unix(t * CHUNK_SAMPLES) for t in range(1, 10)]
         assert sensor_update_dict[sensors[0].name] == [
             aiokatcp.Reading(t, aiokatcp.Sensor.Status.NOMINAL, 5000) for t in expected_timestamps
         ]
@@ -995,7 +995,7 @@ class TestEngine:
             dig_data,
         )
         time_converter = TimeConverter(SYNC_TIME, ADC_SAMPLE_RATE)
-        expected_timestamps = [time_converter.adc_to_unix(t * 524288) for t in range(1, 10)]
+        expected_timestamps = [time_converter.adc_to_unix(t * CHUNK_SAMPLES) for t in range(1, 10)]
         for pol in range(N_POLS):
             assert sensor_update_dict[sensors[pol].name] == [
                 aiokatcp.Reading(t, aiokatcp.Sensor.Status.WARN, output_power_dbfs) for t in expected_timestamps


### PR DESCRIPTION
I'm hoping this helps the reader to understand the intent better. I noticed it while working on #772.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
