### PR TITLE
Decrease max_antennas for qualification testing

### DIFF
--- a/qualification/pytest-jenkins.ini
+++ b/qualification/pytest-jenkins.ini
@@ -13,7 +13,7 @@ log_cli_level = info
 log_cli_format = %(asctime)s.%(msecs)03d  %(levelname)-8s %(name)s:%(filename)s:%(lineno)d %(message)s
 addopts = --report-log=report.json
 default_antennas = 24
-max_antennas = 40
+max_antennas = 32
 wideband_channels = 1024 4096 8192 32768
 narrowband_channels = 32768
 narrowband_decimation = 8 16


### PR DESCRIPTION
The previous settings depended on 100% of the agents being online, leading to failed qualification tests if one of them fell over or was borrowed and not returned overnight.
