### PR TITLE
{src, dst} -> {recv, send}

### DIFF
--- a/doc/control.rst
+++ b/doc/control.rst
@@ -148,11 +148,11 @@ instance on ``host2``::
     .
     [Connect to host2 and activate the local virtual environment]
     (katgpucbf) user@host2:~/katgpucbf$ spead2_net_raw numactl -C 1 xbgpu \
-                                        --src-affinity 0 --src-comp-vector 0 \
-                                        --dst-affinity 1 --dst-comp-vector 1 \
-                                        --src-interface <interface name> \
-                                        --dst-interface <interface name> \
-                                        --src-ibv --dst-ibv \
+                                        --recv-affinity 0 --recv-comp-vector 0 \
+                                        --send-affinity 1 --send-comp-vector 1 \
+                                        --recv-interface <interface name> \
+                                        --send-interface <interface name> \
+                                        --recv-ibv --send-ibv \
                                         --adc-sample-rate 1712e6 --array-size 4 \
                                         --channels 4096 \
                                         --channels-per-substream 1024 \

--- a/scratch/benchmarks/benchmark_fgpu.py
+++ b/scratch/benchmarks/benchmark_fgpu.py
@@ -122,25 +122,25 @@ def fgpu_factory(
     qstep = step // 4
     my_cpus = server_info.cpus[index * step : (index + 1) * step]
     if args.use_vkgdr:
-        src_chunk_samples = 2**24 // scaling_n
-        dst_chunk_jones = src_chunk_samples // 2
+        recv_chunk_samples = 2**24 // scaling_n
+        send_chunk_jones = recv_chunk_samples // 2
     else:
-        src_chunk_samples = 2**27 // scaling_n
-        dst_chunk_jones = src_chunk_samples // 4
+        recv_chunk_samples = 2**27 // scaling_n
+        send_chunk_jones = recv_chunk_samples // 4
     if n == 1:
         interface = ",".join(server.interfaces[:2])
-        src_affinity = f"0,1,{qstep},{qstep + 1}"
-        dst_affinity = f"{2 * qstep}"
+        recv_affinity = f"0,1,{qstep},{qstep + 1}"
+        send_affinity = f"{2 * qstep}"
         other_affinity = f"{3 * qstep}"
     elif n == 2:
         interface = server.interfaces[index % len(server.interfaces)]
-        src_affinity = f"{my_cpus[0]},{my_cpus[hstep]}"
-        dst_affinity = f"{my_cpus[qstep]}"
+        recv_affinity = f"{my_cpus[0]},{my_cpus[hstep]}"
+        send_affinity = f"{my_cpus[qstep]}"
         other_affinity = f"{my_cpus[hstep + qstep]}"
     else:
         interface = server.interfaces[index % len(server.interfaces)]
-        src_affinity = f"{my_cpus[0]}"
-        dst_affinity = f"{my_cpus[hstep]}"
+        recv_affinity = f"{my_cpus[0]}"
+        send_affinity = f"{my_cpus[hstep]}"
         other_affinity = f"{my_cpus[hstep + 1]}"
     gpu = server.gpus[index % len(server.gpus)]
 
@@ -161,13 +161,13 @@ def fgpu_factory(
         f"-e NVIDIA_MOFED=enabled --ulimit=memlock=-1 --rm "
         f" {' '.join(args.fgpu_docker_arg)} {args.image} "
         f"schedrr taskset -c {other_affinity} fgpu "
-        f"--src-packet-samples={args.dig_heap_samples} "
-        f"--src-chunk-samples={src_chunk_samples} --dst-chunk-jones={dst_chunk_jones} "
-        f"--src-buffer={256 * 1024 * 1024 // scaling_n} "
-        f"--src-interface={interface} --src-ibv "
-        f"--dst-interface={interface} --dst-ibv "
-        f"--src-affinity={src_affinity} --src-comp-vector={src_affinity} "
-        f"--dst-affinity={dst_affinity} --dst-comp-vector={dst_affinity} "
+        f"--recv-packet-samples={args.dig_heap_samples} "
+        f"--recv-chunk-samples={recv_chunk_samples} --send-chunk-jones={send_chunk_jones} "
+        f"--recv-buffer={256 * 1024 * 1024 // scaling_n} "
+        f"--recv-interface={interface} --recv-ibv "
+        f"--send-interface={interface} --send-ibv "
+        f"--recv-affinity={recv_affinity} --recv-comp-vector={recv_affinity} "
+        f"--send-affinity={send_affinity} --send-comp-vector={send_affinity} "
         f"--adc-sample-rate={adc_sample_rate} "
         f"--katcp-port={katcp_port} "
         f"--prometheus-port={prometheus_port} "

--- a/scratch/fgpu/benchmarks/compute_bench.py
+++ b/scratch/fgpu/benchmarks/compute_bench.py
@@ -30,12 +30,12 @@ from katgpucbf.fgpu.main import DEFAULT_DDC_TAPS_RATIO
 def main():  # noqa: C901
     parser = argparse.ArgumentParser()
     parser.add_argument("--taps", type=int, default=16)
-    parser.add_argument("--src-chunk-samples", type=int, default=32 * 1024 * 1024)
-    parser.add_argument("--dst-chunk-jones", type=int, default=8 * 1024 * 1024)
+    parser.add_argument("--recv-chunk-samples", type=int, default=32 * 1024 * 1024)
+    parser.add_argument("--send-chunk-jones", type=int, default=8 * 1024 * 1024)
     parser.add_argument("--channels", type=int, default=32768)
     parser.add_argument("--spectra-per-heap", type=int, default=256)
     parser.add_argument("--dig-sample-bits", type=int, default=DIG_SAMPLE_BITS)
-    parser.add_argument("--dst-sample-bits", type=int, default=8, choices=[4, 8])
+    parser.add_argument("--send-sample-bits", type=int, default=8, choices=[4, 8])
     parser.add_argument("--passes", type=int, default=1000)
     parser.add_argument("--ddc-taps", type=int)  # Default is computed from decimation
     parser.add_argument("--narrowband", action="store_true")
@@ -72,15 +72,15 @@ def main():  # noqa: C901
             spectra_samples = 2 * args.channels
             window = args.taps * spectra_samples
         template = ComputeTemplate(
-            context, args.taps, args.channels, args.dig_sample_bits, args.dst_sample_bits, narrowband=narrowband_config
+            context, args.taps, args.channels, args.dig_sample_bits, args.send_sample_bits, narrowband=narrowband_config
         )
         command_queue = context.create_tuning_command_queue()
-        out_spectra = accel.roundup(args.dst_chunk_jones // args.channels, args.spectra_per_heap)
-        frontend_spectra = min(args.src_chunk_samples // spectra_samples, out_spectra)
+        out_spectra = accel.roundup(args.send_chunk_jones // args.channels, args.spectra_per_heap)
+        frontend_spectra = min(args.recv_chunk_samples // spectra_samples, out_spectra)
         extra_samples = window - spectra_samples
         fn = template.instantiate(
             command_queue,
-            samples=args.src_chunk_samples + extra_samples,
+            samples=args.recv_chunk_samples + extra_samples,
             spectra=out_spectra,
             spectra_per_heap=args.spectra_per_heap,
         )

--- a/scratch/fgpu/benchmarks/compute_bench.py
+++ b/scratch/fgpu/benchmarks/compute_bench.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 ################################################################################
-# Copyright (c) 2022-2023, National Research Foundation (SARAO)
+# Copyright (c) 2022-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/scratch/fgpu/run-fgpu-hbw.sh
+++ b/scratch/fgpu/run-fgpu-hbw.sh
@@ -5,10 +5,10 @@ set -e -u
 # Load variables for machine-specific config
 . ../config/$(hostname -s).sh
 
-src_affinity="0,1,4,5"
-src_comp=$src_affinity
-dst_affinity="8"
-dst_comp=$dst_affinity
+recv_affinity="0,1,4,5"
+recv_comp=$recv_affinity
+send_affinity="8"
+send_comp=$send_affinity
 other_affinity="12"
 src="239.102.0.64+15:7148"
 dst="239.102.200.0+63:7148"
@@ -21,13 +21,13 @@ export CUDA_VISIBLE_DEVICES="$cuda1"
 
 set -x
 exec spead2_net_raw taskset -c $other_affinity fgpu \
-    --src-chunk-samples 134217728 \
-    --dst-chunk-jones 33554432 \
-    --src-buffer=268435456 \
-    --src-interface $iface1,$iface2 --src-ibv \
-    --dst-interface $iface1,$iface2 --dst-ibv \
-    --src-affinity $src_affinity --src-comp-vector=$src_comp \
-    --dst-affinity $dst_affinity --dst-comp-vector=$dst_comp \
+    --recv-chunk-samples 134217728 \
+    --send-chunk-jones 33554432 \
+    --recv-buffer=268435456 \
+    --recv-interface $iface1,$iface2 --recv-ibv \
+    --send-interface $iface1,$iface2 --send-ibv \
+    --recv-affinity $recv_affinity --recv-comp-vector=$recv_comp \
+    --send-affinity $send_affinity --send-comp-vector=$send_comp \
     --adc-sample-rate ${adc_sample_rate:-7000000000} \
     --jones-per-batch ${jones_per_batch:-1048576} \
     --katcp-port $katcp_port \

--- a/scratch/fgpu/run-fgpu.sh
+++ b/scratch/fgpu/run-fgpu.sh
@@ -9,14 +9,14 @@ nodes=$(lscpu | grep 'NUMA node.*CPU' | wc -l)
 nproc=$(nproc)
 step=$(($nproc / $nodes))
 hstep=$(($step / 2))
-src_idx=$(($1 % 4))
+recv_idx=$(($1 % 4))
 
-src_affinity="$(($step*$1))"
-src_comp=$src_affinity
-dst_affinity="$(($step*$1+$hstep))"
-dst_comp=$dst_affinity
+recv_affinity="$(($step*$1))"
+recv_comp=$recv_affinity
+send_affinity="$(($step*$1+$hstep))"
+send_comp=$send_affinity
 other_affinity="$(($step*$1+$hstep+1))"
-src="239.102.$src_idx.64+15:7148"
+src="239.102.$recv_idx.64+15:7148"
 dst="239.102.$((200+$1)).0+63:7148"
 nb_dst="239.102.$((216+$1)).0+7:7148"
 katcp_port="$(($1+7140))"
@@ -49,10 +49,10 @@ shift
 
 set -x
 exec spead2_net_raw taskset -c $other_affinity fgpu \
-    --src-interface $iface --src-ibv \
-    --dst-interface $iface --dst-ibv \
-    --src-affinity $src_affinity --src-comp-vector=$src_comp \
-    --dst-affinity $dst_affinity --dst-comp-vector=$dst_comp \
+    --recv-interface $iface --recv-ibv \
+    --send-interface $iface --send-ibv \
+    --recv-affinity $recv_affinity --recv-comp-vector=$recv_comp \
+    --send-affinity $send_affinity --send-comp-vector=$send_comp \
     --adc-sample-rate ${adc_sample_rate:-1712000000} \
     --jones-per-batch ${jones_per_batch:-1048576} \
     --katcp-port $katcp_port \

--- a/scratch/xbgpu/run-xbgpu.sh
+++ b/scratch/xbgpu/run-xbgpu.sh
@@ -23,8 +23,8 @@ rx_comp=$rx_affinity
 tx_affinity=$((affinity + 1))
 tx_comp=$tx_affinity
 other_affinity=$tx_affinity
-src_mcast="239.10.10.$((10 + index)):7148"
-dst_mcast="239.10.11.$((10 + index)):7148"
+src="239.10.10.$((10 + index)):7148"
+dst="239.10.11.$((10 + index)):7148"
 channel_offset=$((channels_per_substream * index))
 katcp_port="$((7140 + index))"
 prom_port="$((7150 + index))"
@@ -74,7 +74,7 @@ exec schedrr spead2_net_raw numactl -C $other_affinity xbgpu \
     --recv-interface $iface \
     --send-interface $iface \
     --recv-ibv --send-ibv \
-    --corrprod=name=bcp1,heap_accumulation_threshold=${heap_accumulation_threshold},dst=$dst_mcast \
+    --corrprod=name=bcp1,heap_accumulation_threshold=${heap_accumulation_threshold},dst=$dst \
     "${beam_args[@]}" \
     --adc-sample-rate ${adc_sample_rate} \
     --array-size ${array_size:-64} \
@@ -88,4 +88,4 @@ exec schedrr spead2_net_raw numactl -C $other_affinity xbgpu \
     --katcp-port $katcp_port \
     --prometheus-port $prom_port \
     --send-enabled \
-    $src_mcast
+    $src

--- a/scratch/xbgpu/run-xbgpu.sh
+++ b/scratch/xbgpu/run-xbgpu.sh
@@ -24,7 +24,7 @@ tx_affinity=$((affinity + 1))
 tx_comp=$tx_affinity
 other_affinity=$tx_affinity
 src_mcast="239.10.10.$((10 + index)):7148"
-send_mcast="239.10.11.$((10 + index)):7148"
+dst_mcast="239.10.11.$((10 + index)):7148"
 channel_offset=$((channels_per_substream * index))
 katcp_port="$((7140 + index))"
 prom_port="$((7150 + index))"
@@ -74,7 +74,7 @@ exec schedrr spead2_net_raw numactl -C $other_affinity xbgpu \
     --recv-interface $iface \
     --send-interface $iface \
     --recv-ibv --send-ibv \
-    --corrprod=name=bcp1,heap_accumulation_threshold=${heap_accumulation_threshold},dst=$send_mcast \
+    --corrprod=name=bcp1,heap_accumulation_threshold=${heap_accumulation_threshold},dst=$dst_mcast \
     "${beam_args[@]}" \
     --adc-sample-rate ${adc_sample_rate} \
     --array-size ${array_size:-64} \

--- a/scratch/xbgpu/run-xbgpu.sh
+++ b/scratch/xbgpu/run-xbgpu.sh
@@ -24,7 +24,7 @@ tx_affinity=$((affinity + 1))
 tx_comp=$tx_affinity
 other_affinity=$tx_affinity
 src_mcast="239.10.10.$((10 + index)):7148"
-dst_mcast="239.10.11.$((10 + index)):7148"
+send_mcast="239.10.11.$((10 + index)):7148"
 channel_offset=$((channels_per_substream * index))
 katcp_port="$((7140 + index))"
 prom_port="$((7150 + index))"
@@ -67,14 +67,14 @@ fi
 set -x
 
 exec schedrr spead2_net_raw numactl -C $other_affinity xbgpu \
-    --src-affinity $rx_affinity \
-    --src-comp-vector $rx_comp \
-    --dst-affinity $tx_affinity \
-    --dst-comp-vector $tx_comp \
-    --src-interface $iface \
-    --dst-interface $iface \
-    --src-ibv --dst-ibv \
-    --corrprod=name=bcp1,heap_accumulation_threshold=${heap_accumulation_threshold},dst=$dst_mcast \
+    --recv-affinity $rx_affinity \
+    --recv-comp-vector $rx_comp \
+    --send-affinity $tx_affinity \
+    --send-comp-vector $tx_comp \
+    --recv-interface $iface \
+    --send-interface $iface \
+    --recv-ibv --send-ibv \
+    --corrprod=name=bcp1,heap_accumulation_threshold=${heap_accumulation_threshold},dst=$send_mcast \
     "${beam_args[@]}" \
     --adc-sample-rate ${adc_sample_rate} \
     --array-size ${array_size:-64} \

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -491,8 +491,8 @@ class Pipeline:
             context,
             output.taps,
             output.channels,
-            engine.src_layout.sample_bits,
-            engine.dst_sample_bits,
+            engine.recv_layout.sample_bits,
+            engine.send_sample_bits,
             narrowband=narrowband_config,
         )
         self._compute = template.instantiate(compute_queue, engine.n_samples, self.spectra, output.spectra_per_heap)
@@ -526,7 +526,7 @@ class Pipeline:
         self.descriptor_heap = send.make_descriptor_heap(
             channels_per_substream=output.channels // len(output.dst),
             spectra_per_heap=output.spectra_per_heap,
-            sample_bits=engine.dst_sample_bits,
+            sample_bits=engine.send_sample_bits,
         )
 
     def _populate_sensors(self) -> None:
@@ -606,7 +606,7 @@ class Pipeline:
                     send.Chunk(
                         accel.HostArray(
                             send_shape,
-                            gaussian_dtype(self.engine.dst_sample_bits),
+                            gaussian_dtype(self.engine.send_sample_bits),
                             context=self._compute.template.context,
                         ),
                         accel.HostArray((heaps, N_POLS), np.uint32, context=self._compute.template.context),
@@ -847,9 +847,9 @@ class Pipeline:
                         )
                         # Offset of the last sample (inclusive, rather than past-the-end)
                         last_offset = first_offset + self.output.window - 1
-                        first_packet = first_offset // self.engine.src_layout.heap_samples
+                        first_packet = first_offset // self.engine.recv_layout.heap_samples
                         # last_packet is exclusive
-                        last_packet = last_offset // self.engine.src_layout.heap_samples + 1
+                        last_packet = last_offset // self.engine.recv_layout.heap_samples + 1
                         present_packets = (
                             in_item.present_cumsum[pol, last_packet] - in_item.present_cumsum[pol, first_packet]
                         )
@@ -914,7 +914,7 @@ class Pipeline:
                     avg_power = total_power / (out_item.n_spectra * self.output.spectra_samples)
                     # Normalise relative to full scale. The factor of 2 is because we
                     # want 1.0 to correspond to a sine wave rather than a square wave.
-                    avg_power /= ((1 << (self.engine.src_layout.sample_bits - 1)) - 1) ** 2 / 2
+                    avg_power /= ((1 << (self.engine.recv_layout.sample_bits - 1)) - 1) ** 2 / 2
                     # If for some reason there's zero power, avoid reporting
                     # -inf dB by assigning the most negative representable value
                     avg_power_db = 10 * math.log10(avg_power) if avg_power else np.finfo(np.float64).min
@@ -1081,35 +1081,35 @@ class Engine(aiokatcp.DeviceServer):
         Handle to vkgdr for the same device as `context`.
     srcs
         A list of source endpoints for the incoming data, or a pcap filename.
-    src_interface
+    recv_interface
         IP addresses of the network devices to use for input.
-    src_ibv
+    recv_ibv
         Use ibverbs for input.
-    src_affinity
+    recv_affinity
         List of CPU cores for input-handling threads. Must be one number per
         pol.
-    src_comp_vector
+    recv_comp_vector
         Completion vectors for source streams, or -1 for polling.
         See :class:`spead2.recv.UdpIbvConfig` for further information.
-    src_packet_samples
+    recv_packet_samples
         The number of samples per digitiser packet.
-    src_buffer
+    recv_buffer
         The size of the network receive buffer.
-    dst_interface
+    send_interface
         IP addresses of the network devices to use for output.
-    dst_ttl
+    send_ttl
         TTL for outgoing packets.
-    dst_ibv
+    send_ibv
         Use ibverbs for output.
-    dst_packet_payload
+    send_packet_payload
         Size for output packets (voltage payload only, headers and padding are
         added to this).
-    dst_affinity
+    send_affinity
         CPU core for output-handling thread.
-    dst_comp_vector
+    send_comp_vector
         Completion vector for transmission, or -1 for polling.
         See :class:`spead2.send.UdpIbvConfig` for further information.
-    dst_buffer
+    send_buffer
         Size of the network send buffer.
     outputs
         Output streams to generate.
@@ -1163,19 +1163,19 @@ class Engine(aiokatcp.DeviceServer):
         context: AbstractContext,
         vkgdr_handle: vkgdr.Vkgdr,
         srcs: str | list[tuple[str, int]],
-        src_interface: list[str] | None,
-        src_ibv: bool,
-        src_affinity: list[int],
-        src_comp_vector: list[int],
-        src_packet_samples: int,
-        src_buffer: int,
-        dst_interface: list[str],
-        dst_ttl: int,
-        dst_ibv: bool,
-        dst_packet_payload: int,
-        dst_affinity: int,
-        dst_comp_vector: int,
-        dst_buffer: int,
+        recv_interface: list[str] | None,
+        recv_ibv: bool,
+        recv_affinity: list[int],
+        recv_comp_vector: list[int],
+        recv_packet_samples: int,
+        recv_buffer: int,
+        send_interface: list[str],
+        send_ttl: int,
+        send_ibv: bool,
+        send_packet_payload: int,
+        send_affinity: int,
+        send_comp_vector: int,
+        send_buffer: int,
         outputs: list[Output],
         adc_sample_rate: float,
         send_rate_factor: float,
@@ -1184,7 +1184,7 @@ class Engine(aiokatcp.DeviceServer):
         chunk_samples: int,
         chunk_jones: int,
         dig_sample_bits: int,
-        dst_sample_bits: int,
+        send_sample_bits: int,
         max_delay_diff: int,
         gain: complex,
         sync_time: float,
@@ -1201,17 +1201,17 @@ class Engine(aiokatcp.DeviceServer):
 
         # Attributes copied or initialised from arguments
         self._srcs = copy.copy(srcs)
-        self._src_comp_vector = list(src_comp_vector)
-        self._src_interface = src_interface
-        self._src_buffer = src_buffer
-        self._src_ibv = src_ibv
-        self.src_layout = recv.Layout(dig_sample_bits, src_packet_samples, chunk_samples, mask_timestamp)
-        self._dst_interface = dst_interface
-        self._dst_ttl = dst_ttl
-        self._dst_ibv = dst_ibv
-        self._dst_packet_payload = dst_packet_payload
-        self._dst_comp_vector = dst_comp_vector
-        self._dst_buffer = dst_buffer
+        self._recv_comp_vector = list(recv_comp_vector)
+        self._recv_interface = recv_interface
+        self._recv_buffer = recv_buffer
+        self._recv_ibv = recv_ibv
+        self.recv_layout = recv.Layout(dig_sample_bits, recv_packet_samples, chunk_samples, mask_timestamp)
+        self._send_interface = send_interface
+        self._send_ttl = send_ttl
+        self._send_ibv = send_ibv
+        self._send_packet_payload = send_packet_payload
+        self._send_comp_vector = send_comp_vector
+        self._send_buffer = send_buffer
         self._send_rate_factor = send_rate_factor
         self.adc_sample_rate = adc_sample_rate
         self.feng_id = feng_id
@@ -1222,7 +1222,7 @@ class Engine(aiokatcp.DeviceServer):
         self.monitor = monitor
         self.use_vkgdr = use_vkgdr
         self.use_peerdirect = use_peerdirect
-        self.dst_sample_bits = dst_sample_bits
+        self.send_sample_bits = send_sample_bits
         self.vkgdr_handle = vkgdr_handle
 
         # Tuning knobs not exposed via arguments
@@ -1233,50 +1233,50 @@ class Engine(aiokatcp.DeviceServer):
         self._copy_queue = context.create_command_queue()
 
         extra_samples = max_delay_diff + max(output.window for output in outputs)
-        if extra_samples > self.src_layout.chunk_samples:
+        if extra_samples > self.recv_layout.chunk_samples:
             raise RuntimeError(f"chunk_samples is too small; it must be at least {extra_samples}")
-        self.n_samples = self.src_layout.chunk_samples + extra_samples
+        self.n_samples = self.recv_layout.chunk_samples + extra_samples
 
         self._in_free_queue: asyncio.Queue[InQueueItem] = monitor.make_queue("in_free_queue", self.n_in)
-        self._init_recv(src_affinity, monitor)
+        self._init_recv(recv_affinity, monitor)
 
         # Prevent multiple chunks from being in flight in pipelines at the same
         # time. This keeps the pipelines synchronised to avoid running out of
         # InItems.
         self._active_in_sem = asyncio.BoundedSemaphore(1)
         self._pipelines = []
-        self._send_thread_pool = spead2.ThreadPool(1, [] if dst_affinity < 0 else [dst_affinity])
+        self._send_thread_pool = spead2.ThreadPool(1, [] if send_affinity < 0 else [send_affinity])
         for i, output in enumerate(outputs):
             # Wideband outputs are always placed first, but we need to consider
             # the case of there being no wideband output at all.
             dig_stats = i == 0 and isinstance(output, WidebandOutput)
             self._pipelines.append(Pipeline(output, self, context, dig_stats))
 
-    def _init_recv(self, src_affinity: list[int], monitor: Monitor) -> None:
+    def _init_recv(self, recv_affinity: list[int], monitor: Monitor) -> None:
         """Initialise the receive side of the engine."""
-        src_chunks = 4
-        ringbuffer_capacity = src_chunks * N_POLS
+        recv_chunks = 4
+        ringbuffer_capacity = recv_chunks * N_POLS
 
         context = self._upload_queue.context
         for _ in range(self._in_free_queue.maxsize):
             self._in_free_queue.put_nowait(
-                InQueueItem(context, self.src_layout, self.n_samples, use_vkgdr=self.use_vkgdr)
+                InQueueItem(context, self.recv_layout, self.n_samples, use_vkgdr=self.use_vkgdr)
             )
 
         data_ringbuffer = ChunkRingbuffer(
             ringbuffer_capacity, name="recv_data_ringbuffer", task_name="run_receive", monitor=monitor
         )
-        free_ringbuffer = spead2.recv.ChunkRingbuffer(src_chunks)
+        free_ringbuffer = spead2.recv.ChunkRingbuffer(recv_chunks)
         if self.use_vkgdr:
             # These quantities are per-pol
-            array_bytes = self.n_samples * self.src_layout.sample_bits // BYTE_BITS
+            array_bytes = self.n_samples * self.recv_layout.sample_bits // BYTE_BITS
             stride = _padded_input_size(array_bytes)
         else:
-            stride = self.src_layout.chunk_bytes
-        self._src_group = recv.make_stream_group(
-            self.src_layout, data_ringbuffer, free_ringbuffer, src_affinity, stride
+            stride = self.recv_layout.chunk_bytes
+        self._recv_group = recv.make_stream_group(
+            self.recv_layout, data_ringbuffer, free_ringbuffer, recv_affinity, stride
         )
-        for _ in range(src_chunks):
+        for _ in range(recv_chunks):
             if self.use_vkgdr:
                 with context:
                     mem = vkgdr.pycuda.Memory(self.vkgdr_handle, N_POLS * stride)
@@ -1294,9 +1294,9 @@ class Engine(aiokatcp.DeviceServer):
             chunk = recv.Chunk(
                 data=buf,
                 device=device_array,
-                present=np.zeros((N_POLS, self.src_layout.chunk_heaps), np.uint8),
-                extra=np.zeros((N_POLS, self.src_layout.chunk_heaps), np.uint16),
-                sink=self._src_group,
+                present=np.zeros((N_POLS, self.recv_layout.chunk_heaps), np.uint8),
+                extra=np.zeros((N_POLS, self.recv_layout.chunk_heaps), np.uint16),
+                sink=self._recv_group,
             )
             chunk.recycle()  # Make available to the stream
 
@@ -1346,12 +1346,12 @@ class Engine(aiokatcp.DeviceServer):
             output_name=output.name,
             thread_pool=self._send_thread_pool,
             endpoints=output.dst,
-            interfaces=self._dst_interface,
-            ttl=self._dst_ttl,
-            ibv=self._dst_ibv,
-            packet_payload=self._dst_packet_payload,
-            comp_vector=self._dst_comp_vector,
-            buffer=self._dst_buffer,
+            interfaces=self._send_interface,
+            ttl=self._send_ttl,
+            ibv=self._send_ibv,
+            packet_payload=self._send_packet_payload,
+            comp_vector=self._send_comp_vector,
+            buffer=self._send_buffer,
             bandwidth=self.adc_sample_rate * 0.5 / output.decimation,
             send_rate_factor=self._send_rate_factor,
             feng_id=self.feng_id,
@@ -1416,10 +1416,10 @@ class Engine(aiokatcp.DeviceServer):
         `prev_item` then the tail of `prev_item` is instead marked as absent.
         This can happen if we lose a whole input chunk from the digitiser.
         """
-        chunk_heaps = prev_item.n_samples // self.src_layout.heap_samples
+        chunk_heaps = prev_item.n_samples // self.recv_layout.heap_samples
         copy_heaps = prev_item.present.shape[1] - chunk_heaps
         if in_item is not None and prev_item.end_timestamp == in_item.timestamp:
-            sample_bits = self.src_layout.sample_bits
+            sample_bits = self.recv_layout.sample_bits
             copy_samples = prev_item.capacity - prev_item.n_samples
             copy_samples = min(copy_samples, in_item.n_samples)
             copy_bytes = copy_samples * sample_bits // BYTE_BITS
@@ -1679,28 +1679,28 @@ class Engine(aiokatcp.DeviceServer):
             self.add_service_task(descriptor_task)
             self._cancel_tasks.append(descriptor_task)
 
-        src_comp_vector_iter = iter(self._src_comp_vector)
-        if self._src_interface is None:
-            src_interface_iter: Iterator[str | None] = itertools.repeat(None)
+        recv_comp_vector_iter = iter(self._recv_comp_vector)
+        if self._recv_interface is None:
+            recv_interface_iter: Iterator[str | None] = itertools.repeat(None)
         else:
-            src_interface_iter = itertools.cycle(self._src_interface)
+            recv_interface_iter = itertools.cycle(self._recv_interface)
         if isinstance(self._srcs, str):
-            self._src_group[0].add_udp_pcap_file_reader(self._srcs)
+            self._recv_group[0].add_udp_pcap_file_reader(self._srcs)
         else:
-            for i, stream in enumerate(self._src_group):
-                first_src = i * len(self._srcs) // len(self._src_group)
-                last_src = (i + 1) * len(self._srcs) // len(self._src_group)
+            for i, stream in enumerate(self._recv_group):
+                first_src = i * len(self._srcs) // len(self._recv_group)
+                last_src = (i + 1) * len(self._srcs) // len(self._recv_group)
                 base_recv.add_reader(
                     stream,
                     src=self._srcs[first_src:last_src],
-                    interface=next(src_interface_iter),
-                    ibv=self._src_ibv,
-                    comp_vector=next(src_comp_vector_iter),
-                    buffer=self._src_buffer // len(self._src_group),
+                    interface=next(recv_interface_iter),
+                    ibv=self._recv_ibv,
+                    comp_vector=next(recv_comp_vector_iter),
+                    buffer=self._recv_buffer // len(self._recv_group),
                 )
 
         recv_task = asyncio.create_task(
-            self._run_receive(self._src_group, self.src_layout),
+            self._run_receive(self._recv_group, self.recv_layout),
             name=RECV_TASK_NAME,
         )
         self.add_service_task(recv_task)
@@ -1729,7 +1729,7 @@ class Engine(aiokatcp.DeviceServer):
         """
         for task in self._cancel_tasks:
             task.cancel()
-        self._src_group.stop()
+        self._recv_group.stop()
         # If any of the tasks are already done then we had an exception, and
         # waiting for the rest may hang as the shutdown path won't proceed
         # neatly.

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -266,7 +266,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         type=comma_split(get_interface_address),
         help="Name(s) of input network device(s)",
     )
-    parser.add_argument("--recv-ibv", action="store_true", help="Use ibverbs for input [no]")
+    parser.add_argument("--recv-ibv", action="store_true", help="Use ibverbs for receiving [no]")
     parser.add_argument(
         "--recv-affinity",
         type=comma_split(int),

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -262,59 +262,63 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     )
     add_aiomonitor_arguments(parser)
     parser.add_argument(
-        "--src-interface",
+        "--recv-interface",
         type=comma_split(get_interface_address),
         help="Name(s) of input network device(s)",
     )
-    parser.add_argument("--src-ibv", action="store_true", help="Use ibverbs for input [no]")
+    parser.add_argument("--recv-ibv", action="store_true", help="Use ibverbs for input [no]")
     parser.add_argument(
-        "--src-affinity",
+        "--recv-affinity",
         type=comma_split(int),
         metavar="CORE,...",
         default=[-1],
         help="Cores for input-handling threads (comma-separated) [not bound]",
     )
     parser.add_argument(
-        "--src-comp-vector",
+        "--recv-comp-vector",
         type=comma_split(int),
         metavar="VECTOR,...",
         default=[0],
         help="Completion vectors for source streams, or -1 for polling [0]",
     )
     parser.add_argument(
-        "--src-packet-samples", type=int, default=4096, help="Number of samples per digitiser packet [%(default)s]"
+        "--recv-packet-samples", type=int, default=4096, help="Number of samples per digitiser packet [%(default)s]"
     )
     parser.add_argument(
-        "--src-buffer",
+        "--recv-buffer",
         type=int,
         default=128 * 1024 * 1024,
         metavar="BYTES",
         help="Size of network receive buffer [128MiB]",
     )
     parser.add_argument(
-        "--dst-interface", type=comma_split(get_interface_address), required=True, help="Name of output network device"
+        "--send-interface", type=comma_split(get_interface_address), required=True, help="Name of output network device"
     )
-    parser.add_argument("--dst-ttl", type=int, default=DEFAULT_TTL, help="TTL for outgoing packets [%(default)s]")
-    parser.add_argument("--dst-ibv", action="store_true", help="Use ibverbs for output [no]")
+    parser.add_argument("--send-ttl", type=int, default=DEFAULT_TTL, help="TTL for outgoing packets [%(default)s]")
+    parser.add_argument("--send-ibv", action="store_true", help="Use ibverbs for output [no]")
     parser.add_argument(
-        "--dst-packet-payload",
+        "--send-packet-payload",
         type=int,
         default=DEFAULT_PACKET_PAYLOAD_BYTES,
         metavar="BYTES",
         help="Size for output packets (voltage payload only) [%(default)s]",
     )
     parser.add_argument(
-        "--dst-affinity", type=int, default=-1, metavar="CORE,...", help="Cores for output-handling threads [not bound]"
+        "--send-affinity",
+        type=int,
+        default=-1,
+        metavar="CORE,...",
+        help="Cores for output-handling threads [not bound]",
     )
     parser.add_argument(
-        "--dst-comp-vector",
+        "--send-comp-vector",
         type=int,
         default=0,
         metavar="VECTOR",
         help="Completion vector for transmission, or -1 for polling [0]",
     )
     parser.add_argument(
-        "--dst-buffer",
+        "--send-buffer",
         type=int,
         default=1024 * 1024,
         metavar="BYTES",
@@ -355,14 +359,14 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         help="Jones vectors in each output batch [%(default)s]",
     )
     parser.add_argument(
-        "--src-chunk-samples",
+        "--recv-chunk-samples",
         type=int,
         default=2**25,
         metavar="SAMPLES",
         help="Number of digitiser samples to process at a time (per pol). [%(default)s]",
     )
     parser.add_argument(
-        "--dst-chunk-jones",
+        "--send-chunk-jones",
         type=int,
         default=2**23,
         metavar="VECTORS",
@@ -384,7 +388,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         help="Number of bits per digitised sample [%(default)s]",
     )
     parser.add_argument(
-        "--dst-sample-bits",
+        "--send-sample-bits",
         type=int,
         default=8,
         choices=[4, 8],
@@ -416,12 +420,12 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("src", type=parse_source, help="Source endpoints (or pcap file)")
     args = parser.parse_args(arglist)
 
-    if args.use_peerdirect and not args.dst_ibv:
-        parser.error("--use-peerdirect requires --dst-ibv")
-    if not isinstance(args.src, str) and args.src_interface is None:
-        parser.error("Live source requires --src-interface")
-    if args.src_ibv and len(args.src_affinity) != len(args.src_comp_vector):
-        parser.error("--src-comp-vector must have same length as --src-affinity")
+    if args.use_peerdirect and not args.send_ibv:
+        parser.error("--use-peerdirect requires --send-ibv")
+    if not isinstance(args.src, str) and args.recv_interface is None:
+        parser.error("Live source requires --recv-interface")
+    if args.recv_ibv and len(args.recv_affinity) != len(args.recv_comp_vector):
+        parser.error("--recv-comp-vector must have same length as --recv-affinity")
 
     # Convert from _*OutputDict to *Output
     used_names = set()
@@ -431,7 +435,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
             name = output.name
             if output.name in used_names:
                 parser.error(f"output name {name} used twice")
-            if len(output.dst) % len(args.dst_interface) != 0:
+            if len(output.dst) % len(args.send_interface) != 0:
                 parser.error(f"{name}: number of destinations must be divisible by number of destination interfaces")
             used_names.add(name)
             args.outputs.append(output)
@@ -461,35 +465,35 @@ def make_engine(ctx: AbstractContext, vkgdr_handle: vkgdr.Vkgdr, args: argparse.
         monitor = NullMonitor()
 
     batch_jones_lcm = math.lcm(*(output.jones_per_batch for output in args.outputs))
-    chunk_jones = accel.roundup(args.dst_chunk_jones, batch_jones_lcm)
+    chunk_jones = accel.roundup(args.send_chunk_jones, batch_jones_lcm)
     engine = Engine(
         katcp_host=args.katcp_host,
         katcp_port=args.katcp_port,
         context=ctx,
         vkgdr_handle=vkgdr_handle,
         srcs=args.src,
-        src_interface=args.src_interface,
-        src_ibv=args.src_ibv,
-        src_affinity=args.src_affinity,
-        src_comp_vector=args.src_comp_vector,
-        src_packet_samples=args.src_packet_samples,
-        src_buffer=args.src_buffer,
-        dst_interface=args.dst_interface,
-        dst_ttl=args.dst_ttl,
-        dst_ibv=args.dst_ibv,
-        dst_packet_payload=args.dst_packet_payload,
-        dst_affinity=args.dst_affinity,
-        dst_comp_vector=args.dst_comp_vector,
-        dst_buffer=args.dst_buffer,
+        recv_interface=args.recv_interface,
+        recv_ibv=args.recv_ibv,
+        recv_affinity=args.recv_affinity,
+        recv_comp_vector=args.recv_comp_vector,
+        recv_packet_samples=args.recv_packet_samples,
+        recv_buffer=args.recv_buffer,
+        send_interface=args.send_interface,
+        send_ttl=args.send_ttl,
+        send_ibv=args.send_ibv,
+        send_packet_payload=args.send_packet_payload,
+        send_affinity=args.send_affinity,
+        send_comp_vector=args.send_comp_vector,
+        send_buffer=args.send_buffer,
         outputs=args.outputs,
         adc_sample_rate=args.adc_sample_rate,
         send_rate_factor=args.send_rate_factor,
         feng_id=args.feng_id,
         n_ants=args.array_size,
-        chunk_samples=args.src_chunk_samples,
+        chunk_samples=args.recv_chunk_samples,
         chunk_jones=chunk_jones,
         dig_sample_bits=args.dig_sample_bits,
-        dst_sample_bits=args.dst_sample_bits,
+        send_sample_bits=args.send_sample_bits,
         max_delay_diff=args.max_delay_diff,
         gain=args.gain,
         sync_time=args.sync_time,

--- a/src/katgpucbf/fgpu/recv.py
+++ b/src/katgpucbf/fgpu/recv.py
@@ -173,7 +173,7 @@ def make_stream_group(
     layout: Layout,
     data_ringbuffer: spead2.recv.asyncio.ChunkRingbuffer,
     free_ringbuffer: spead2.recv.ChunkRingbuffer,
-    src_affinity: Sequence[int],
+    recv_affinity: Sequence[int],
     stride: int,
 ) -> spead2.recv.ChunkStreamRingGroup:
     """Create SPEAD receiver streams.
@@ -189,7 +189,7 @@ def make_stream_group(
         Output ringbuffer to which chunks will be sent.
     free_ringbuffer
         Ringbuffer for holding chunks for recycling once they've been used.
-    src_affinity
+    recv_affinity
         CPU core affinity for the worker threads (one per thread).
         Use -1 to indicate no affinity for a thread.
     stride
@@ -209,7 +209,7 @@ def make_stream_group(
         max_heap_extra=np.dtype(np.uint16).itemsize,
         data_ringbuffer=data_ringbuffer,
         free_ringbuffer=free_ringbuffer,
-        affinity=src_affinity,
+        affinity=recv_affinity,
         max_heaps=1,  # Digitiser heaps are single-packet, so no need for more
         stream_stats=["katgpucbf.metadata_heaps", "katgpucbf.bad_timestamp_heaps"],
         user_data=user_data,

--- a/src/katgpucbf/fsim/main.py
+++ b/src/katgpucbf/fsim/main.py
@@ -90,7 +90,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--ttl", type=int, default=DEFAULT_TTL, help="IP TTL for multicast [%(default)s]")
     parser.add_argument("--ibv", action="store_true", help="Use ibverbs for acceleration")
     parser.add_argument(
-        "--dst-packet-payload",
+        "--send-packet-payload",
         type=int,
         default=DEFAULT_PACKET_PAYLOAD_BYTES,
         metavar="BYTES",
@@ -207,13 +207,13 @@ def make_stream(args: argparse.Namespace, idx: int, data: np.ndarray) -> "spead2
     data
         All payload data for this destination
     """
-    overhead = 1 + PREAMBLE_SIZE / args.dst_packet_payload
+    overhead = 1 + PREAMBLE_SIZE / args.send_packet_payload
     # Data rate for the entire array, excluding packet overhead
     full_rate = args.adc_sample_rate * N_POLS * DTYPE.itemsize * args.array_size
     rate = full_rate * args.channels_per_substream / args.channels * overhead
     print(f"Rate for {args.dest[idx]}: {rate * 8e-9:.3f} Gbps")
     config = spead2.send.StreamConfig(
-        max_packet_size=args.dst_packet_payload + PREAMBLE_SIZE,
+        max_packet_size=args.send_packet_payload + PREAMBLE_SIZE,
         rate=rate,
         max_heaps=QUEUE_DEPTH * args.array_size + 1,  # + 1 for descriptor heaps
     )

--- a/src/katgpucbf/recv.py
+++ b/src/katgpucbf/recv.py
@@ -394,7 +394,7 @@ def add_reader(
         stream.add_udp_pcap_file_reader(src)
     elif ibv:
         if interface is None:
-            raise ValueError("--src-interface is required with --src-ibv")
+            raise ValueError("--recv-interface is required with --recv-ibv")
         ibv_config = spead2.recv.UdpIbvConfig(
             endpoints=src,
             interface_address=interface,

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -293,7 +293,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         "is required to do. [%(default)s]",
     )
     parser.add_argument(
-        "--src-reorder-tol",
+        "--recv-reorder-tol",
         type=int,
         default=2**29,
         help="Maximum time (in ADC ticks) that packets can be delayed relative to others "
@@ -306,51 +306,51 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         help="UNIX time at which digitisers were synced.",
     )
     parser.add_argument(
-        "--src-affinity", type=int, default=-1, help="Core to which the receiver thread will be bound [not bound]."
+        "--recv-affinity", type=int, default=-1, help="Core to which the receiver thread will be bound [not bound]."
     )
     parser.add_argument(
-        "--src-comp-vector",
+        "--recv-comp-vector",
         type=int,
         default=0,
         help="Completion vector for source streams, or -1 for polling [%(default)s].",
     )
     parser.add_argument(
-        "--src-interface",
+        "--recv-interface",
         type=get_interface_address,
         required=True,
         help="Name of the interface receiving data from the F-Engines, e.g. eth0.",
     )
-    parser.add_argument("--src-ibv", action="store_true", help="Use ibverbs for input [no].")
+    parser.add_argument("--recv-ibv", action="store_true", help="Use ibverbs for input [no].")
     parser.add_argument(
-        "--src-buffer",
+        "--recv-buffer",
         type=int,
         default=32 * 1024 * 1024,
         metavar="BYTES",
         help="Size of network receive buffer [32MiB]",
     )
     parser.add_argument(
-        "--dst-affinity", type=int, default=-1, help="Core to which the sender thread will be bound [not bound]."
+        "--send-affinity", type=int, default=-1, help="Core to which the sender thread will be bound [not bound]."
     )
     parser.add_argument(
-        "--dst-comp-vector",
+        "--send-comp-vector",
         type=int,
         default=1,
         help="Completion vector for transmission, or -1 for polling [%(default)s].",
     )
     parser.add_argument(
-        "--dst-interface",
+        "--send-interface",
         type=get_interface_address,
         required=True,
         help="Name of the interface that this engine will transmit data on, e.g. eth1.",
     )
     parser.add_argument(
-        "--dst-packet-payload",
+        "--send-packet-payload",
         type=int,
         default=DEFAULT_PACKET_PAYLOAD_BYTES,
         help="Size in bytes for output packets (baseline correlation products payload only) [%(default)s]",
     )
-    parser.add_argument("--dst-ttl", type=int, default=DEFAULT_TTL, help="TTL for outgoing packets [%(default)s]")
-    parser.add_argument("--dst-ibv", action="store_true", help="Use ibverbs for output [no].")
+    parser.add_argument("--send-ttl", type=int, default=DEFAULT_TTL, help="TTL for outgoing packets [%(default)s]")
+    parser.add_argument("--send-ibv", action="store_true", help="Use ibverbs for output [no].")
     parser.add_argument(
         "--send-enabled",
         action="store_true",
@@ -417,19 +417,19 @@ def make_engine(
         channel_offset_value=args.channel_offset_value,
         outputs=args.outputs,
         src=args.src,
-        src_interface=args.src_interface,
-        src_ibv=args.src_ibv,
-        src_affinity=args.src_affinity,
-        src_comp_vector=args.src_comp_vector,
-        src_buffer=args.src_buffer,
-        dst_interface=args.dst_interface,
-        dst_ttl=args.dst_ttl,
-        dst_ibv=args.dst_ibv,
-        dst_packet_payload=args.dst_packet_payload,
-        dst_affinity=args.dst_affinity,
-        dst_comp_vector=args.dst_comp_vector,
+        recv_interface=args.recv_interface,
+        recv_ibv=args.recv_ibv,
+        recv_affinity=args.recv_affinity,
+        recv_comp_vector=args.recv_comp_vector,
+        recv_buffer=args.recv_buffer,
+        send_interface=args.send_interface,
+        send_ttl=args.send_ttl,
+        send_ibv=args.send_ibv,
+        send_packet_payload=args.send_packet_payload,
+        send_affinity=args.send_affinity,
+        send_comp_vector=args.send_comp_vector,
         heaps_per_fengine_per_chunk=args.heaps_per_fengine_per_chunk,
-        src_reorder_tol=args.src_reorder_tol,
+        recv_reorder_tol=args.recv_reorder_tol,
         send_enabled=args.send_enabled,
         monitor=monitor,
         context=context,

--- a/src/katgpucbf/xbgpu/recv.py
+++ b/src/katgpucbf/xbgpu/recv.py
@@ -172,7 +172,7 @@ def make_stream(
     layout: Layout,
     data_ringbuffer: spead2.recv.asyncio.ChunkRingbuffer,
     free_ringbuffer: spead2.recv.ChunkRingbuffer,
-    src_affinity: int,
+    recv_affinity: int,
     max_active_chunks: int,
 ) -> spead2.recv.ChunkRingStream:
     """Create a SPEAD receiver stream.
@@ -187,7 +187,7 @@ def make_stream(
         Output ringbuffer to which chunks will be sent.
     free_ringbuffer
         Ringbuffer for holding chunks for recycling once they've been used.
-    src_affinity
+    recv_affinity
         CPU core affinity for the worker thread.
     max_active_chunks
         Maximum number of chunks under construction.
@@ -199,7 +199,7 @@ def make_stream(
         max_active_chunks=max_active_chunks,
         data_ringbuffer=data_ringbuffer,
         free_ringbuffer=free_ringbuffer,
-        affinity=src_affinity,
+        affinity=recv_affinity,
         stream_stats=["katgpucbf.metadata_heaps", "katgpucbf.bad_timestamp_heaps", "katgpucbf.bad_feng_id_heaps"],
         substreams=layout.n_ants,
         stop_on_stop_item=False,  # By default, a heap containing a stream control stop item will terminate the stream

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -228,13 +228,13 @@ class TestEngine:
         return [
             "--katcp-host=127.0.0.1",
             "--katcp-port=0",
-            "--src-interface=lo",
-            "--dst-interface=lo",
+            "--recv-interface=lo",
+            "--send-interface=lo",
             f"--sync-time={SYNC_TIME}",
-            f"--src-chunk-samples={CHUNK_SAMPLES}",
-            f"--dst-chunk-jones={CHUNK_JONES}",
+            f"--recv-chunk-samples={CHUNK_SAMPLES}",
+            f"--send-chunk-jones={CHUNK_JONES}",
             f"--max-delay-diff={MAX_DELAY_DIFF}",
-            f"--src-packet-samples={PACKET_SAMPLES}",
+            f"--recv-packet-samples={PACKET_SAMPLES}",
             f"--feng-id={FENG_ID}",
             f"--adc-sample-rate={ADC_SAMPLE_RATE}",
             f"--gain={default_gain}",
@@ -254,8 +254,8 @@ class TestEngine:
           correctly populated.
         """
         assert engine_server._port == 0
-        assert engine_server._src_interface == ["127.0.0.1"]
-        # TODO: `dst_interface` goes to the _sender member, which doesn't have anything we can query.
+        assert engine_server._recv_interface == ["127.0.0.1"]
+        # TODO: `send_interface` goes to the _sender member, which doesn't have anything we can query.
         assert engine_server._pipelines[0].output.channels == CHANNELS
         assert engine_server.time_converter.sync_time == SYNC_TIME
         assert engine_server._srcs == [(f"239.10.10.{i}", 7149) for i in range(16)]
@@ -303,8 +303,8 @@ class TestEngine:
         *,
         first_timestamp: int = 0,
         expected_first_timestamp: int | None = None,
-        src_present: np.ndarray | None = None,
-        dst_present: int | np.ndarray | None = None,
+        recv_present: np.ndarray | None = None,
+        send_present: int | np.ndarray | None = None,
     ) -> tuple[np.ndarray, np.ndarray]:
         """Send a contiguous stream of data to the engine and retrieve results.
 
@@ -322,10 +322,10 @@ class TestEngine:
         expected_first_timestamp
             Timestamp expected for the first output heap; if none is provided
             the first timestamp in the data is not checked.
-        src_present
+        recv_present
             If present, a bitmask per pol and input heap indicating which heaps
             will be sent.
-        dst_present
+        send_present
             A bitmask per output batch indicating which batches should be
             present. As a shortcut, specifying an integer indicates the number
             of expected output batches, which must all be present; and specifying
@@ -343,22 +343,22 @@ class TestEngine:
             Labels for the time axis of `data`
         """
         # Reshape into heap-size pieces (now has indices pol, heap, offset)
-        src_layout = engine.src_layout
+        recv_layout = engine.recv_layout
         channels = output.channels
         spectra_per_heap = output.spectra_per_heap
         n_samples = dig_data.shape[1]
         assert dig_data.shape[0] == N_POLS
-        assert n_samples % src_layout.chunk_samples == 0, "samples must be a whole number of chunks"
-        saturation_value = 2 ** (src_layout.sample_bits - 1) - 1
+        assert n_samples % recv_layout.chunk_samples == 0, "samples must be a whole number of chunks"
+        saturation_value = 2 ** (recv_layout.sample_bits - 1) - 1
         saturated = np.abs(dig_data) >= saturation_value
-        saturated = np.sum(saturated.reshape(N_POLS, -1, src_layout.heap_samples), axis=-1, dtype=np.uint16)
-        dig_data = packbits(dig_data, src_layout.sample_bits)
+        saturated = np.sum(saturated.reshape(N_POLS, -1, recv_layout.heap_samples), axis=-1, dtype=np.uint16)
+        dig_data = packbits(dig_data, recv_layout.sample_bits)
         dig_stream = self._make_digitiser(mock_recv_stream)
         heap_gen = gen_heaps(
-            src_layout,
+            recv_layout,
             dig_data,
             first_timestamp,
-            present=src_present,
+            present=recv_present,
             saturated=saturated,
         )
 
@@ -372,16 +372,16 @@ class TestEngine:
         out_tp = spead2.ThreadPool()
 
         timestamp_step = spectra_per_heap * output.spectra_samples
-        if dst_present is None:
+        if send_present is None:
             expected_spectra = (n_samples - output.window) // output.spectra_samples
-            dst_present_mask = np.ones(expected_spectra // spectra_per_heap, dtype=bool)
-        elif isinstance(dst_present, int):
-            dst_present_mask = np.ones(dst_present, dtype=bool)
+            send_present_mask = np.ones(expected_spectra // spectra_per_heap, dtype=bool)
+        elif isinstance(send_present, int):
+            send_present_mask = np.ones(send_present, dtype=bool)
         else:
-            dst_present_mask = dst_present
-        assert np.sum(dst_present_mask) > 0
+            send_present_mask = send_present
+        assert np.sum(send_present_mask) > 0
 
-        data = np.zeros((channels, len(dst_present_mask) * spectra_per_heap, N_POLS, COMPLEX), np.int8)
+        data = np.zeros((channels, len(send_present_mask) * spectra_per_heap, N_POLS, COMPLEX), np.int8)
         channels_per_substream = channels // n_out_streams
         for i, queue in enumerate(mock_send_stream):
             stream = spead2.recv.asyncio.Stream(out_tp, out_config)
@@ -395,7 +395,7 @@ class TestEngine:
             assert items == {}, "This heap contains data, not just descriptors"
 
             # Now, for the actual processing
-            for j, present in enumerate(dst_present_mask):
+            for j, present in enumerate(send_present_mask):
                 if present:
                     heap = await stream.get()
                     while (updated_items := set(ig.update(heap))) == set():
@@ -433,7 +433,7 @@ class TestEngine:
             (8192.0, 234.5),
             (-42.0, 58.0),
             (42.4, 24.2),
-            pytest.param((42.7, 24.9), marks=[pytest.mark.cmdline_args("--dst-chunk-jones=65536")]),
+            pytest.param((42.7, 24.9), marks=[pytest.mark.cmdline_args("--send-chunk-jones=65536")]),
             pytest.param((42.8, 24.5), marks=[pytest.mark.use_vkgdr]),
         ],
     )
@@ -496,10 +496,10 @@ class TestEngine:
 
         # Don't send the first chunk, to avoid complications with the step
         # change in the delay at SYNC_TIME.
-        src_layout = engine_server.src_layout
+        recv_layout = engine_server.recv_layout
         heap_samples = output.spectra_samples * output.spectra_per_heap
-        first_timestamp = roundup(src_layout.chunk_samples, heap_samples)
-        n_samples = 20 * src_layout.chunk_samples
+        first_timestamp = roundup(recv_layout.chunk_samples, heap_samples)
+        n_samples = 20 * recv_layout.chunk_samples
         tone_timestamps = np.arange(n_samples) + first_timestamp
         dig_data = self._make_tone(tone_timestamps, tones[0], 0) + self._make_tone(tone_timestamps, tones[1], 1)
         dig_data[:, 1::2] *= -1  # Down-convert to baseband
@@ -521,7 +521,7 @@ class TestEngine:
             dig_data,
             first_timestamp=first_timestamp,
             expected_first_timestamp=expected_first_timestamp,
-            dst_present=expected_spectra // output.spectra_per_heap,
+            send_present=expected_spectra // output.spectra_per_heap,
         )
 
         # Check for the tones
@@ -569,7 +569,7 @@ class TestEngine:
         # Add some extra data to align to an input heap, and to fill out the
         # last output chunk.
         output_chunk_samples = engine_server.chunk_jones * 2 * output.decimation
-        padded_size = roundup(dig_data.shape[1] + output_chunk_samples, engine_server.src_layout.chunk_samples)
+        padded_size = roundup(dig_data.shape[1] + output_chunk_samples, engine_server.recv_layout.chunk_samples)
         n_pad = padded_size - dig_data.shape[1]
         padding = np.zeros((2, n_pad), dig_data.dtype)
         dig_data = np.concatenate([dig_data, padding], axis=1)
@@ -606,13 +606,13 @@ class TestEngine:
                 data[CHANNELS // 2 + 1] = 0
             np.testing.assert_equal(data, pytest.approx(0, abs=tol))
 
-    # Just test 2 values for dig_sample_bits and dst_sample_bits; it gets
+    # Just test 2 values for dig_sample_bits and send_sample_bits; it gets
     # expensive otherwise. Also just do it for one test, as a sanity check.
     @pytest.mark.parametrize(
-        "dig_sample_bits,dst_sample_bits",
+        "dig_sample_bits,send_sample_bits",
         [
-            pytest.param(DIG_SAMPLE_BITS, 4, marks=pytest.mark.cmdline_args("--dst-sample-bits=4")),
-            pytest.param(12, 8, marks=pytest.mark.cmdline_args("--dig-sample-bits=12", "--dst-sample-bits=8")),
+            pytest.param(DIG_SAMPLE_BITS, 4, marks=pytest.mark.cmdline_args("--send-sample-bits=4")),
+            pytest.param(12, 8, marks=pytest.mark.cmdline_args("--dig-sample-bits=12", "--send-sample-bits=8")),
         ],
     )
     async def test_delay_phase_rate(
@@ -625,7 +625,7 @@ class TestEngine:
         extra_delay_samples: float,
         extra_phase: float,
         dig_sample_bits: int,
-        dst_sample_bits: int,
+        send_sample_bits: int,
     ) -> None:
         """Test that delay rate and phase rate setting works."""
         # One tone at centre frequency to test the absolute phase, and one at another
@@ -634,14 +634,14 @@ class TestEngine:
         tones = [
             CW(
                 frac_channel=frac_channel(output, channel),
-                magnitude=round(0.4 * 2**dst_sample_bits),
+                magnitude=round(0.4 * 2**send_sample_bits),
                 delay=extra_delay_samples,
                 phase=extra_phase,
             )
             for channel in tone_channels
         ]
-        src_layout = engine_server.src_layout
-        n_samples = 32 * src_layout.chunk_samples
+        recv_layout = engine_server.recv_layout
+        n_samples = 32 * recv_layout.chunk_samples
 
         # Should be high enough to cause multiple coarse delay changes per chunk
         delay_rate = np.array([1e-5, 1.2e-5])
@@ -651,7 +651,7 @@ class TestEngine:
         coeffs = [f"0.0,{dr}:0.0,{pr}" for dr, pr in zip(delay_rate, phase_rate)]
         await engine_client.request("delays", output.name, SYNC_TIME, *coeffs)
 
-        first_timestamp = roundup(100 * src_layout.chunk_samples, output.spectra_samples * output.spectra_per_heap)
+        first_timestamp = roundup(100 * recv_layout.chunk_samples, output.spectra_samples * output.spectra_per_heap)
         end_delay = round(min(delay_rate) * n_samples)
         expected_spectra = (n_samples + end_delay - output.window) // output.spectra_samples
         tone_timestamps = np.arange(n_samples) + first_timestamp
@@ -667,11 +667,11 @@ class TestEngine:
             # The first output heap would require data from before first_timestamp, so
             # is omitted.
             expected_first_timestamp=first_timestamp + output.spectra_samples * output.spectra_per_heap,
-            dst_present=expected_spectra // output.spectra_per_heap - 1,
+            send_present=expected_spectra // output.spectra_per_heap - 1,
         )
         # Add a polarisation dimension to timestamps to simplify some
         # broadcasting computations below.
-        atol = 2 * 0.5**dst_sample_bits
+        atol = 2 * 0.5**send_sample_bits
         timestamps = timestamps[:, np.newaxis]
         expected_phase = phase_rate_per_sample * timestamps
         assert_angles_allclose(np.angle(out_data[tone_channels[0]]), expected_phase, atol=atol)
@@ -722,8 +722,8 @@ class TestEngine:
         tone = CW(
             frac_channel=frac_channel(output, tone_channel), magnitude=110, delay=extra_delay_samples, phase=extra_phase
         )
-        src_layout = engine_server.src_layout
-        n_samples = 10 * src_layout.chunk_samples
+        recv_layout = engine_server.recv_layout
+        n_samples = 10 * recv_layout.chunk_samples
         dig_data = self._make_tone(np.arange(n_samples), tone, 0)
 
         # Load some delay models for the future (the last one beyond the end of the data)
@@ -785,12 +785,12 @@ class TestEngine:
         coeffs = ["0.0,0.0:0.0,0.0", f"{delay_s},0.0:0.0,0.0"]
         await engine_client.request("delays", output.name, SYNC_TIME, *coeffs)
 
-        src_layout = engine_server.src_layout
+        recv_layout = engine_server.recv_layout
         # Don't send the first chunk, to avoid complications with the step
         # change in the delay at SYNC_TIME.
         heap_samples = output.spectra_samples * output.spectra_per_heap
-        first_timestamp = roundup(src_layout.chunk_samples, heap_samples)
-        n_samples = 20 * src_layout.chunk_samples
+        first_timestamp = roundup(recv_layout.chunk_samples, heap_samples)
+        n_samples = 20 * recv_layout.chunk_samples
         tone_timestamps = np.arange(n_samples) + first_timestamp
 
         rng = np.random.default_rng(123)
@@ -824,7 +824,7 @@ class TestEngine:
             dig_data,
             first_timestamp=first_timestamp,
             expected_first_timestamp=expected_first_timestamp,
-            dst_present=expected_spectra // output.spectra_per_heap,
+            send_present=expected_spectra // output.spectra_per_heap,
         )
 
         # Ensure we haven't saturated
@@ -838,14 +838,14 @@ class TestEngine:
         # There is quite a lot of quantisation noise, so we need a large tolerance
         assert_angles_allclose(orig_phase + phase_ramp, delayed_phase, atol=3e-2)
 
-    # Test with spectra_samples less than, equal to and greater than src-packet-samples
+    # Test with spectra_samples less than, equal to and greater than recv-packet-samples
     @pytest.mark.parametrize("channels", [64, 2048, 8192])
     # Use small jones-per-batch to get finer-grained testing of which spectra
     # were ditched. Fewer would be better, but there are internal alignment
-    # requirements. --src-chunk-samples needs to be increased (from
+    # requirements. --recv-chunk-samples needs to be increased (from
     # CHUNK_SAMPLES) to ensure narrowband windows fit.
     @pytest.mark.spectra_per_heap(32)
-    @pytest.mark.cmdline_args("--src-chunk-samples=4194304")
+    @pytest.mark.cmdline_args("--recv-chunk-samples=4194304")
     async def test_missing_heaps(
         self,
         mock_recv_stream: spead2.InprocQueue,
@@ -864,7 +864,7 @@ class TestEngine:
         sensors = [engine_server.sensors[f"input{pol}.dig-rms-dbfs"] for pol in range(N_POLS)]
         sensor_update_dict = self._watch_sensors(sensors)
         spectra_per_heap = output.spectra_per_heap
-        chunk_samples = engine_server.src_layout.chunk_samples
+        chunk_samples = engine_server.recv_layout.chunk_samples
         n_samples = 16 * chunk_samples
         # Half-open ranges of input heaps that are missing
         missing_ranges = [
@@ -875,15 +875,15 @@ class TestEngine:
         ]
         rng = np.random.default_rng(seed=1)
         dig_data = np.tile(rng.integers(-255, 255, size=(2, n_samples // 2), dtype=np.int16), 2)
-        src_present = np.ones((2, n_samples // PACKET_SAMPLES), bool)
+        recv_present = np.ones((2, n_samples // PACKET_SAMPLES), bool)
         for a, b in missing_ranges:
-            assert b < src_present.shape[1]
-            src_present[:, a:b] = False
+            assert b < recv_present.shape[1]
+            recv_present[:, a:b] = False
         # The data should have as many samples as the input, minus a reduction
         # from windowing, rounded down to a full heap.
         total_spectra = (n_samples - output.window) // output.spectra_samples
         total_heaps = total_spectra // spectra_per_heap
-        dst_present = np.ones(total_heaps, bool)
+        send_present = np.ones(total_heaps, bool)
         # Compute which output heaps should be missing. first_* and last_* are
         # both inclusive (b is exclusive)
         for a, b in missing_ranges:
@@ -894,7 +894,7 @@ class TestEngine:
             last_spectrum = last_sample // output.spectra_samples
             first_heap = first_spectrum // spectra_per_heap
             last_heap = last_spectrum // spectra_per_heap
-            dst_present[first_heap : last_heap + 1] = False
+            send_present[first_heap : last_heap + 1] = False
 
         with PromDiff(namespace=METRIC_NAMESPACE) as prom_diff:
             out_data, timestamps = await self._send_data(
@@ -904,13 +904,13 @@ class TestEngine:
                 output,
                 dig_data,
                 expected_first_timestamp=0,
-                src_present=src_present,
-                dst_present=dst_present,
+                recv_present=recv_present,
+                send_present=send_present,
             )
-        # Position in dst_present corresponding to the second half of dig_data.
+        # Position in send_present corresponding to the second half of dig_data.
         middle = (n_samples // 2) // (output.spectra_samples * spectra_per_heap)
-        for i, p in enumerate(dst_present):
-            if p and i + middle < len(dst_present):
+        for i, p in enumerate(send_present):
+            if p and i + middle < len(send_present):
                 x = out_data[:, i * spectra_per_heap : (i + 1) * spectra_per_heap]
                 y = out_data[:, (i + middle) * spectra_per_heap : (i + middle + 1) * spectra_per_heap]
                 # For narrowband they're only guaranteed to be equal because
@@ -919,24 +919,25 @@ class TestEngine:
 
         for pol in range(N_POLS):
             # Check prometheus counter
-            input_missing_heaps = np.sum(~src_present[pol])
+            input_missing_heaps = np.sum(~recv_present[pol])
             assert prom_diff.get_sample_diff("input_missing_heaps_total", {"pol": str(pol)}) == input_missing_heaps
 
         n_substreams = len(mock_send_stream)
-        output_heaps = np.sum(dst_present) * n_substreams
+        output_heaps = np.sum(send_present) * n_substreams
         assert prom_diff.get_sample_diff("output_heaps_total", {"stream": output.name}) == output_heaps
         batch_samples = channels * spectra_per_heap * N_POLS
         batch_size = batch_samples * COMPLEX * np.dtype(np.int8).itemsize
         assert (
-            prom_diff.get_sample_diff("output_bytes_total", {"stream": output.name}) == np.sum(dst_present) * batch_size
+            prom_diff.get_sample_diff("output_bytes_total", {"stream": output.name})
+            == np.sum(send_present) * batch_size
         )
         assert (
             prom_diff.get_sample_diff("output_samples_total", {"stream": output.name})
-            == np.sum(dst_present) * batch_samples
+            == np.sum(send_present) * batch_samples
         )
         assert (
             prom_diff.get_sample_diff("output_skipped_heaps_total", {"stream": output.name})
-            == np.sum(~dst_present) * n_substreams
+            == np.sum(~send_present) * n_substreams
         )
 
         # Sensor is not present in the narrowband mode.
@@ -957,7 +958,7 @@ class TestEngine:
             for i in range(total_chunks):
                 start_heap = i * heaps_per_output_chunk
                 stop_heap = (i + 1) * heaps_per_output_chunk
-                n_present = np.sum(dst_present[start_heap:stop_heap])
+                n_present = np.sum(send_present[start_heap:stop_heap])
                 # The sensor timestamp shows from the previous processed chunk
                 sensor_timestamp = TIME_CONVERTER.adc_to_unix(
                     timestamps[start_heap * spectra_per_heap] + chunk_timestamp_step
@@ -1006,7 +1007,7 @@ class TestEngine:
         sensor_update_dict = self._watch_sensors(sensors)
         n_samples = 9 * CHUNK_SAMPLES
         dig_data = np.zeros((2, n_samples), np.int16)
-        saturation_value = 2 ** (engine_server.src_layout.sample_bits - 1) - 1
+        saturation_value = 2 ** (engine_server.recv_layout.sample_bits - 1) - 1
         dig_data[0, 10000:15000] = saturation_value
         dig_data[1, 2 * CHUNK_SAMPLES + 50000 : 2 * CHUNK_SAMPLES + 60000] = -saturation_value
         await self._send_data(
@@ -1076,8 +1077,8 @@ class TestEngine:
             # Set gain high enough to make the tone saturate
             await engine_client.request("gain", output.name, pol, default_gain * 2)
 
-        src_layout = engine_server.src_layout
-        n_samples = 20 * src_layout.chunk_samples
+        recv_layout = engine_server.recv_layout
+        n_samples = 20 * recv_layout.chunk_samples
         dig_data = self._make_tone(np.arange(n_samples), tone, tone_pol)
         with PromDiff(namespace=METRIC_NAMESPACE) as prom_diff:
             _, timestamps = await self._send_data(

--- a/test/fgpu/test_katcp_interface.py
+++ b/test/fgpu/test_katcp_interface.py
@@ -58,8 +58,8 @@ class TestKatcpRequests:
         return [
             "--katcp-host=127.0.0.1",
             "--katcp-port=0",
-            "--src-interface=lo",
-            "--dst-interface=lo",
+            "--recv-interface=lo",
+            "--send-interface=lo",
             f"--sync-time={SYNC_TIME}",
             f"--gain={GAIN}",
             "--adc-sample-rate=1.712e9",

--- a/test/fgpu/test_main.py
+++ b/test/fgpu/test_main.py
@@ -96,8 +96,8 @@ class TestParseArgs:
     def test_narrowband_defaults(self) -> None:
         """Test that missing narrowband config is taken from the global config."""
         raw_args = [
-            "--src-interface=lo",
-            "--dst-interface=lo",
+            "--recv-interface=lo",
+            "--send-interface=lo",
             "--adc-sample-rate=1712000000.0",
             "--sync-time=0",
             "--wideband=name=wideband,dst=239.0.3.0+1:7148,channels=1024,taps=64,w_cutoff=0.9,jones_per_batch=262144",

--- a/test/xbgpu/conftest.py
+++ b/test/xbgpu/conftest.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2022-2023, National Research Foundation (SARAO)
+# Copyright (c) 2022-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/xbgpu/conftest.py
+++ b/test/xbgpu/conftest.py
@@ -21,22 +21,22 @@ import spead2
 
 
 @pytest.fixture
-def n_src_streams() -> int:  # noqa: D401
+def n_recv_streams() -> int:  # noqa: D401
     """Number of source streams for an xbgpu instance."""
     return 1
 
 
 @pytest.fixture
-def mock_recv_streams(mocker, n_src_streams: int) -> list[spead2.InprocQueue]:
+def mock_recv_streams(mocker, n_recv_streams: int) -> list[spead2.InprocQueue]:
     """Mock out :func:`katgpucbf.recv.add_reader` to use in-process queues.
 
     Returns
     -------
     queues
         A list of in-process queue to use for sending data. The number of queues
-        in the list is determined by ``n_src_streams``.
+        in the list is determined by ``n_recv_streams``.
     """
-    queues = [spead2.InprocQueue() for _ in range(n_src_streams)]
+    queues = [spead2.InprocQueue() for _ in range(n_recv_streams)]
     queue_iter = iter(queues)  # Each call to add_reader gets the next queue
 
     def add_reader(

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -830,8 +830,8 @@ class TestEngine:
             f"--jones-per-batch={n_jones_per_batch}",
             f"--heaps-per-fengine-per-chunk={HEAPS_PER_FENGINE_PER_CHUNK}",
             "--sync-time=1234567890",
-            "--src-interface=lo",
-            "--dst-interface=lo",
+            "--recv-interface=lo",
+            "--send-interface=lo",
             "--send-enabled",
             "239.10.11.4:7149",  # src
         ]


### PR DESCRIPTION
As per @bmerry's suggestion on #795.

I've purposefully left the following unchanged, to be discussed during this PR review
* the positional `src` arguments (for fgpu and xbgpu), as well as 
* the `--output` `dst` arguments.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [x] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match - see https://github.com/ska-sa/katsdpcontroller/pull/745

Closes NGC-1158.
