### PR TITLE
Refine bsend usage of substream term

### DIFF
--- a/src/katgpucbf/xbgpu/bsend.py
+++ b/src/katgpucbf/xbgpu/bsend.py
@@ -122,13 +122,13 @@ class Batch:
     ) -> None:
         self.heaps: list[spead2.send.Heap] = []
         self.data = data
-        n_substreams = data.shape[0]
+        n_beams = data.shape[0]
 
         item_group = make_item_group(data.shape[1:])  # Get rid of the 'beam' dimension
         item_group[FREQUENCY_ID].value = channel_offset
         item_group[TIMESTAMP_ID].value = timestamp
         item_group[BEAM_ANTS_ID].value = present_ants
-        for i in range(n_substreams):
+        for i in range(n_beams):
             item_group[BF_RAW_ID].value = self.data[i, ...]
             heap = item_group.get_heap(descriptors="none", data="all")
             heap.repeat_pointers = True
@@ -353,7 +353,7 @@ class BSend(Send):
     queue for reuse.
 
     This object keeps track of each tied-array-channelised-voltage data stream by
-    means of a substreams in :class:`spead2.send.asyncio.AsyncStream`, allowing
+    means of substreams in :class:`spead2.send.asyncio.AsyncStream`, allowing
     for individual enabling and disabling of the data product.
 
     To allow this class to be used with multiple transports, the constructor
@@ -449,22 +449,22 @@ class BSend(Send):
             descriptor_heap=item_group.get_heap(descriptors="all", data="none"),
         )
 
-    def enable_substream(self, stream_id: int, enable: bool = True) -> None:
-        """Enable/Disable a substream's data transmission.
+    def enable_beam(self, beam_id: int, enable: bool = True) -> None:
+        """Enable/Disable a beam's data transmission.
 
-        :class:`.BSend` operates as a large single stream with multiple
-        substreams. Each substream is its own data product and is required
-        to be enabled/disabled independently.
+        :class:`.BSend` operates as a single, large stream with multiple
+        substreams. Each substream (beam) is its own data product and is
+        required to be enabled/disabled independently.
 
         Parameters
         ----------
-        stream_id
-            Index of the substream's data product.
+        beam_id
+            Index of the beam's data product.
         enable
-            Boolean indicating whether the `stream_id` should be enabled or
+            Boolean indicating whether the `beam_id` should be enabled or
             disabled.
         """
-        self.send_enabled[stream_id] = enable
+        self.send_enabled[beam_id] = enable
         self.send_enabled_version += 1
 
     async def get_free_chunk(self) -> Chunk:

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -577,7 +577,7 @@ class BPipeline(Pipeline[BOutput, BOutQueueItem]):
         logger.debug("sender_loop completed")
 
     def capture_enable(self, *, stream_id: int, enable: bool = True) -> None:  # noqa: D102
-        self.send_stream.enable_substream(stream_id=stream_id, enable=enable)
+        self.send_stream.enable_beam(beam_id=stream_id, enable=enable)
 
     def _weights_updated(self) -> None:
         """Update version tracking when weight-related parameters are updated."""
@@ -994,7 +994,8 @@ class XBEngine(DeviceServer):
     n_channels
         The total number of frequency channels out of the F-Engine.
     n_channels_per_substream
-        The number of frequency channels contained per substream.
+        The number of frequency channels contained in the incoming F-engine
+        data stream.
     n_samples_between_spectra
         The number of samples between frequency spectra received.
     n_spectra_per_heap


### PR DESCRIPTION
Specifically to differentiate between
* channels-per-substream (being received), and 
* substream referring to individual beam products in the BSend spead2 send stream.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1153.
