### PR TITLE
Improve PromDiff for unit tests

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -31,29 +31,30 @@ class PromDiff:
 
     Typical usage is::
 
-        with PromDiff(namespace=METRIC_NAMESPACE) as diff:
+        with PromDiff(namespace=METRIC_NAMESPACE) as prom_diff:
             ...  # Do stuff that increments counters
-        diff.get_sample_diff(name, labels)
+        prom_diff.diff(name, labels)
 
     In some cases one may wish to make many queries with the same labels.
     In this case, default labels can be passed to the constructor::
 
-        with PromDiff(namespace=METRIC_NAMESPACE) as diff:
+        with PromDiff(namespace=METRIC_NAMESPACE, labels={"stream": stream_name}) as prom_diff:
             ...  # Do stuff that increments counters
-        diff.get_sample_diff(name1)
-        diff.get_sample_diff(name2)
+        # Metrics `name1` and `name2` both have the same label
+        prom_diff.diff(name1)
+        prom_diff.diff(name2)
 
     Alternatively, one can create a new :class:`PromDiff` that holds the same
     data but has additional default labels:
 
-        with PromDiff(namespace=METRIC_NAMESPACE) as diff:
+        with PromDiff(namespace=METRIC_NAMESPACE) as prom_diff:
             ...  # Do stuff that increments counters
-        diff2 = diff.with_labels(labels)
-        diff2.get_sample_diff(name1)
-        diff2.get_sample_diff(name2)
+        labelled_diff = diff.with_labels(labels)
+        labelled_diff.diff(name1)
+        labelled_diff.diff(name2)
 
-    Labels are cumulative: more labels can be passed to :meth:`get_sample_diff`
-    and they augment the default labels.
+    Labels are cumulative: more labels can be passed to :meth:`value` or
+    :meth:`diff` and they augment the default labels.
 
     Parameters
     ----------
@@ -100,7 +101,7 @@ class PromDiff:
                 return s.value
         return None
 
-    def get_sample_value(self, name: str, labels: Mapping[str, str] | None = None) -> float:
+    def value(self, name: str, labels: Mapping[str, str] | None = None) -> float:
         """Return the value of the metric at the end of the context manager protocol.
 
         If it is not found, raises an :exc:`AssertionError`.
@@ -109,7 +110,7 @@ class PromDiff:
         assert value is not None, f"Metric {name}{labels} does not exist"
         return value
 
-    def get_sample_diff(self, name: str, labels: Mapping[str, str] | None = None) -> float:
+    def diff(self, name: str, labels: Mapping[str, str] | None = None) -> float:
         """Return the increase in the metric during the context manager protocol.
 
         If the metric did not exist at the start and end, raises an

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -120,7 +120,7 @@ class PromDiff:
         before = self._get_value(self._before, name, effective_labels)
         after = self._get_value(self._after, name, effective_labels)
         assert before is not None, f"Metric {name}{labels} did not exist at start"
-        assert after is not None, f"Metric {name}{labels} did not exist at start"
+        assert after is not None, f"Metric {name}{labels} did not exist at end"
         return after - before
 
     def with_labels(self, labels: Mapping[str, str] | None = None) -> Self:

--- a/test/dsim/test_send.py
+++ b/test/dsim/test_send.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2021-2022, National Research Foundation (SARAO)
+# Copyright (c) 2021-2022, 2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/dsim/test_send.py
+++ b/test/dsim/test_send.py
@@ -148,5 +148,5 @@ async def test_sender(
     assert (await switch_task) == switch_heap * DIG_HEAP_SAMPLES
 
     # Check the Prometheus counters
-    assert prom_diff.get_sample_diff("output_heaps_total") == SIGNAL_HEAPS * repeats * N_POLS
-    assert prom_diff.get_sample_diff("output_bytes_total") == orig_payload[0].nbytes * repeats
+    assert prom_diff.diff("output_heaps_total") == SIGNAL_HEAPS * repeats * N_POLS
+    assert prom_diff.diff("output_bytes_total") == orig_payload[0].nbytes * repeats

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -920,17 +920,17 @@ class TestEngine:
         for pol in range(N_POLS):
             # Check prometheus counter
             input_missing_heaps = np.sum(~recv_present[pol])
-            assert prom_diff.get_sample_diff("input_missing_heaps_total", {"pol": str(pol)}) == input_missing_heaps
+            assert prom_diff.diff("input_missing_heaps_total", {"pol": str(pol)}) == input_missing_heaps
 
         n_substreams = len(mock_send_stream)
         output_heaps = np.sum(send_present) * n_substreams
         prom_diff = prom_diff.with_labels({"stream": output.name})
-        assert prom_diff.get_sample_diff("output_heaps_total") == output_heaps
+        assert prom_diff.diff("output_heaps_total") == output_heaps
         batch_samples = channels * spectra_per_heap * N_POLS
         batch_size = batch_samples * COMPLEX * np.dtype(np.int8).itemsize
-        assert prom_diff.get_sample_diff("output_bytes_total") == np.sum(send_present) * batch_size
-        assert prom_diff.get_sample_diff("output_samples_total") == np.sum(send_present) * batch_samples
-        assert prom_diff.get_sample_diff("output_skipped_heaps_total") == np.sum(~send_present) * n_substreams
+        assert prom_diff.diff("output_bytes_total") == np.sum(send_present) * batch_size
+        assert prom_diff.diff("output_samples_total") == np.sum(send_present) * batch_samples
+        assert prom_diff.diff("output_skipped_heaps_total") == np.sum(~send_present) * n_substreams
 
         # Sensor is not present in the narrowband mode.
         if output.decimation == 1:
@@ -1081,8 +1081,8 @@ class TestEngine:
                 dig_data,
             )
 
-        assert prom_diff.get_sample_diff("output_clipped_samples_total", {"pol": f"{tone_pol}"}) == len(timestamps)
-        assert prom_diff.get_sample_diff("output_clipped_samples_total", {"pol": f"{1 - tone_pol}"}) == 0
+        assert prom_diff.diff("output_clipped_samples_total", {"pol": f"{tone_pol}"}) == len(timestamps)
+        assert prom_diff.diff("output_clipped_samples_total", {"pol": f"{1 - tone_pol}"}) == 0
 
         # Compute the expected timestamp. The timestamp is associated with the
         # output chunk, so we need to round up to output chunk size.

--- a/test/fgpu/test_recv.py
+++ b/test/fgpu/test_recv.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2023, National Research Foundation (SARAO)
+# Copyright (c) 2020-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/fgpu/test_recv.py
+++ b/test/fgpu/test_recv.py
@@ -352,16 +352,16 @@ class TestIterChunks:
 
         # Check metrics
         def get_sample_diffs(name: str) -> list[float | None]:
-            return [prom_diff.get_sample_diff(name, {"pol": str(pol)}) for pol in range(N_POLS)]
+            return [prom_diff.diff(name, {"pol": str(pol)}) for pol in range(N_POLS)]
 
         assert get_sample_diffs("input_heaps_total") == [61, 58]
-        assert prom_diff.get_sample_diff("input_chunks_total") == 5
+        assert prom_diff.diff("input_chunks_total") == 5
         assert get_sample_diffs("input_samples_total") == [61 * 4096, 58 * 4096]
         assert get_sample_diffs("input_bytes_total") == [61 * 5120, 58 * 5120]
-        assert prom_diff.get_sample_diff("input_too_old_heaps_total") == 1222
+        assert prom_diff.diff("input_too_old_heaps_total") == 1222
         assert get_sample_diffs("input_missing_heaps_total") == [12 * 16 - 61, 12 * 16 - 58]
-        assert prom_diff.get_sample_diff("input_bad_timestamp_heaps_total") == 1246
-        assert prom_diff.get_sample_diff("input_metadata_heaps_total") == 1642
+        assert prom_diff.diff("input_bad_timestamp_heaps_total") == 1246
+        assert prom_diff.diff("input_metadata_heaps_total") == 1642
         expected_clip_total = [sum(expected_clip[chunk_id, pol] for chunk_id in expected_ids) for pol in range(N_POLS)]
         assert get_sample_diffs("input_clipped_samples_total") == expected_clip_total
 

--- a/test/fgpu/test_send.py
+++ b/test/fgpu/test_send.py
@@ -224,7 +224,7 @@ async def test_send(
     saturated = np.concatenate([chunk.saturated for chunk in chunks])
     saturated = np.sum(saturated[skip_batches:], axis=0, dtype=np.uint64)
 
-    with PromDiff(namespace=METRIC_NAMESPACE) as prom_diff:
+    with PromDiff(namespace=METRIC_NAMESPACE, labels={"stream": NAME}) as prom_diff:
         # Send all the chunks, without waiting for the first one to complete
         # transmission (to ensure that the send streams have sufficient
         # capacity).
@@ -271,14 +271,13 @@ async def test_send(
         assert heaps_per_iface[iface] == N_SUBSTREAMS * good_batches // len(queues)
 
     # Check the sensors and Prometheus metrics
-    labels = {"stream": NAME}
-    assert prom_diff.get_sample_diff("output_heaps_total", labels) == good_batches * N_SUBSTREAMS
+    assert prom_diff.get_sample_diff("output_heaps_total") == good_batches * N_SUBSTREAMS
     expected_samples = good_batches * N_SPECTRA_PER_HEAP * N_CHANNELS * N_POLS
-    assert prom_diff.get_sample_diff("output_samples_total", labels) == expected_samples
+    assert prom_diff.get_sample_diff("output_samples_total") == expected_samples
     expected_bytes = expected_samples * COMPLEX * sample_bits // BYTE_BITS
-    assert prom_diff.get_sample_diff("output_bytes_total", labels) == expected_bytes
-    assert prom_diff.get_sample_diff("output_skipped_heaps_total", labels) == skip_batches * N_SUBSTREAMS
+    assert prom_diff.get_sample_diff("output_bytes_total") == expected_bytes
+    assert prom_diff.get_sample_diff("output_skipped_heaps_total") == skip_batches * N_SUBSTREAMS
     for pol in range(N_POLS):
-        pol_labels = {"stream": NAME, "pol": str(pol)}
+        pol_labels = {"pol": str(pol)}
         assert prom_diff.get_sample_diff("output_clipped_samples_total", pol_labels) == saturated[pol]
         assert sensors[f"{NAME}.input{pol}.feng-clip-cnt"].value == saturated[pol]

--- a/test/fgpu/test_send.py
+++ b/test/fgpu/test_send.py
@@ -271,13 +271,13 @@ async def test_send(
         assert heaps_per_iface[iface] == N_SUBSTREAMS * good_batches // len(queues)
 
     # Check the sensors and Prometheus metrics
-    assert prom_diff.get_sample_diff("output_heaps_total") == good_batches * N_SUBSTREAMS
+    assert prom_diff.diff("output_heaps_total") == good_batches * N_SUBSTREAMS
     expected_samples = good_batches * N_SPECTRA_PER_HEAP * N_CHANNELS * N_POLS
-    assert prom_diff.get_sample_diff("output_samples_total") == expected_samples
+    assert prom_diff.diff("output_samples_total") == expected_samples
     expected_bytes = expected_samples * COMPLEX * sample_bits // BYTE_BITS
-    assert prom_diff.get_sample_diff("output_bytes_total") == expected_bytes
-    assert prom_diff.get_sample_diff("output_skipped_heaps_total") == skip_batches * N_SUBSTREAMS
+    assert prom_diff.diff("output_bytes_total") == expected_bytes
+    assert prom_diff.diff("output_skipped_heaps_total") == skip_batches * N_SUBSTREAMS
     for pol in range(N_POLS):
         pol_labels = {"pol": str(pol)}
-        assert prom_diff.get_sample_diff("output_clipped_samples_total", pol_labels) == saturated[pol]
+        assert prom_diff.diff("output_clipped_samples_total", pol_labels) == saturated[pol]
         assert sensors[f"{NAME}.input{pol}.feng-clip-cnt"].value == saturated[pol]

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -374,13 +374,7 @@ def verify_corrprod_sensors(
     """
     skipped_accs_total = 0
     for xpipeline in xpipelines:
-        # The assert statements are mainly to force mypy to realise the
-        # prom_diff values obtained are the expected data type
-        def prom_get(name: str) -> float:
-            diff = prom_diff.get_sample_diff(name, {"stream": xpipeline.output.name})  # noqa: B023
-            assert diff is not None, f"{name} is None"
-            return diff
-
+        stream_diff = prom_diff.with_labels({"stream": xpipeline.output.name})
         # Count accumulations for which we expect to receive the accumulation
         # but have incomplete data. Also calculate expected updates to
         # rx.synchronised.
@@ -418,14 +412,16 @@ def verify_corrprod_sensors(
                     skipped_accs += 1
         sent_accs = complete_accs + incomplete_accs
 
-        assert prom_get("output_x_incomplete_accs_total") == incomplete_accs
-        assert prom_get("output_x_skipped_accs_total") == skipped_accs
-        assert prom_get("output_x_heaps_total") == sent_accs
-        assert prom_get("output_x_bytes_total") == (
+        assert stream_diff.get_sample_diff("output_x_incomplete_accs_total") == incomplete_accs
+        assert stream_diff.get_sample_diff("output_x_skipped_accs_total") == skipped_accs
+        assert stream_diff.get_sample_diff("output_x_heaps_total") == sent_accs
+        assert stream_diff.get_sample_diff("output_x_bytes_total") == (
             n_channels_per_substream * n_baselines * COMPLEX * xsend.SEND_DTYPE.itemsize * sent_accs
         )
-        assert prom_get("output_x_visibilities_total") == (n_channels_per_substream * n_baselines * sent_accs)
-        assert prom_get("output_x_clipped_visibilities_total") == 0
+        assert stream_diff.get_sample_diff("output_x_visibilities_total") == (
+            n_channels_per_substream * n_baselines * sent_accs
+        )
+        assert stream_diff.get_sample_diff("output_x_clipped_visibilities_total") == 0
         skipped_accs_total += skipped_accs
 
         # Verify sensor updates while we're here
@@ -489,23 +485,17 @@ def verify_beam_sensors(
     # number of (COMPLEX) samples.
     heap_samples = np.prod(heap_shape[:-1])
     for i, beam_output in enumerate(beam_outputs):
-        # The assert statements are mainly to force mypy to realise the
-        # prom_diff values obtained are the expected data type
-        def prom_get(name: str) -> float:
-            diff = prom_diff.get_sample_diff(name, {"stream": beam_output.name})  # noqa: B023
-            assert diff is not None, f"{name} is None"
-            return diff
-
-        assert prom_get("output_b_heaps_total") == n_beam_heaps_sent
-        assert prom_get("output_b_bytes_total") == n_beam_heaps_sent * heap_bytes
-        assert prom_get("output_b_samples_total") == n_beam_heaps_sent * heap_samples
-        assert saturated_low[i] <= prom_get("output_b_clipped_samples_total") <= saturated_high[i]
+        stream_diff = prom_diff.with_labels({"stream": beam_output.name})
+        assert stream_diff.get_sample_diff("output_b_heaps_total") == n_beam_heaps_sent
+        assert stream_diff.get_sample_diff("output_b_bytes_total") == n_beam_heaps_sent * heap_bytes
+        assert stream_diff.get_sample_diff("output_b_samples_total") == n_beam_heaps_sent * heap_samples
+        assert saturated_low[i] <= stream_diff.get_sample_diff("output_b_clipped_samples_total") <= saturated_high[i]
 
         # Check that sensor value matches Prometheus
         assert actual_sensor_updates[f"{beam_output.name}.beng-clip-cnt"][-1] == aiokatcp.Reading(
             mock.ANY,
             aiokatcp.Sensor.Status.NOMINAL,
-            prom_get("output_b_clipped_samples_total"),
+            stream_diff.get_sample_diff("output_b_clipped_samples_total"),
         )
 
         assert first_timestamp < last_timestamp, (
@@ -1159,11 +1149,9 @@ class TestEngine:
 
         n_vis = n_channels_per_substream * n_baselines
         for corrprod_output in corrprod_outputs:
-            assert prom_diff.get_sample_diff("output_x_visibilities_total", {"stream": corrprod_output.name}) == n_vis
-            assert (
-                prom_diff.get_sample_diff("output_x_clipped_visibilities_total", {"stream": corrprod_output.name})
-                == n_vis
-            )
+            stream_diff = prom_diff.with_labels({"stream": corrprod_output.name})
+            assert stream_diff.get_sample_diff("output_x_visibilities_total") == n_vis
+            assert stream_diff.get_sample_diff("output_x_clipped_visibilities_total") == n_vis
             assert xbengine.sensors[f"{corrprod_output.name}.xeng-clip-cnt"].value == n_vis
 
     def _patch_get_in_item(

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -418,9 +418,7 @@ def verify_corrprod_sensors(
         assert stream_diff.diff("output_x_bytes_total") == (
             n_channels_per_substream * n_baselines * COMPLEX * xsend.SEND_DTYPE.itemsize * sent_accs
         )
-        assert stream_diff.diff("output_x_visibilities_total") == (
-            n_channels_per_substream * n_baselines * sent_accs
-        )
+        assert stream_diff.diff("output_x_visibilities_total") == (n_channels_per_substream * n_baselines * sent_accs)
         assert stream_diff.diff("output_x_clipped_visibilities_total") == 0
         skipped_accs_total += skipped_accs
 

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -412,16 +412,16 @@ def verify_corrprod_sensors(
                     skipped_accs += 1
         sent_accs = complete_accs + incomplete_accs
 
-        assert stream_diff.get_sample_diff("output_x_incomplete_accs_total") == incomplete_accs
-        assert stream_diff.get_sample_diff("output_x_skipped_accs_total") == skipped_accs
-        assert stream_diff.get_sample_diff("output_x_heaps_total") == sent_accs
-        assert stream_diff.get_sample_diff("output_x_bytes_total") == (
+        assert stream_diff.diff("output_x_incomplete_accs_total") == incomplete_accs
+        assert stream_diff.diff("output_x_skipped_accs_total") == skipped_accs
+        assert stream_diff.diff("output_x_heaps_total") == sent_accs
+        assert stream_diff.diff("output_x_bytes_total") == (
             n_channels_per_substream * n_baselines * COMPLEX * xsend.SEND_DTYPE.itemsize * sent_accs
         )
-        assert stream_diff.get_sample_diff("output_x_visibilities_total") == (
+        assert stream_diff.diff("output_x_visibilities_total") == (
             n_channels_per_substream * n_baselines * sent_accs
         )
-        assert stream_diff.get_sample_diff("output_x_clipped_visibilities_total") == 0
+        assert stream_diff.diff("output_x_clipped_visibilities_total") == 0
         skipped_accs_total += skipped_accs
 
         # Verify sensor updates while we're here
@@ -486,16 +486,16 @@ def verify_beam_sensors(
     heap_samples = np.prod(heap_shape[:-1])
     for i, beam_output in enumerate(beam_outputs):
         stream_diff = prom_diff.with_labels({"stream": beam_output.name})
-        assert stream_diff.get_sample_diff("output_b_heaps_total") == n_beam_heaps_sent
-        assert stream_diff.get_sample_diff("output_b_bytes_total") == n_beam_heaps_sent * heap_bytes
-        assert stream_diff.get_sample_diff("output_b_samples_total") == n_beam_heaps_sent * heap_samples
-        assert saturated_low[i] <= stream_diff.get_sample_diff("output_b_clipped_samples_total") <= saturated_high[i]
+        assert stream_diff.diff("output_b_heaps_total") == n_beam_heaps_sent
+        assert stream_diff.diff("output_b_bytes_total") == n_beam_heaps_sent * heap_bytes
+        assert stream_diff.diff("output_b_samples_total") == n_beam_heaps_sent * heap_samples
+        assert saturated_low[i] <= stream_diff.diff("output_b_clipped_samples_total") <= saturated_high[i]
 
         # Check that sensor value matches Prometheus
         assert actual_sensor_updates[f"{beam_output.name}.beng-clip-cnt"][-1] == aiokatcp.Reading(
             mock.ANY,
             aiokatcp.Sensor.Status.NOMINAL,
-            stream_diff.get_sample_diff("output_b_clipped_samples_total"),
+            stream_diff.diff("output_b_clipped_samples_total"),
         )
 
         assert first_timestamp < last_timestamp, (
@@ -1150,8 +1150,8 @@ class TestEngine:
         n_vis = n_channels_per_substream * n_baselines
         for corrprod_output in corrprod_outputs:
             stream_diff = prom_diff.with_labels({"stream": corrprod_output.name})
-            assert stream_diff.get_sample_diff("output_x_visibilities_total") == n_vis
-            assert stream_diff.get_sample_diff("output_x_clipped_visibilities_total") == n_vis
+            assert stream_diff.diff("output_x_visibilities_total") == n_vis
+            assert stream_diff.diff("output_x_clipped_visibilities_total") == n_vis
             assert xbengine.sensors[f"{corrprod_output.name}.xeng-clip-cnt"].value == n_vis
 
     def _patch_get_in_item(

--- a/test/xbgpu/test_recv.py
+++ b/test/xbgpu/test_recv.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2023, National Research Foundation (SARAO)
+# Copyright (c) 2020-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/xbgpu/test_recv.py
+++ b/test/xbgpu/test_recv.py
@@ -234,13 +234,13 @@ class TestStream:
         assert seen == 5
         expected_bad_timestamps = seen * layout.chunk_heaps if timestamps == "bad" else 0
 
-        assert prom_diff.get_sample_diff("input_chunks_total") == seen + empty_chunks
-        assert prom_diff.get_sample_diff("input_heaps_total") == (seen + empty_chunks) * layout.chunk_heaps
-        assert prom_diff.get_sample_diff("input_bytes_total") == layout.chunk_bytes * seen
-        assert prom_diff.get_sample_diff("input_bad_timestamp_heaps_total") == expected_bad_timestamps
-        assert prom_diff.get_sample_diff("input_bad_feng_id_heaps_total") == 1
-        assert prom_diff.get_sample_diff("input_metadata_heaps_total") == 1
-        assert prom_diff.get_sample_diff("input_too_old_heaps_total") == 1
+        assert prom_diff.diff("input_chunks_total") == seen + empty_chunks
+        assert prom_diff.diff("input_heaps_total") == (seen + empty_chunks) * layout.chunk_heaps
+        assert prom_diff.diff("input_bytes_total") == layout.chunk_bytes * seen
+        assert prom_diff.diff("input_bad_timestamp_heaps_total") == expected_bad_timestamps
+        assert prom_diff.diff("input_bad_feng_id_heaps_total") == 1
+        assert prom_diff.diff("input_metadata_heaps_total") == 1
+        assert prom_diff.diff("input_too_old_heaps_total") == 1
 
     async def test_missing_heaps(
         self,
@@ -339,9 +339,9 @@ class TestStream:
         np.testing.assert_array_equal(received_chunk_presence.flatten(), expected_chunk_presence_flat)
 
         # Check StatsCollector's values
-        assert prom_diff.get_sample_diff("input_heaps_total") == seen * layout.chunk_heaps - n_single_heaps_to_delete
+        assert prom_diff.diff("input_heaps_total") == seen * layout.chunk_heaps - n_single_heaps_to_delete
         assert (
-            prom_diff.get_sample_diff("input_missing_heaps_total")
+            prom_diff.diff("input_missing_heaps_total")
             == n_chunks_to_delete * layout.chunk_heaps + n_single_heaps_to_delete
         )
 


### PR DESCRIPTION
Can't take much credit for this one, this is all @bmerry. My attempt at #812 
was largely because I thought we didn't "own" our implementation of `PromDiff`.

I tweaked the class's docstring and renamed `get_sample_{value, diff}` to just
`{value, diff}`.

I noticed katgpucbf doesn't adopt/use the convention of adding a 
```
Raises
------
```
section in the docstring, so I left the discussion as-is in `PromDiff.{value, diff}`.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1316.
