### PR TITLE
Handle decimation factors less than 8

### DIFF
--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1233,6 +1233,7 @@ class Engine(aiokatcp.DeviceServer):
         self._copy_queue = context.create_command_queue()
 
         extra_samples = max_delay_diff + max(output.window for output in outputs)
+        extra_samples = accel.roundup(extra_samples, BYTE_BITS)
         if extra_samples > self.recv_layout.chunk_samples:
             raise RuntimeError(f"chunk_samples is too small; it must be at least {extra_samples}")
         self.n_samples = self.recv_layout.chunk_samples + extra_samples


### PR DESCRIPTION
The padding added to each input chunk needs to be a multiple of BYTE_BITS (8), but that doesn't necessarily happen when the narrowband decimation is small.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1393.
