### PR TITLE
Increase qualification timeout to 10 hours

### DIFF
--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
   }
 
   options {
-    timeout(time: 8, unit: 'HOURS')
+    timeout(time: 10, unit: 'HOURS')
   }
 
   stages {


### PR DESCRIPTION
Not sure if this will be needed, but after #792 it might be.

See NGC-938.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
