### PR TITLE
Qual: increase receiver buffer size

### DIFF
--- a/qualification/__init__.py
+++ b/qualification/__init__.py
@@ -569,7 +569,7 @@ def _create_receive_stream_group(
 
         if use_ibv:
             config = spead2.recv.UdpIbvConfig(
-                endpoints=endpoints, interface_address=interface_address, buffer_size=int(16e6), comp_vector=-1
+                endpoints=endpoints, interface_address=interface_address, buffer_size=64 * 1024 * 1024, comp_vector=-1
             )
             stream.add_udp_ibv_reader(config)
         else:


### PR DESCRIPTION
Increase it from 16MB to 64MiB. This seems to make the test_group_delay test more reliably receive a contiguous block of data without needing multiple attempts.

I haven't experimented with intermediate values like 32MiB, but 64MiB per buffer only requires 576MiB in total so it is pretty cheap to make this change.

See NGC-938.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
