### PR TITLE
Implement larger window for dig-rms-dbfs sensor

### DIFF
--- a/doc/katgpucbf.fgpu.accum.rst
+++ b/doc/katgpucbf.fgpu.accum.rst
@@ -1,0 +1,7 @@
+katgpucbf.fgpu.accum module
+===================================
+
+.. automodule:: katgpucbf.fgpu.accum
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/katgpucbf.fgpu.rst
+++ b/doc/katgpucbf.fgpu.rst
@@ -7,6 +7,7 @@ Submodules
 .. toctree::
    :maxdepth: 4
 
+   katgpucbf.fgpu.accum
    katgpucbf.fgpu.compute
    katgpucbf.fgpu.ddc
    katgpucbf.fgpu.delay

--- a/src/katgpucbf/fgpu/__init__.py
+++ b/src/katgpucbf/fgpu/__init__.py
@@ -1,7 +1,7 @@
 # noqa: D104
 
 ################################################################################
-# Copyright (c) 2020-2021, 2023 National Research Foundation (SARAO)
+# Copyright (c) 2020-2021, 2023-2024 National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -24,6 +24,7 @@ METRIC_NAMESPACE: Final = "fgpu"
 # TODO these thresholds are inherited from MeerKAT. Are they what we want?
 DIG_RMS_DBFS_LOW: Final = -32.0
 DIG_RMS_DBFS_HIGH: Final = -22.0
+DIG_RMS_DBFS_WINDOW: Final = 1.0  # Window length in seconds
 
 #: Valid values for the ``--dig-sample-bits`` command-line option
 DIG_SAMPLE_BITS_VALID = [2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 16]

--- a/src/katgpucbf/fgpu/accum.py
+++ b/src/katgpucbf/fgpu/accum.py
@@ -1,0 +1,155 @@
+################################################################################
+# Copyright (c) 2024, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Compute statistics by bucketing into windows."""
+
+from dataclasses import dataclass
+from typing import Final, Generic, Protocol, Self, TypeVar
+
+_T_co = TypeVar("_T_co", covariant=True)
+
+
+# Based on typing.SupportsAbs etc.
+class _SupportsAdd(Protocol[_T_co]):
+    def __add__(self, other: Self) -> _T_co:
+        pass  # pragma: nocover
+
+
+_T = TypeVar("_T", bound=_SupportsAdd)
+
+
+@dataclass(frozen=True)
+class Measurement(Generic[_T]):
+    """A measurement returned by :meth:`Accum.add`."""
+
+    start_timestamp: int
+    end_timestamp: int
+    #: Total of the value over the provided data.
+    total: _T | None
+
+
+def _add(a: _T | None, b: _T | None) -> _T | None:
+    """Add two values, returning None if either of them is None."""
+    if a is not None and b is not None:
+        return a + b
+    else:
+        return None
+
+
+class Accum(Generic[_T]):
+    """Accumulator for a single statistic.
+
+    The statistic is a linear measurement over intervals of time.
+    Measurements over small intervals are provided to this class, which
+    accumulates them. Time is divided into fixed "windows" (all the same
+    length), with a total produced for each window for which at least some data
+    is provided. If a window is missing some data, either because it was not
+    provided or it was explicitly indicated that it was missing, then the
+    window measurement will instead indicate that the sum is unknown.
+
+    Time is considered to be discrete (integer). Window intervals are
+    timestamps that are multiples of `window_size`. Data cannot be added for
+    intervals that cross window boundaries.
+
+    Parameters
+    ----------
+    window_size
+        Factor that divides timestamp window boundaries
+    zero
+        Value to initialise the accumulator to
+    """
+
+    def __init__(self, window_size: int, zero: _T) -> None:
+        self._window_size: Final = window_size
+        self._zero: Final = zero
+        self._total: _T | None = zero  # Sum for current window, if valid
+        # Point up to which we have received calls to :meth:`add`
+        self._end_timestamp = 0
+        self._window_id = 0  # Start timestamp divided by the window size
+
+    def _flush(self, new_window_id: int) -> Measurement | None:
+        """Generate a :class:`Measurement` (if non-empty) and reset state."""
+        # [base_timestamp, next_timestamp) is the full range of the current window
+        base_timestamp = self._window_id * self._window_size
+        next_timestamp = base_timestamp + self._window_size
+        ret: Measurement | None = None
+        # Don't send if the old window was completely empty
+        if self._end_timestamp > base_timestamp:
+            # If we didn't get the end of the window, then we don't know the total
+            total = self._total if self._end_timestamp == next_timestamp else None
+            ret = Measurement(
+                base_timestamp,
+                next_timestamp,
+                total,
+            )
+        # Reset the state
+        self._window_id = new_window_id
+        self._end_timestamp = new_window_id * self._window_size
+        self._total = self._zero
+        return ret
+
+    def add(self, start_timestamp: int, end_timestamp: int, value: _T | None) -> Measurement | None:
+        """Add new data.
+
+        If the new data falls into a new window compared to the existing data
+        or it completes the current window, then an instance of
+        :class:`Measurement` is returned with the total for the previous
+        window. Note that if both occur, the result for the old window is
+        simply discarded.
+
+        Parameters
+        ----------
+        start_timestamp, end_timestamp
+            The time range for the extension
+        value
+            The statistic measured over the given time range, or
+            None if there was missing data in the range.
+
+        Raises
+        ------
+        ValueError
+            if `start_timestamp` > `end_timestamp`
+        ValueError
+            if the new data overlaps or preceeds previous data
+        ValueError
+            if [start_timestamp, end_timestamp) crosses a window boundary
+        """
+        if start_timestamp > end_timestamp:
+            raise ValueError("start_timestamp ({start_timestamp}) > end_timestamp ({end_timestamp})")
+        new_window_id = start_timestamp // self._window_size
+        new_window_end = (new_window_id + 1) * self._window_size
+        if end_timestamp > new_window_end:
+            raise ValueError("new data crosses a window boundary")
+        if start_timestamp < self._end_timestamp:
+            raise ValueError("new data starts before end of previous data")
+
+        ret: Measurement | None = None
+        if new_window_id != self._window_id:
+            # New data falls into a new window - flush out the old one.
+            ret = self._flush(new_window_id)
+
+        if start_timestamp != self._end_timestamp:
+            # We skipped some data
+            value = None
+
+        self._total = _add(self._total, value)
+        self._end_timestamp = end_timestamp
+
+        if end_timestamp == new_window_end:
+            # New data completes a window - flush it now.
+            ret = self._flush(self._window_id + 1)
+
+        return ret

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -59,7 +59,8 @@ from ..utils import (
     gaussian_dtype,
     steady_state_timestamp_sensor,
 )
-from . import DIG_RMS_DBFS_HIGH, DIG_RMS_DBFS_LOW, INPUT_CHUNK_PADDING, recv, send
+from . import DIG_RMS_DBFS_HIGH, DIG_RMS_DBFS_LOW, DIG_RMS_DBFS_WINDOW, INPUT_CHUNK_PADDING, recv, send
+from .accum import Accum
 from .compute import Compute, ComputeTemplate, NarrowbandConfig
 from .delay import AbstractDelayModel, AlignedDelayModel, LinearDelayModel, MultiDelayModel, wrap_angle
 from .output import NarrowbandOutput, Output, WidebandOutput
@@ -901,27 +902,42 @@ class Pipeline:
                 chunk.cleanup()
                 chunk.cleanup = None  # Potentially helps break reference cycles
 
-    def _update_dig_power_sensors(self, dig_total_power: accel.HostArray | None, out_item: OutQueueItem) -> None:
+    def _update_dig_power_sensors(
+        self,
+        dig_total_power_accums: list[Accum],
+        dig_total_power: accel.HostArray,
+        out_item: OutQueueItem,
+    ) -> None:
         """Update digitiser power sensors.
 
-        Helper function for keeping the complexity of :meth:`run_transmit` down to manageable levels.
+        Parameters
+        ----------
+        dig_total_power_accums
+            Accumulators tracking long-term digitiser total power (one per polarisation)
+        dig_total_power
+            The total power per polarisation in `out_item`
+        out_item
+            The current :class:`OutQueueItem`
         """
-        if dig_total_power is not None:
-            update_timestamp = self.engine.time_converter.adc_to_unix(out_item.next_timestamp)
-            if np.all(out_item.present):
-                for pol, trg in enumerate(dig_total_power):
-                    total_power = float(trg)
-                    avg_power = total_power / (out_item.n_spectra * self.output.spectra_samples)
+        all_present = np.all(out_item.present)
+        for pol, (accum, trg) in enumerate(zip(dig_total_power_accums, dig_total_power)):
+            power: int | None = int(trg)
+            if not all_present:
+                power = None
+            if measurement := accum.add(out_item.timestamp, out_item.next_timestamp, power):
+                sensor = self.engine.sensors[f"input{pol}.dig-rms-dbfs"]
+                update_timestamp = self.engine.time_converter.adc_to_unix(measurement.end_timestamp)
+                if measurement.total is not None:
                     # Normalise relative to full scale. The factor of 2 is because we
                     # want 1.0 to correspond to a sine wave rather than a square wave.
-                    avg_power /= ((1 << (self.engine.recv_layout.sample_bits - 1)) - 1) ** 2 / 2
+                    fs = ((1 << (self.engine.recv_layout.sample_bits - 1)) - 1) ** 2 / 2
+                    avg_power = measurement.total / (measurement.end_timestamp - measurement.start_timestamp) / fs
                     # If for some reason there's zero power, avoid reporting
                     # -inf dB by assigning the most negative representable value
                     avg_power_db = 10 * math.log10(avg_power) if avg_power else np.finfo(np.float64).min
-                    self.engine.sensors[f"input{pol}.dig-rms-dbfs"].set_value(avg_power_db, timestamp=update_timestamp)
-            else:
-                for pol in range(N_POLS):
-                    self.engine.sensors[f"input{pol}.dig-rms-dbfs"].set_value(
+                    sensor.set_value(avg_power_db, timestamp=update_timestamp)
+                else:
+                    sensor.set_value(
                         np.finfo(np.float64).min, status=aiokatcp.Sensor.Status.FAILURE, timestamp=update_timestamp
                     )
 
@@ -946,9 +962,14 @@ class Pipeline:
         func_name = f"{self.output.name}.run_transmit"
         # Scratch space for transferring digitiser power
         if self.dig_stats:
+            chunk_samples = self.spectra * self.output.spectra_samples
+            window_chunks = max(1, round(DIG_RMS_DBFS_WINDOW * self.engine.adc_sample_rate / chunk_samples))
+            window_samples = window_chunks * chunk_samples
             dig_total_power = self._compute.slots["dig_total_power"].allocate_host(context)
+            dig_total_power_windows = [Accum(window_samples, 0) for _ in range(N_POLS)]
         else:
             dig_total_power = None
+            dig_total_power_windows = []
         while True:
             with self.engine.monitor.with_state(func_name, "wait out_queue"):
                 out_item = await self._out_queue.get()
@@ -977,7 +998,8 @@ class Pipeline:
             with self.engine.monitor.with_state(func_name, "wait transfer"):
                 await async_wait_for_events([download_marker])
 
-            self._update_dig_power_sensors(dig_total_power, out_item)
+            if dig_total_power is not None:
+                self._update_dig_power_sensors(dig_total_power_windows, dig_total_power, out_item)
 
             n_batches = out_item.n_spectra // self.output.spectra_per_heap
             if last_end_timestamp is not None and out_item.timestamp > last_end_timestamp:
@@ -1321,8 +1343,6 @@ class Engine(aiokatcp.DeviceServer):
                     "Digitiser ADC average power",
                     units="dBFS",
                     status_func=dig_rms_dbfs_status,
-                    auto_strategy=aiokatcp.SensorSampler.Strategy.EVENT_RATE,
-                    auto_strategy_parameters=(MIN_SENSOR_UPDATE_PERIOD, math.inf),
                 )
             )
 

--- a/test/fgpu/conftest.py
+++ b/test/fgpu/conftest.py
@@ -32,12 +32,6 @@ from katgpucbf.fgpu.main import make_engine, parse_args
 
 
 @pytest.fixture
-def dig_rms_dbfs_window_chunks() -> int:  # noqa: D401
-    """Number of chunks per window for ``dig-rms-dbfs`` sensors."""
-    return 2
-
-
-@pytest.fixture
 def recv_max_chunks_one(monkeypatch) -> None:
     """Change :data:`.recv.MAX_CHUNKS` to 1 for the test.
 
@@ -80,9 +74,7 @@ def mock_recv_stream(mocker) -> spead2.InprocQueue:
 @pytest.fixture
 async def engine_server(
     request: pytest.FixtureRequest,
-    monkeypatch: pytest.MonkeyPatch,
     engine_arglist: list[str],
-    dig_rms_dbfs_window_chunks: int,
     mock_recv_stream,
     mock_send_stream,
     recv_max_chunks_one,
@@ -109,18 +101,6 @@ async def engine_server(
 
     args = parse_args(arglist)
     server, _monitor = make_engine(context, vkgdr_handle, args)
-
-    # Adjust DIG_RMS_DBFS_WINDOW. This is handled here rather than as a
-    # separate fixture to solve a chicken-and-egg issue: the actual
-    # engine.chunk_jones is computed from a formula in make_engine, so that
-    # needs to happen first. But once server.start() has been called, it is too
-    # late to match the change.
-    # Compute the number of digitiser samples per *output* chunk. Each output
-    # complex value takes two incoming real values.
-    chunk_samples = server.chunk_jones * 2
-    monkeypatch.setattr(
-        "katgpucbf.fgpu.engine.DIG_RMS_DBFS_WINDOW", chunk_samples * dig_rms_dbfs_window_chunks / server.adc_sample_rate
-    )
 
     await server.start()
     yield server

--- a/test/fgpu/test_accum.py
+++ b/test/fgpu/test_accum.py
@@ -1,0 +1,93 @@
+################################################################################
+# Copyright (c) 2024, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Unit test :mod:`katgpucbf.fgpu.accum."""
+
+import pytest
+
+from katgpucbf.fgpu.accum import Accum, Measurement
+
+
+@pytest.fixture
+def empty_accum() -> Accum:
+    """Accum in initial state."""
+    return Accum(100, 0)
+
+
+@pytest.fixture
+def valid_accum() -> Accum:
+    """Accum with valid data."""
+    accum = Accum(100, 0)
+    accum.add(200, 220, 200)
+    return accum
+
+
+@pytest.fixture
+def invalid_accum() -> Accum:
+    """Accum with missing data."""
+    accum = Accum(100, 0)
+    accum.add(200, 220, None)
+    return accum
+
+
+@pytest.mark.parametrize(
+    "start_timestamp, stop_timestamp",
+    [
+        (0, 100),  # Before existing data
+        (210, 230),  # Overlaps existing data
+        (250, 249),  # Negative length
+        (220, 301),  # Overlaps window boundary
+    ],
+)
+def test_bad_add(valid_accum: Accum, start_timestamp: int, stop_timestamp: int) -> None:
+    """Bad calls to :meth:`.Accum.add` raise :exc:`ValueError`."""
+    with pytest.raises(ValueError):
+        valid_accum.add(start_timestamp, stop_timestamp, 1)
+
+
+def test_add_contiguous(valid_accum: Accum) -> None:
+    """Extending contiguously does not invalidate."""
+    assert valid_accum.add(220, 250, 10) is None
+    assert valid_accum.add(250, 300, 90) == Measurement(200, 300, 300)
+    assert valid_accum.add(500, 600, 200) == Measurement(500, 600, 200)
+
+
+def test_add_to_invalid(invalid_accum: Accum) -> None:
+    """Extending an invalid window does not validate it."""
+    assert invalid_accum.add(220, 300, 10) == Measurement(200, 300, None)
+
+
+def test_add_gap(valid_accum: Accum) -> None:
+    """Extending a window with a gap invalidates it."""
+    assert valid_accum.add(230, 250, 10) is None
+    assert valid_accum.add(250, 300, 20) == Measurement(200, 300, None)
+
+
+def test_add_skip(valid_accum: Accum) -> None:
+    """Adding to a new window returns the existing one, invalidated."""
+    assert valid_accum.add(500, 550, 10) == Measurement(200, 300, None)
+    assert valid_accum.add(550, 600, 40) == Measurement(500, 600, 50)
+
+
+def test_add_full_skip(valid_accum: Accum) -> None:
+    """Adding a complete new window ignores the previous one."""
+    assert valid_accum.add(500, 600, 700) == Measurement(500, 600, 700)
+
+
+def test_add_none(valid_accum: Accum) -> None:
+    """Adding with power=None invalidates."""
+    assert valid_accum.add(220, 250, None) is None
+    assert valid_accum.add(250, 300, 10) == Measurement(200, 300, None)


### PR DESCRIPTION
The sensor now reports on roughly the last one second of data, instead of just the last OutQueueItem. The exact interval is a whole number of output chunks.

The chunks are divided into windows according to their timestamps, with the same number of chunks in each window. The sensor is updated at the end of each window with the average power for the window.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1369.
