### PR TITLE
Make qualification reporting more robust to failed CBFs

### DIFF
--- a/qualification/report/generate_pdf.py
+++ b/qualification/report/generate_pdf.py
@@ -391,17 +391,23 @@ class ResultSet:
         self.group = self.results[0].group
         for result in self.results:
             assert result.base_nodeid == self.base_nodeid, "base_nodeids do not match"
-            if result.text_name != self.text_name:
-                raise ValueError(
-                    f"Inconsistent text names for tests in ResultSet ({result.text_name} != {self.text_name})"
-                )
-            if result.blurb != self.blurb:
-                raise ValueError(f"Inconsistent blurbs for tests in ResultSet {self.base_nodeid}")
+            self.text_name = self._merge(self.text_name, result.text_name, "text names")
+            self.blurb = self._merge(self.blurb, result.blurb, "blurbs")
             self.duration += result.duration
             self.outcome_counts[result.outcome] += 1
             for requirement in result.requirements:
                 if requirement not in self.requirements:
                     self.requirements.append(requirement)
+
+    def _merge(self, a: str, b: str, name: str) -> str:
+        """Combine a property from two results.
+
+        If either is blank, the other is used. If both are non-blank and they
+        don't match, raise a :exc:`ValueError`.
+        """
+        if a != b and a and b:
+            raise ValueError(f"Inconsistent {name} for tests in ResultSet {self.base_nodeid}")
+        return a or b
 
     @property
     def marker(self) -> Marker:


### PR DESCRIPTION
When a CBF fails to configure, the tests don't even get to the point of reporting their blurbs, which was leading to errors about inconsistent names/blurbs. We should probably tweak the conftest to fix that, but for now this makes the reporting more robust so that we can at least get a PDF out the other end.

Relates to NGC-938.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [ ] If qualification tests are changed: attach a sample qualification report: I have a file but it's too big to attach.
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
