### PR TITLE
Qual report: avoid archiving 3 copies of working dir

### DIFF
--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -101,19 +101,39 @@ pipeline {
          junit testResults: 'result.xml', skipPublishingChecks: true
 
          // Compress and publish json file so that at least we have that.
+         // 'includes' specifies which files from the current directory to archive;
+         // we only want the linked file itself
          sh 'xz --keep --force -T 0 report.json'
-         publishHTML(target: [keepAll: true, reportName: 'Qualification Test Intermediate JSON', reportDir: '', reportFiles: 'report.json.xz'])
+         publishHTML(target: [
+           keepAll: true,
+           reportName: 'Qualification Test Intermediate JSON',
+           reportDir: '',
+           reportFiles: 'report.json.xz',
+           includes: 'report.json.xz'
+         ])
 
          script {
            // Generate and publish test report
            COMMIT_ID = sh(script: 'qualification/report/generate_pdf.py report.json report.pdf -c', returnStdout: true)
            currentBuild.displayName = "#${BUILD_NUMBER} (${COMMIT_ID})"
          }
-         publishHTML(target: [keepAll: true, reportName: 'Qualification Test Report', reportDir: '', reportFiles: 'report.pdf'])
+         publishHTML(target: [
+           keepAll: true,
+           reportName: 'Qualification Test Report',
+           reportDir: '',
+           reportFiles: 'report.pdf',
+           includes: 'report.pdf'
+         ])
 
          // If that worked, we can probably generate and publish a procedure as well
          sh 'qualification/report/generate_pdf.py report.json procedure.pdf --generate-procedure-doc'
-         publishHTML(target: [keepAll: true, reportName: 'Qualification Test Procedure', reportDir: '', reportFiles: 'procedure.pdf'])
+         publishHTML(target: [
+           keepAll: true,
+           reportName: 'Qualification Test Procedure',
+           reportDir: '',
+           reportFiles: 'procedure.pdf',
+           includes: 'procedure.pdf'
+         ])
        }
      }
    }


### PR DESCRIPTION
The publishHTML call defaults to archiving the entire directory containing the file being linked. That ends up storing an order of magnitude more data than we actually want it to.

Closes NGC-1414.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report: check build 153
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
