### PR TITLE
Qualification: make default_antennas configurable

### DIFF
--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -44,7 +44,6 @@ from .reporter import Reporter
 
 logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
-DEFAULT_ANTENNAS = 8  #: Number of antennas for antenna_channelised_voltage tests
 FULL_ANTENNAS = [1, 4, 8, 10, 16, 20, 32, 40, 55, 64, 65, 80]
 
 
@@ -67,6 +66,7 @@ ini_options = [
     IniOption(name="use_ibv", help="Use ibverbs", type="bool", default=False),
     IniOption(name="product_name", help="Name of subarray product", type="string", default="qualification_cbf"),
     IniOption(name="tester", help="Name of person executing this qualification run", type="string", default="Unknown"),
+    IniOption(name="default_antennas", help="Number of antennas for antenna-channelised-voltage tests", type="string", default="8"),
     IniOption(name="max_antennas", help="Maximum number of antennas to test", type="string", default="8"),
     IniOption(
         name="wideband_channels",
@@ -156,10 +156,11 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     if "n_antennas" in metafunc.fixturenames:
         rel_path = metafunc.definition.path.relative_to(metafunc.config.rootpath)
         max_antennas = int(metafunc.config.getini("max_antennas"))
+        default_antennas = int(metafunc.config.getini("default_antennas"))
         if rel_path.parts[0] != "antenna_channelised_voltage":
             values = FULL_ANTENNAS
         else:
-            values = [min(max_antennas, DEFAULT_ANTENNAS)]
+            values = [min(max_antennas, default_antennas)]
         values = [value for value in values if value <= max_antennas]
         metafunc.parametrize("n_antennas", values, indirect=True)
     if "band" in metafunc.fixturenames:

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -66,7 +66,12 @@ ini_options = [
     IniOption(name="use_ibv", help="Use ibverbs", type="bool", default=False),
     IniOption(name="product_name", help="Name of subarray product", type="string", default="qualification_cbf"),
     IniOption(name="tester", help="Name of person executing this qualification run", type="string", default="Unknown"),
-    IniOption(name="default_antennas", help="Number of antennas for antenna-channelised-voltage tests", type="string", default="8"),
+    IniOption(
+        name="default_antennas",
+        help="Number of antennas for antenna-channelised-voltage tests",
+        type="string",
+        default="8",
+    ),
     IniOption(name="max_antennas", help="Maximum number of antennas to test", type="string", default="8"),
     IniOption(
         name="wideband_channels",

--- a/qualification/pytest-jenkins.ini
+++ b/qualification/pytest-jenkins.ini
@@ -11,6 +11,7 @@ use_ibv = true
 log_cli = true
 log_cli_level = info
 addopts = --report-log=report.json
+default_antennas = 8
 max_antennas = 10
 wideband_channels = 1024 4096 8192 32768
 narrowband_channels = 32768


### PR DESCRIPTION
Ideally one wants to make it large, so that tests that parallelise over antennas will run quickly, but it can't be so large that one runs out of resources. So it makes sense for it to be configurable.

See NGC-938.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [ ] If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [x] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

