### PR TITLE
Add Prometheus get_sample* helper class

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -95,6 +95,58 @@ class PromDiff:
             return after
 
 
+class PromGetHelp:
+    """Helper class for obtaining Prometheus metric values.
+
+    This is used when the developer is condifent on the return type and aides
+    code readability. It only needs the :class:`PromDiff` upon initialisation
+    and the user can continually obtain metric values against it.
+
+    Typical usage is::
+
+        labels = {"stream": stream_name}
+        promget = PromGetHelp(prom_diff, labels)
+        assert promget.value(name) == expected_value
+        new_labels = {"pol": "0"}
+        assert promget.diff(name, label_override=new_labels) == expected_diff
+
+    Parameters
+    ----------
+    prom_diff
+        Instance of :class:`PromDiff` that is used during a unit test.
+    labels
+        Optional identifiers for Prometheus metrics under test.
+    """
+
+    def __init__(self, prom_diff: PromDiff, labels: dict[str, str] | None = None) -> None:
+        self.prom_diff = prom_diff
+        self.labels = labels
+
+    def value(self, name: str, label_override: dict[str, str] | None = None) -> float:
+        """See :meth:`PromDiff.get_sample_value`.
+
+        This allows the user to override any default metric labels.
+        """
+        if label_override is not None:
+            value = self.prom_diff.get_sample_value(name, labels=label_override)
+        else:
+            value = self.prom_diff.get_sample_value(name, labels=self.labels)
+        assert value is not None, f"{name} is None"
+        return value
+
+    def diff(self, name: str, label_override: dict[str, str] | None = None) -> float:
+        """See :meth:`PromDiff.get_sample_diff`.
+
+        This allows the user to override any default metric labels.
+        """
+        if label_override is not None:
+            diff = self.prom_diff.get_sample_diff(name, labels=label_override)
+        else:
+            diff = self.prom_diff.get_sample_diff(name, labels=self.labels)
+        assert diff is not None, f"{name} is None"
+        return diff
+
+
 def unpackbits(data: NDArray[np.uint8], sample_bits: int = DIG_SAMPLE_BITS) -> np.ndarray:
     """Unpack a bit-packed array of signed big-endian integers.
 

--- a/test/dsim/test_send.py
+++ b/test/dsim/test_send.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2021-2022, National Research Foundation (SARAO)
+# Copyright (c) 2021-2022, 2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/dsim/test_send.py
+++ b/test/dsim/test_send.py
@@ -31,7 +31,7 @@ from katgpucbf.dsim import send
 from katgpucbf.send import DescriptorSender
 from katgpucbf.utils import TimeConverter
 
-from .. import PromDiff, unpackbits
+from .. import PromDiff, PromGetHelp, unpackbits
 from .conftest import ADC_SAMPLE_RATE, N_ENDPOINTS_PER_POL, N_POLS, SIGNAL_HEAPS
 
 
@@ -148,5 +148,6 @@ async def test_sender(
     assert (await switch_task) == switch_heap * DIG_HEAP_SAMPLES
 
     # Check the Prometheus counters
-    assert prom_diff.get_sample_diff("output_heaps_total") == SIGNAL_HEAPS * repeats * N_POLS
-    assert prom_diff.get_sample_diff("output_bytes_total") == orig_payload[0].nbytes * repeats
+    prom_get = PromGetHelp(prom_diff)
+    assert prom_get.diff("output_heaps_total") == SIGNAL_HEAPS * repeats * N_POLS
+    assert prom_get.diff("output_bytes_total") == orig_payload[0].nbytes * repeats

--- a/test/fgpu/test_recv.py
+++ b/test/fgpu/test_recv.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2023, National Research Foundation (SARAO)
+# Copyright (c) 2020-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/xbgpu/test_recv.py
+++ b/test/xbgpu/test_recv.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2023, National Research Foundation (SARAO)
+# Copyright (c) 2020-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/xbgpu/test_recv.py
+++ b/test/xbgpu/test_recv.py
@@ -33,7 +33,7 @@ from katgpucbf.utils import TimeConverter
 from katgpucbf.xbgpu import METRIC_NAMESPACE, recv
 from katgpucbf.xbgpu.recv import Chunk, Layout, make_sensors, recv_chunks
 
-from .. import PromDiff
+from .. import PromDiff, PromGetHelp
 
 
 @pytest.fixture
@@ -234,13 +234,14 @@ class TestStream:
         assert seen == 5
         expected_bad_timestamps = seen * layout.chunk_heaps if timestamps == "bad" else 0
 
-        assert prom_diff.get_sample_diff("input_chunks_total") == seen + empty_chunks
-        assert prom_diff.get_sample_diff("input_heaps_total") == (seen + empty_chunks) * layout.chunk_heaps
-        assert prom_diff.get_sample_diff("input_bytes_total") == layout.chunk_bytes * seen
-        assert prom_diff.get_sample_diff("input_bad_timestamp_heaps_total") == expected_bad_timestamps
-        assert prom_diff.get_sample_diff("input_bad_feng_id_heaps_total") == 1
-        assert prom_diff.get_sample_diff("input_metadata_heaps_total") == 1
-        assert prom_diff.get_sample_diff("input_too_old_heaps_total") == 1
+        prom_get = PromGetHelp(prom_diff)
+        assert prom_get.diff("input_chunks_total") == seen + empty_chunks
+        assert prom_get.diff("input_heaps_total") == (seen + empty_chunks) * layout.chunk_heaps
+        assert prom_get.diff("input_bytes_total") == layout.chunk_bytes * seen
+        assert prom_get.diff("input_bad_timestamp_heaps_total") == expected_bad_timestamps
+        assert prom_get.diff("input_bad_feng_id_heaps_total") == 1
+        assert prom_get.diff("input_metadata_heaps_total") == 1
+        assert prom_get.diff("input_too_old_heaps_total") == 1
 
     async def test_missing_heaps(
         self,
@@ -339,9 +340,10 @@ class TestStream:
         np.testing.assert_array_equal(received_chunk_presence.flatten(), expected_chunk_presence_flat)
 
         # Check StatsCollector's values
-        assert prom_diff.get_sample_diff("input_heaps_total") == seen * layout.chunk_heaps - n_single_heaps_to_delete
+        prom_get = PromGetHelp(prom_diff)
+        assert prom_get.diff("input_heaps_total") == seen * layout.chunk_heaps - n_single_heaps_to_delete
         assert (
-            prom_diff.get_sample_diff("input_missing_heaps_total")
+            prom_get.diff("input_missing_heaps_total")
             == n_chunks_to_delete * layout.chunk_heaps + n_single_heaps_to_delete
         )
 


### PR DESCRIPTION
And update uses of `PromDiff.get_sample_diff` accordingly.

I mainly went with this MO because I focused on [your original critique/observation](https://github.com/ska-sa/katgpucbf/pull/805#issuecomment-2178718952) of
> [...] the helper function is still valuable for readability

I know it's not common to request a review before Jenkins is done, but I have run the affected/
updated tests manually (on cbfgpu033) and they all passed fine.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1316.