### PR TITLE
Qualification: share CBFs between packages

### DIFF
--- a/qualification/antenna_channelised_voltage/conftest.py
+++ b/qualification/antenna_channelised_voltage/conftest.py
@@ -19,7 +19,7 @@
 import pytest
 
 
-@pytest.fixture(scope="package")
+@pytest.fixture
 def n_dsims(n_antennas: int):
     """Give every simulated antenna its own dsim."""
     return n_antennas


### PR DESCRIPTION
Give up on pytest's fixture scoping support, and manage caching of CBFs explicitly. Previous attempts to use session-scoped fixtures have gone wrong because pytest doesn't cope well with per-test parametrisation of session-scoped fixtures (it matches them by position in the list of parameters, rather than the parameter value).

This should significantly speed up tests by allowing each CBF to be reused between the tied_array_channelised_voltage and baseline_correlation_products packages.

The sorting function is a little hacky and there is a small chance it will cause more reconfigurations than necessary. However, correctness is ensured, because a CBF is only reused if the exact config dictionary matches.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report: [report2.pdf](https://github.com/user-attachments/files/15902148/report2.pdf)
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Relates to NGC-1343.
