### PR TITLE
Make qualification work with pytest-dev/pytest-asyncio#871

### DIFF
--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -28,6 +28,7 @@ from collections.abc import AsyncGenerator, Generator
 
 import matplotlib.style
 import pytest
+import pytest_asyncio
 import pytest_check
 from katsdpservices import get_interface_address
 
@@ -176,14 +177,10 @@ def pytest_collection_modifyitems(session: pytest.Session, config: pytest.Config
         return tuple(ans)
 
     items.sort(key=key)
-
-
-# Need to redefine this from pytest-asyncio to have it at session scope
-@pytest.fixture(scope="session")
-def event_loop():  # noqa: D103
-    loop = asyncio.get_event_loop_policy().new_event_loop()
-    yield loop
-    loop.close()
+    scope_marker = pytest.mark.asyncio(loop_scope="session")
+    for item in items:
+        if pytest_asyncio.is_async_test(item):
+            item.add_marker(scope_marker, append=False)
 
 
 @pytest.fixture(scope="package")


### PR DESCRIPTION
This should not be merged until that PR is released and we switch to that version (probably 0.24).

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [ ] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [ ] If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [ ] Ensure copyright notices are present and up-to-date
- [ ] If qualification tests are changed: attach a sample qualification report
- [ ] If design has changed: ensure documentation is up to date
- [ ] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Partially addresses NGC-1181.
