### PR TITLE
Make use of TaskGroup

### DIFF
--- a/qualification/antenna_channelised_voltage/__init__.py
+++ b/qualification/antenna_channelised_voltage/__init__.py
@@ -132,11 +132,10 @@ async def sample_tone_response(
 
     async def flush() -> None:
         """Execute all the work in `tasks`."""
-        requests = []
-        for i in range(len(tasks)):
-            signal = tasks[i][1] * N_POLS
-            requests.append(asyncio.create_task(receiver.cbf.dsim_clients[i].request("signals", signal)))
-        await asyncio.gather(*requests)
+        async with asyncio.TaskGroup() as tg:
+            for i in range(len(tasks)):
+                signal = tasks[i][1] * N_POLS
+                tg.create_task(receiver.cbf.dsim_clients[i].request("signals", signal))
         _, data = await receiver.next_complete_chunk()
         for task, bl_idx in zip(tasks, corrs):
             # In the absence of noise this should be purely real, but

--- a/test/dsim/test_send.py
+++ b/test/dsim/test_send.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2021-2022, National Research Foundation (SARAO)
+# Copyright (c) 2021-2022, 2024 National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -103,9 +103,10 @@ async def test_sender(
         return ret
 
     # Start descriptor sender and wait for descriptors before awaiting for DSim data
-    descriptor_sender_task = asyncio.create_task(descriptor_sender.run())
-    descriptor_recv_streams_task = asyncio.create_task(descriptor_recv(descriptor_recv_streams, descriptor_sender))
-    _, ig = await asyncio.gather(descriptor_sender_task, descriptor_recv_streams_task)
+    async with asyncio.TaskGroup() as tg:
+        tg.create_task(descriptor_sender.run())
+        descriptor_recv_streams_task = tg.create_task(descriptor_recv(descriptor_recv_streams, descriptor_sender))
+    ig = descriptor_recv_streams_task.result()
 
     # Note: only do this after dealing with the descriptors, as otherwise
     # they interfere with the countdown.

--- a/test/fgpu/test_send.py
+++ b/test/fgpu/test_send.py
@@ -228,10 +228,9 @@ async def test_send(
         # Send all the chunks, without waiting for the first one to complete
         # transmission (to ensure that the send streams have sufficient
         # capacity).
-        futures = [
-            asyncio.create_task(chunk.send(send_streams, N_BATCHES, time_converter, sensors, NAME)) for chunk in chunks
-        ]
-        await asyncio.gather(*futures)
+        async with asyncio.TaskGroup() as tg:
+            for chunk in chunks:
+                tg.create_task(chunk.send(send_streams, N_BATCHES, time_converter, sensors, NAME))
 
     for queue_list in queues.values():
         for queue in queue_list:


### PR DESCRIPTION
Where asyncio.gather was used to start, run and await multiple tasks, use the new TaskGroup instead, which has better cancellation behaviour (cancels the other tasks as soon as one task fails, and potentially report multiple exceptions via an ExceptionGroup).

This is not used everywhere it could be yet. In particular, tasks started by engines are managed by aiokatcp's add_service_task, which does similar things to TaskGroup (although it does not raise exception groups). There are a number of other places where the creation of and waiting for a task are widely separated such that it would be inconvenient to use a context manager.

See NGC-1380.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
