### PR TITLE
Make global memory access for dithering more efficient

### DIFF
--- a/doc/xbgpu.design.b.rst
+++ b/doc/xbgpu.design.b.rst
@@ -66,6 +66,8 @@ This does mean that the inputs are loaded multiple times, but caches help
 significantly here, and the kernel tends to be more compute-bound in this
 domain.
 
+.. _dithering:
+
 Dithering
 ^^^^^^^^^
 To improve linearity, a random value in the interval (-0.5, 0.5) is added to
@@ -84,6 +86,13 @@ mapping the :math:`2^{32}` possible return values of :cpp:func:`!curand` to
 the range :math:`(-2^{31}, 2^{31})` with zero represented twice, before
 scaling to convert to a real value in :math:`(-0.5, 0.5)`. While this is
 still a deviation from uniformity, it does give a symmetric distribution.
+
+The :c:struct:`curandStateXORWOW_t` struct defined by curand is unnecessarily large
+for our purposes, because it retains state needed to generate Gaussian
+distributions (Box-Muller transform). To reduce global memory traffic, we use
+a different type we define (:c:struct:`randState_t`) to hold random states in
+global memory, together with helpers that save and restore this smaller state
+from a private :c:struct:`curandStateXORWOW_t` used within a kernel.
 
 .. _curand: https://docs.nvidia.com/cuda/curand/index.html
 

--- a/scratch/xbgpu/benchmarks/beamform_bench.py
+++ b/scratch/xbgpu/benchmarks/beamform_bench.py
@@ -20,7 +20,6 @@ import argparse
 
 import katsdpsigproc.accel
 
-from katgpucbf.curand_helpers import RandomStateBuilder
 from katgpucbf.xbgpu.beamform import BeamformTemplate
 
 
@@ -47,10 +46,6 @@ def main():
         seed=1,
         sequence_first=0,
     )
-
-    builder = RandomStateBuilder(ctx)
-    slot = fn.slots["rand_states"]
-    fn.bind(rand_states=builder.make_states(slot.shape, seed=1234567, sequence_first=0))
 
     fn.ensure_all_bound()
     # Set non-trivial weights so the whole thing isn't just zero

--- a/src/katgpucbf/curand_helpers.py
+++ b/src/katgpucbf/curand_helpers.py
@@ -16,15 +16,9 @@
 
 """Helpers to initialise random state with curand.
 
-The :c:struct:`curandXORWOW_t` struct defined by curand is unnecessarily large
-for our purposes, because it retains state needed to generate Gaussian
-distributions (Box-Muller transform). To reduce global memory traffic, we use
-a different type we define (:c:struct:`randState_t`) to hold random states in
-global memory, together with helpers that save and restore this smaller state
-from a private :c:struct:`curandXORWOW_t` used within a kernel.
-
-Code using this module should thus NOT generate Gaussian distributions without
-understanding the implications.
+See :ref:`dithering` for an explanation of why we introduce a separate
+:c:struct:`randState_t` structure. Code using this module should **not**
+generate Gaussian distributions without understanding the implications.
 """
 
 from importlib import resources
@@ -37,7 +31,7 @@ from katsdpsigproc.abc import AbstractCommandQueue, AbstractContext
 RAND_STATE_SIZE = 24
 #: alignof(randState_t)
 RAND_STATE_ALIGNMENT = 8
-#: dtype corresponding to randState_t
+#: opaque dtype corresponding to randState_t (only size and alignment matter)
 RAND_STATE_DTYPE = np.dtype(
     {"names": ["_align"], "formats": [np.dtype(f"u{RAND_STATE_ALIGNMENT}")], "itemsize": RAND_STATE_SIZE}, align=True
 )

--- a/src/katgpucbf/curand_helpers.py
+++ b/src/katgpucbf/curand_helpers.py
@@ -51,7 +51,7 @@ class RandomStateBuilder:
     def __init__(self, context: AbstractContext) -> None:
         with resources.as_file(resources.files(__package__)) as resource_dir:
             program = accel.build(context, "kernels/curand_init.mako", extra_dirs=[str(resource_dir)])
-        self._init_kernel = program.get_kernel("init_randState_t")
+        self._init_kernel = program.get_kernel("rand_state_init")
 
     def make_states(
         self,

--- a/src/katgpucbf/curand_helpers.py
+++ b/src/katgpucbf/curand_helpers.py
@@ -16,7 +16,7 @@
 
 """Helpers to initialise random state with curand.
 
-The :c:struct:`curandXORWOW_t` struct define by curand is unnecessarily large
+The :c:struct:`curandXORWOW_t` struct defined by curand is unnecessarily large
 for our purposes, because it retains state needed to generate Gaussian
 distributions (Box-Muller transform). To reduce global memory traffic, we use
 a different type we define (:c:struct:`randState_t`) to hold random states in

--- a/src/katgpucbf/kernels/curand_helpers.mako
+++ b/src/katgpucbf/kernels/curand_helpers.mako
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2024, National Research Foundation (SARAO)
+ *
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+<%include file="/port.mako"/>
+
+extern "C++"  // PyCUDA wraps the whole file in extern "C"
+{
+#include <curand_kernel.h>
+#include <type_traits>
+#include <utility>
+}
+
+/* Holds the same random state as curandStateXORWOW_t, excluding the state for
+ * the Box-Muller transform. It uses an array of uint2 rather than uint so
+ * that global memory instructions use 64-bit rather than 32-bit access.
+ *
+ * If this structure is updated, be sure to update the constants in
+ * curand_helpers.py.
+ */
+typedef struct
+{
+    uint2 raw[3];
+} randState_t;
+
+// Check that CUDA hasn't changed the internals of curandStateXORWOW_t
+static_assert(offsetof(curandStateXORWOW_t, d) == 0);
+static_assert(std::is_same_v<decltype(std::declval<curandStateXORWOW_t>().d), unsigned int>);
+static_assert(offsetof(curandStateXORWOW_t, v) == 4);
+static_assert(std::is_same_v<decltype(std::declval<curandStateXORWOW_t>().v), unsigned int[5]>);
+
+DEVICE_FN static inline void rand_state_load(curandStateXORWOW_t * RESTRICT out, const GLOBAL randState_t * RESTRICT in)
+{
+    // Zero initialise, just to avoid any undefined behaviour. The compiler
+    // should elide this.
+    *out = curandStateXORWOW_t{};
+    randState_t tmp = *in;  // Load into registers as uint2's first
+    out->d = tmp.raw[0].x;
+    out->v[0] = tmp.raw[0].y;
+    out->v[1] = tmp.raw[1].x;
+    out->v[2] = tmp.raw[1].y;
+    out->v[3] = tmp.raw[2].x;
+    out->v[4] = tmp.raw[2].y;
+}
+
+DEVICE_FN static inline void rand_state_save(GLOBAL randState_t * RESTRICT out, const curandStateXORWOW_t * RESTRICT in)
+{
+    randState_t tmp;  // Prepare in registers so that writes can be uint2 sized
+    tmp.raw[0].x = in->d;
+    tmp.raw[0].y = in->v[0];
+    tmp.raw[1].x = in->v[1];
+    tmp.raw[1].y = in->v[2];
+    tmp.raw[2].x = in->v[3];
+    tmp.raw[2].y = in->v[4];
+    *out = tmp;
+}

--- a/src/katgpucbf/kernels/curand_init.mako
+++ b/src/katgpucbf/kernels/curand_init.mako
@@ -14,21 +14,12 @@
  * limitations under the License.
  ******************************************************************************/
 
-extern "C++"  // PyCUDA wraps the whole file in extern "C"
-{
-#include <curand_kernel.h>
-}
+<%include file="/port.mako"/>
+<%include file="curand_helpers.mako"/>
 
-/// Get sizeof and alignof curandStateXORWOW_t
-__global__ void sizeof_alignof_curandStateXORWOW_t(int *out)
-{
-    out[0] = sizeof(curandStateXORWOW_t);
-    out[1] = alignof(curandStateXORWOW_t);
-}
-
-/// Initialise an array of curandState_t with sequential sequence numbers
-__global__ void init_curandStateXORWOW_t(
-    curandStateXORWOW_t *out,
+/// Initialise an array of randState_t with sequential sequence numbers
+KERNEL void init_randState_t(
+    randState_t *out,
     unsigned long long seed,
     unsigned long long sequence_first,
     unsigned long long sequence_step,
@@ -38,5 +29,7 @@ __global__ void init_curandStateXORWOW_t(
     unsigned int id = blockIdx.x * blockDim.x + threadIdx.x;
     if (id >= n)
         return;
-    curand_init(seed, sequence_first + id * sequence_step, offset, out + id);
+    curandStateXORWOW_t tmp;
+    curand_init(seed, sequence_first + id * sequence_step, offset, &tmp);
+    rand_state_save(out + id, &tmp);
 }

--- a/src/katgpucbf/kernels/curand_init.mako
+++ b/src/katgpucbf/kernels/curand_init.mako
@@ -18,7 +18,7 @@
 <%include file="curand_helpers.mako"/>
 
 /// Initialise an array of randState_t with sequential sequence numbers
-KERNEL void init_randState_t(
+KERNEL void rand_state_init(
     randState_t *out,
     unsigned long long seed,
     unsigned long long sequence_first,

--- a/src/katgpucbf/xbgpu/beamform.py
+++ b/src/katgpucbf/xbgpu/beamform.py
@@ -24,7 +24,7 @@ from katsdpsigproc import accel
 from katsdpsigproc.abc import AbstractCommandQueue, AbstractContext
 
 from .. import COMPLEX, N_POLS
-from ..curand_helpers import RandomStateBuilder
+from ..curand_helpers import RAND_STATE_DTYPE, RandomStateBuilder
 
 
 class BeamformTemplate:
@@ -153,9 +153,10 @@ class Beamform(accel.Operation):
                 accel.Dimension(n_channels_per_substream, exact=True),
                 accel.Dimension(n_spectra_per_batch, exact=True),
             ),
-            builder.dtype,
+            RAND_STATE_DTYPE,
         )
         rand_states = builder.make_states(
+            command_queue,
             (n_batches, n_channels_per_substream, n_spectra_per_batch),
             seed=seed,
             sequence_first=sequence_first,

--- a/src/katgpucbf/xbgpu/kernels/beamform.mako
+++ b/src/katgpucbf/xbgpu/kernels/beamform.mako
@@ -96,7 +96,8 @@ KERNEL REQD_WORK_GROUP_SIZE(BLOCK_SPECTRA, 1, 1) void beamform(
     rand_states += (batch * get_num_groups(1) + channel) * n_spectra + spectrum;
 
     curandStateXORWOW_t rand_state;
-    rand_state_load(&rand_state, rand_states);
+    if (valid)
+        rand_state_load(&rand_state, rand_states);
 
     /* It's critical that this loop is unrolled, so that b_batch_size is known at
      * compile time.
@@ -195,5 +196,6 @@ KERNEL REQD_WORK_GROUP_SIZE(BLOCK_SPECTRA, 1, 1) void beamform(
     }
 
     // Persist the random state for reuse next time
-    rand_state_save(rand_states, &rand_state);
+    if (valid)
+        rand_state_save(rand_states, &rand_state);
 }

--- a/src/katgpucbf/xbgpu/kernels/beamform.mako
+++ b/src/katgpucbf/xbgpu/kernels/beamform.mako
@@ -14,13 +14,9 @@
  * limitations under the License.
  ******************************************************************************/
 
-extern "C++"  // PyCUDA wraps the whole file in extern "C"
-{
-#include <curand_kernel.h>
-}
-
 <%include file="/port.mako"/>
 <%include file="/kernels/complex.mako"/>
+<%include file="/kernels/curand_helpers.mako"/>
 <%include file="/kernels/quant.mako"/>
 
 <%
@@ -37,7 +33,7 @@ batch_beams = min(16, n_beams)
 #define BATCH_BEAMS ${batch_beams}
 
 /// Generate a random value in (-0.5, 0.5)
-DEVICE_FN float dither(GLOBAL curandStateXORWOW_t *state)
+DEVICE_FN float dither(curandStateXORWOW_t *state)
 {
     /* This magic value is chosen so that the largest possible return value
      * can be added to 127 and still produce 127.49999 rather than 127.5
@@ -64,7 +60,7 @@ KERNEL REQD_WORK_GROUP_SIZE(BLOCK_SPECTRA, 1, 1) void beamform(
     GLOBAL const char4 * RESTRICT in,        // shape batch, antenna, channel, time, pol
     GLOBAL const cplx * RESTRICT weights,    // shape antenna, beam, tightly packed
     GLOBAL const float * RESTRICT delays,    // shape antenna, beam, tightly packed
-    GLOBAL curandStateXORWOW_t * RESTRICT rand_state,  // shape batch, channel, time (packed)
+    GLOBAL randState_t * RESTRICT rand_states,  // shape batch, channel, time (packed)
     int out_stride,                          // elements between channels
     int out_beam_stride,                     // elements between beams
     int out_batch_stride,                    // elements between batches
@@ -97,7 +93,10 @@ KERNEL REQD_WORK_GROUP_SIZE(BLOCK_SPECTRA, 1, 1) void beamform(
     // Point to the first input/output handled by this work item
     in += batch * in_batch_stride + channel * in_stride + spectrum;
     out += batch * out_batch_stride + channel * out_stride + spectrum;
-    rand_state += (batch * get_num_groups(1) + channel) * n_spectra + spectrum;
+    rand_states += (batch * get_num_groups(1) + channel) * n_spectra + spectrum;
+
+    curandStateXORWOW_t rand_state;
+    rand_state_load(&rand_state, rand_states);
 
     /* It's critical that this loop is unrolled, so that b_batch_size is known at
      * compile time.
@@ -167,8 +166,8 @@ KERNEL REQD_WORK_GROUP_SIZE(BLOCK_SPECTRA, 1, 1) void beamform(
                 int beam = i + b_batch;
                 int re, im;
                 bool saturated =
-                    quant_8bit(accum[i].x + dither(rand_state), &re)
-                    | quant_8bit(accum[i].y + dither(rand_state), &im);
+                    quant_8bit(accum[i].x + dither(&rand_state), &re)
+                    | quant_8bit(accum[i].y + dither(&rand_state), &im);
                 out[out_beam_stride * beam] = make_char2(re, im);
                 u.l_saturated[i][lid] = saturated;
             }
@@ -194,4 +193,7 @@ KERNEL REQD_WORK_GROUP_SIZE(BLOCK_SPECTRA, 1, 1) void beamform(
         }
         BARRIER(); // switching back to using u.l_weights for the next loop
     }
+
+    // Persist the random state for reuse next time
+    rand_state_save(rand_states, &rand_state);
 }


### PR DESCRIPTION
Save and restore only the state that's actually needed. This reduces memory usage and global memory traffic for beamforming. In some microbenchmarks it makes beamforming 1.6x more efficient. It also simplifies some of the code by eliminating the need to measure the size and alignment of curandStateXORWOW_t at runtime.

Also removed a redundant initialisation of random state in beamform_bench.py.

This is indirectly related to NGC-1264: this improvement is needed to make F-engine dithering feasible.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
