### PR TITLE
Qual: fix tolerance for tacv/test_delay

### DIFF
--- a/qualification/tied_array_channelised_voltage/test_delay.py
+++ b/qualification/tied_array_channelised_voltage/test_delay.py
@@ -128,9 +128,13 @@ async def test_delay(
     Verification method
     -------------------
     Verification by means of test. Set a delay on one beam (for all inputs)
-    and no delay on another. Check that the results match expectations to
-    within 1.5 ULP. Correlate the beams and check that the angle of the
-    correlation product matches expectations to within 1°.
+    and no delay on another. Check that the results on the test (delayed)
+    beam match expectations computed from the reference (no delay) beam
+    within 2.9 ULP. This allows for 1 ULP tolerance in both the real and
+    imaginary components of both beams.
+
+    Correlate the beams and check that the angle of the correlation product
+    matches expectations to within 1°.
     """
     receiver = receive_tied_array_channelised_voltage
     client = cbf.product_controller_client
@@ -175,7 +179,7 @@ async def test_delay(
         max_error = np.max(np.abs(data[delay_beam] - expected))
         pdf_report.detail(f"Maximum difference from expected is {max_error:.3f} ULP.")
         with check:
-            assert max_error <= 1.5  # A bit more than sqrt(2)
+            assert max_error <= 2.9  # A bit more than 2*sqrt(2)
 
         corr = np.sum(data[delay_beam] * data[ref_beam].conj(), axis=1)
         # Collect more chunks so that quantisation effects average out


### PR DESCRIPTION
The tolerance didn't take into account beam dithering.

Closes NGC-1357.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report: [report2.pdf](https://github.com/user-attachments/files/15793971/report2.pdf)
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
