### PR TITLE
xbgpu: fix references to "correlation product payload"

### DIFF
--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -1043,7 +1043,7 @@ class XBEngine(DeviceServer):
     send_ibv
         Use ibverbs for output.
     send_packet_payload
-        Size for output packets (correlation product payload only, headers and padding are
+        Size for output packets (payload only; headers and padding are
         added to this).
     send_affinity
         CPU core for output-handling thread.

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -347,7 +347,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         "--send-packet-payload",
         type=int,
         default=DEFAULT_PACKET_PAYLOAD_BYTES,
-        help="Size in bytes for output packets (baseline correlation products payload only) [%(default)s]",
+        help="Size in bytes for output packets (payload only) [%(default)s]",
     )
     parser.add_argument("--send-ttl", type=int, default=DEFAULT_TTL, help="TTL for outgoing packets [%(default)s]")
     parser.add_argument("--send-ibv", action="store_true", help="Use ibverbs for output [no].")


### PR DESCRIPTION
It's now just "payload" since it applies to tied array channelised voltages too.

Closes NGC-1389.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
