### PR TITLE
Qual: improve error message when .port sensor missing

### DIFF
--- a/qualification/cbf.py
+++ b/qualification/cbf.py
@@ -271,6 +271,8 @@ async def _report_cbf_config(
     interfaces = await get_task_details_multi(r"interfaces\.([^.]+)\.name", str)
     tasks: dict[str, TaskDict] = {}
     for task_name, hostname in hosts.items():
+        if task_name not in git_version_futures:
+            raise RuntimeError(f"could not get katcp port for {task_name}: possible DNS failure")
         task_interfaces = interfaces.get(task_name, {})
         tasks[task_name] = {
             "host": hostname,


### PR DESCRIPTION
This can happen if the product controller has a temporary DNS failure when resolving the hostname to populate the sensor. In this case, just fail.

Closes NGC-1395.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [ ] If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
