### PR TITLE
Qualification: handle failed subarray products better

### DIFF
--- a/qualification/cbf.py
+++ b/qualification/cbf.py
@@ -351,8 +351,8 @@ class CBFCache:
         if self._cbf is not None and self._cbf.config == cbf_config:
             return self._cbf
 
-        await self._close_cbf()
         try:
+            await self._close_cbf()
             master_controller_client = await self._get_master_controller_client()
             product_name = self._pytestconfig.getini("product_name")
             try:


### PR DESCRIPTION
Fix a couple of bugs in handling subarray products that failed to configure (see individual commits).

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report: [report-3.pdf](https://github.com/user-attachments/files/16232443/report-3.pdf)
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-951.
