### PR TITLE
Add timestamps to qualification log format

### DIFF
--- a/qualification/pytest-jenkins.ini
+++ b/qualification/pytest-jenkins.ini
@@ -10,6 +10,7 @@ interface_gbps = 150
 use_ibv = true
 log_cli = true
 log_cli_level = info
+log_cli_format = %(asctime)s.%(msecs)03d  %(levelname)-8s %(name)s:%(filename)s:%(lineno)d %(message)s
 addopts = --report-log=report.json
 default_antennas = 26
 max_antennas = 40


### PR DESCRIPTION
It's the pytest default format with the addition of a millisecond timestamp. This makes it possible to determine how long some steps are taking by just reading the logs.

Example:
```
09:15:46.825  INFO     qualification.reporter:reporter.py:88 Do things
```