### PR TITLE
Replace --spectra-per-heap with --jones-per-batch in scratch scripts

### DIFF
--- a/scratch/fgpu/benchmarks/compute_bench.py
+++ b/scratch/fgpu/benchmarks/compute_bench.py
@@ -21,7 +21,7 @@ import argparse
 import numpy as np
 from katsdpsigproc import accel
 
-from katgpucbf import DIG_SAMPLE_BITS
+from katgpucbf import DEFAULT_JONES_PER_BATCH, DIG_SAMPLE_BITS
 from katgpucbf.fgpu.compute import ComputeTemplate, NarrowbandConfig
 from katgpucbf.fgpu.engine import generate_ddc_weights, generate_pfb_weights
 from katgpucbf.fgpu.main import DEFAULT_DDC_TAPS_RATIO
@@ -33,7 +33,7 @@ def main():  # noqa: C901
     parser.add_argument("--recv-chunk-samples", type=int, default=32 * 1024 * 1024)
     parser.add_argument("--send-chunk-jones", type=int, default=8 * 1024 * 1024)
     parser.add_argument("--channels", type=int, default=32768)
-    parser.add_argument("--spectra-per-heap", type=int, default=256)
+    parser.add_argument("--jones-per-batch", type=int, default=DEFAULT_JONES_PER_BATCH)
     parser.add_argument("--dig-sample-bits", type=int, default=DIG_SAMPLE_BITS)
     parser.add_argument("--send-sample-bits", type=int, default=8, choices=[4, 8])
     parser.add_argument("--passes", type=int, default=1000)
@@ -57,6 +57,9 @@ def main():  # noqa: C901
             parser.error("--sem must divide into --passes")
     if args.kernel == "ddc" and not args.narrowband:
         parser.error("--kernel=ddc requires --narrowband")
+    if args.jones_per_batch % args.channels != 0:
+        parser.error("--jones-per-batch must be a multiple of --channels")
+    spectra_per_heap = args.jones_per_batch // args.channels
 
     rng = np.random.default_rng(seed=1)
     context = accel.create_some_context(device_filter=lambda device: device.is_cuda)
@@ -77,14 +80,14 @@ def main():  # noqa: C901
             context, args.taps, args.channels, args.dig_sample_bits, args.send_sample_bits, narrowband=narrowband_config
         )
         command_queue = context.create_tuning_command_queue()
-        out_spectra = accel.roundup(args.send_chunk_jones // args.channels, args.spectra_per_heap)
+        out_spectra = accel.roundup(args.send_chunk_jones // args.channels, spectra_per_heap)
         frontend_spectra = min(args.recv_chunk_samples // spectra_samples, out_spectra)
         extra_samples = window - spectra_samples
         fn = template.instantiate(
             command_queue,
             samples=args.recv_chunk_samples + extra_samples,
             spectra=out_spectra,
-            spectra_per_heap=args.spectra_per_heap,
+            spectra_per_heap=spectra_per_heap,
         )
         fn.ensure_all_bound()
 

--- a/scratch/xbgpu/benchmarks/beamform_bench.py
+++ b/scratch/xbgpu/benchmarks/beamform_bench.py
@@ -20,6 +20,7 @@ import argparse
 
 import katsdpsigproc.accel
 
+from katgpucbf import DEFAULT_JONES_PER_BATCH
 from katgpucbf.xbgpu.beamform import BeamformTemplate
 
 
@@ -27,17 +28,28 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--array-size", type=int, default=80, help="Antennas in the array [%(default)s]")
     parser.add_argument(
+        "--channels", type=int, default=1024, help="Total number of channels in the stream [%(default)s]"
+    )
+    parser.add_argument(
         "--channels-per-substream", type=int, default=16, help="Channels processed by one engine [%(default)s]"
     )
-    parser.add_argument("--spectra-per-heap", type=int, default=256, help="Spectra in each batch [%(default)s]")
+    parser.add_argument(
+        "--jones-per-batch",
+        type=int,
+        default=DEFAULT_JONES_PER_BATCH,
+        help="Number of antenna-channelised-voltage Jones vectors in each F-engine batch [%(default)s]",
+    )
     parser.add_argument("--heaps-per-fengine-per-chunk", type=int, default=32, help="Batches per chunk [%(default)s]")
     parser.add_argument("--beams", type=int, default=4, help="Number of dual-pol beams [%(default)s]")
     parser.add_argument("--passes", type=int, default=10000, help="Number of times to repeat the test [%(default)s]")
     args = parser.parse_args()
+    if args.jones_per_batch % args.channels != 0:
+        parser.error("--jones-per-batch must be a multiple of --channels")
+    spectra_per_heap = args.jones_per_batch // args.channels
 
     ctx = katsdpsigproc.accel.create_some_context()
     command_queue = ctx.create_command_queue()
-    template = BeamformTemplate(ctx, [0, 1] * args.beams, n_spectra_per_batch=args.spectra_per_heap)
+    template = BeamformTemplate(ctx, [0, 1] * args.beams, n_spectra_per_batch=spectra_per_heap)
     fn = template.instantiate(
         command_queue,
         n_batches=args.heaps_per_fengine_per_chunk,
@@ -66,7 +78,7 @@ def main():
     voltages = (
         args.array_size
         * args.channels_per_substream
-        * args.spectra_per_heap
+        * spectra_per_heap
         * args.heaps_per_fengine_per_chunk
         * args.passes
     )

--- a/src/katgpucbf/fsim/main.py
+++ b/src/katgpucbf/fsim/main.py
@@ -73,7 +73,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         "--array-size", type=int, default=80, help="Number of antennas in the simulated array [%(default)s]"
     )
     parser.add_argument(
-        "--channels", type=int, default=32768, help="Total number of channels in the simulated array [%(default)s]"
+        "--channels", type=int, default=32768, help="Total number of channels in the simulated stream [%(default)s]"
     )
     parser.add_argument(
         "--channels-per-substream", type=int, default=512, help="Number of channels sent by this fsim [%(default)s]"

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -245,7 +245,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         "--channels",
         type=int,
         required=True,
-        help="Total number of channels out of the F-Engine PFB.",
+        help="Total number of channels in the stream.",
     )
     parser.add_argument(
         "--channels-per-substream",


### PR DESCRIPTION
While the primary executables now use `--jones-per-batch` (or in the case of fgpu, a parameter to `--wideband/--narrowband`) and compute spectra-per-heap from it, some of the scratch scripts still used `--spectra-per-heap` directly with a default of 256. That means that unless it was overridden, we'd be benchmarking something different from what we run in production. The scripts now take `--jones-per-batch` with a default that matches the default of the primary executables.

I also had to address some bit-rot in compare_fengs.py.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1392.
