### PR TITLE
Run Jenkins pytests with -n 4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,12 +118,10 @@ pipeline {
 
         /* This stage actually runs pytest. Pytest has a number of flags that are
          * not required but make life easier:
-         * 1. -n X: Launches X threads and runs the tests in parallel across
-         *     multiple threads. This speeds up testing significantly. NOTE: This
+         * 1. -n X: Launches X processes and runs the tests in parallel across
+         *     multiple processes. This speeds up testing significantly. NOTE: This
          *     can create resource contention over things like GPU RAM. If it
-         *     starts becoming an issue set X to 1. I have noticed an issue once
-         *     where sometimes one thread got stuck and it stalled the pipeline.
-         *     Until this has been solved, I am removing this argument entirely
+         *     starts becoming an issue set X to 1.
          * 2. -v: Increases verbosity
          * 3. --junitxml=reports/result.xml' Writes the results to a file for later
          *    examination.
@@ -132,14 +130,14 @@ pipeline {
           when { not { anyOf { changeRequest target: 'main'; branch 'main' } } }
           options { timeout(time: 30, unit: 'MINUTES') }
           steps {
-            sh 'pytest -v -ra --junitxml=reports/result.xml --cov=katgpucbf --cov=test --cov-report=xml --cov-branch --suppress-tests-failed-exit-code'
+            sh 'pytest -n 4 -v -ra --junitxml=reports/result.xml --cov=katgpucbf --cov=test --cov-report=xml --cov-branch --suppress-tests-failed-exit-code'
           }
         }
         stage('Run pytest (full)') {
           when { anyOf { changeRequest target: 'main'; branch 'main' } }
           options { timeout(time: 60, unit: 'MINUTES') }
           steps {
-            sh 'pytest -v -ra --all-combinations --junitxml=reports/result.xml --cov=test --cov=katgpucbf --cov-report=xml --cov-branch --suppress-tests-failed-exit-code'
+            sh 'pytest -n 4 -v -ra --all-combinations --junitxml=reports/result.xml --cov=test --cov=katgpucbf --cov-report=xml --cov-branch --suppress-tests-failed-exit-code'
           }
         }
 


### PR DESCRIPTION
This brings branch builds to < 5 minutes. Relates to NGC-1363, in that that workaround for that ticket involves running only one build at a time per host and hence we have enough resources to run things in parallel. We might be able to increase the parallelism further, but the pre-commit checks would then become a bottleneck.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match