### PR TITLE
Reorder setting of rx sensors

### DIFF
--- a/src/katgpucbf/fgpu/recv.py
+++ b/src/katgpucbf/fgpu/recv.py
@@ -330,9 +330,7 @@ async def iter_chunks(
                 lost,
             )
             unix_time = time_converter.adc_to_unix(chunk.timestamp)
-            for pol in range(N_POLS):
-                sensors[f"input{pol}.rx.timestamp"].set_value(chunk.timestamp, timestamp=unix_time)
-                sensors[f"input{pol}.rx.unixtime"].set_value(aiokatcp.core.Timestamp(unix_time), timestamp=unix_time)
+            unix_time_katcp = aiokatcp.core.Timestamp(unix_time)
 
             pol_expected_heaps = (chunk.timestamp - first_timestamp + layout.chunk_samples) // layout.heap_samples
             chunks_counter.inc()
@@ -357,8 +355,15 @@ async def iter_chunks(
                     missing_heaps_counter.labels(pol).inc(new_missing - n_missing_heaps[pol])
                     n_missing_heaps[pol] = new_missing
                     sensors[f"input{pol}.rx.missing-unixtime"].set_value(
-                        aiokatcp.core.Timestamp(unix_time), timestamp=unix_time, status=aiokatcp.Sensor.Status.ERROR
+                        unix_time_katcp, timestamp=unix_time, status=aiokatcp.Sensor.Status.ERROR
                     )
+            for pol in range(N_POLS):
+                # Note: these must be set AFTER rx.missing-unixtime so that if
+                # the first chunk received is missing data, we don't have an
+                # intermediate state in which all the sensors are NOMINAL
+                # (which would cause rx.device-status to be NOMINAL).
+                sensors[f"input{pol}.rx.timestamp"].set_value(chunk.timestamp, timestamp=unix_time)
+                sensors[f"input{pol}.rx.unixtime"].set_value(unix_time_katcp, timestamp=unix_time)
             yield chunk
     finally:
         stats_collector.update()  # Ensure final stats updates are captured


### PR DESCRIPTION
We don't want rx.device-status to become OK/NOMINAL until we've received a complete chunk (particularly for NGC-1033).

If the first heap received has missing data, the previous code would have transitioned momentarily though an OK/NOMINAL state because it would first have set rx.timestamp/rx.unixtime (making them NOMINAL) before setting rx.missing-unixtime (making it ERROR).

Fix by setting rx.missing-unixtime first so that there is always at least one non-NOMINAL sensor in this scenario.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
