### PR TITLE
Signal path documentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,8 @@
 version: 2
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.12"
 python:
   install:
     - method: pip

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,6 +9,7 @@ Welcome to katgpucbf's documentation!
 
    introduction
    maths
+   signal_path
    changelog
 
 .. toctree::

--- a/doc/maths.rst
+++ b/doc/maths.rst
@@ -1,5 +1,5 @@
-Mathematical background
-=======================
+Mathematical conventions
+========================
 
 This section is not intended as a tutorial for radio astronomy. It briefly
 summarises some key equations, with the intent of illustrating implementation
@@ -27,10 +27,6 @@ to have a phasor of
 
 where :math:`t` is time and :math:`z` is position. In particular, phase
 measured at a fixed position (an antenna) increases with time.
-
-Narrowband
-----------
-.. todo:: Document the down-conversion filter
 
 .. _math-delay:
 

--- a/doc/maths.rst
+++ b/doc/maths.rst
@@ -28,32 +28,6 @@ to have a phasor of
 where :math:`t` is time and :math:`z` is position. In particular, phase
 measured at a fixed position (an antenna) increases with time.
 
-Polyphase filter bank
----------------------
-A finite impulse response (FIR) filter is applied to the signal to condition
-the frequency-domain response. The filter is the product of a Hann window (to
-reduce spectral leakage) and a sinc (to broaden the peak to cover the
-frequency bin). Specifically, if there are :math:`n` output channels and
-:math:`t` taps in the polyphase filter bank, then the filter has length
-:math:`w = 2nt`, with coefficients
-
-.. math::
-
-   x_i = A\sin^2\left(\frac{\pi i}{w - 1}\right)
-         \operatorname{sinc}\left(w_c\cdot \frac{i + \tfrac 12 - nt}{2n}\right),
-
-where :math:`i` runs from 0 to :math:`w - 1`. Here :math:`A` is a
-normalisation factor which is chosen such that :math:`\sum_i x_i^2 = 1`. This
-ensures that given white Gaussian noise as input, the expected output power
-in a channel is the same as the expected input power in a digitised sample.
-Note that the input and output are treated as integers rather than as
-fixed-point values.
-
-The tuning parameter :math:`w_c` (specified by the :option:`!--w-cutoff`
-command-line option) scales the width of the response in the frequency domain.
-The default value is 1, which makes the width of the response (at -6dB)
-approximately equal the channel spacing.
-
 Correlation products
 --------------------
 Given a baseline (p, q) and time-varying channelised voltages :math:`e_p` and

--- a/doc/maths.rst
+++ b/doc/maths.rst
@@ -28,13 +28,6 @@ to have a phasor of
 where :math:`t` is time and :math:`z` is position. In particular, phase
 measured at a fixed position (an antenna) increases with time.
 
-Correlation products
---------------------
-Given a baseline (p, q) and time-varying channelised voltages :math:`e_p` and
-:math:`e_q`, the correlation product is the sum of :math:`e_p \overline{e_q}`
-over the accumulation period. This is computed in integer arithmetic and so is
-lossless except when saturation occurs.
-
 Narrowband
 ----------
 .. todo:: Document the down-conversion filter

--- a/doc/signal_path.rst
+++ b/doc/signal_path.rst
@@ -1,0 +1,104 @@
+Signal path overview
+====================
+
+This section gives a logical overview of the signal path. The actual
+implementation may split or combine steps for efficiency; refer to the
+:doc:`fgpu.design` and :doc:`xbgpu.design` sections for details.
+
+Edges in diagrams are annotated to indicate the data type. The following types
+are used:
+
+:samp:`i{N}`
+  Signed integer or fixed-point with :samp:`{N}` total bits
+:samp:`u{N}`
+  Unsigned integer or fixed-point with :samp:`{N}` bits
+:samp:`f{N}`
+  Floating-point with :samp:`{N}` bits, following IEEE 754-2019.
+:samp:`c{X}`
+  Complex values formed from real and imaginary components of type :samp:`{X}`
+  e.g., ``cf32`` is single-precision floating point complex.
+
+Channelisation
+--------------
+The figure below shows the signal path for the wide-band case. The dotted
+boxes and arrows represent control parameters that can be adjusted at
+runtime.
+
+Note that the input and output bit depths (shown as ``i10`` and ``ci8`` on the
+diagram) are configurable. Between unpacking and quantisation, all
+calculations are performed in single precision. Since the input has a bounded
+range, overflow is only possible at the quantisation step (which saturates).
+
+.. tikz:: Signal path for wide-band channelisation.
+   :libs: chains, positioning
+
+   \tikzset{
+     base/.style={minimum width=2.5cm, minimum height=1cm, align=center},
+     op/.style={draw, base},
+     control/.style={draw, base, rounded corners, dotted},
+     lbl/.style={font=\scriptsize},
+     every join/.style={draw,->},
+     >=latex,
+   }
+   \newcommand{\side}[2]{
+     \node[op, on chain, join=by {#2, edge label=f32}] (cdelay#1) {Coarse delay};
+     \node[op, on chain, join=by {#2, edge label=f32}] (pfb#1) {PFB};
+     \node[op, on chain, join=by {#2, edge label=cf32}] (eq#1) {Fine delay\\ Equalisation};
+     \node[op, on chain, join=by {#2, edge label=cf32}] (dither#1) {Dither};
+     \node[op, on chain, join=by {#2, edge label=cf32}] (quant#1) {Quantise};
+   }
+   \node[op] (receive) {Receive};
+   \begin{scope}[start chain=chainx going below]
+     \node[op, below left=of receive, on chain] (unpackx) {Unpack};
+     \side{x}{lbl, swap}
+   \end{scope}
+   \begin{scope}[start chain=chainy going below]
+     \node[op, below right=of receive, on chain] (unpacky) {Unpack};
+     \side{y}{lbl}
+   \end{scope}
+   \begin{scope}[start chain=sink going below]
+     \node[op, on chain, below right=of quantx] (pack) {Corner turn\\ Pack};
+     \node[op, on chain, join=by {lbl, edge label=ci8}] (transmit) {Transmit};
+   \end{scope}
+   \node[control, right=of pfbx] (delays) {Delays};
+   \node[control, below=of delays] (eq) {Eq coefficients};
+   \draw[->] (receive)
+     -| node[lbl, very near start, auto, swap] {V}
+        node[lbl, near end, auto, swap] {i10} (unpackx);
+   \draw[->] (receive)
+     -| node[lbl, very near start, auto] {H}
+        node[lbl, near end, auto] {i10} (unpacky);
+   \draw[->, dotted] (delays) to[lbl, auto, swap, edge label=i32] (cdelayx);
+   \draw[->, dotted] (delays) to[lbl, auto, swap, edge label=f32] (eqx);
+   \draw[->, dotted] (delays) to[lbl, auto, edge label=i32] (cdelayy);
+   \draw[->, dotted] (delays) to[lbl, auto, edge label=f32] (eqy);
+   \draw[->, dotted] (eq) to[lbl, auto, swap, edge label=cf32] (eqx);
+   \draw[->, dotted] (eq) to[lbl, auto, edge label=cf32] (eqy);
+   \draw[->] (quantx) |- node[lbl, auto, swap, near start] {ci8} (pack);
+   \draw[->] (quanty) |- node[lbl, auto, near start] {ci8} (pack);
+
+Polyphase filter bank
+^^^^^^^^^^^^^^^^^^^^^
+A finite impulse response (FIR) filter is applied to the signal to condition
+the frequency-domain response. The filter is the product of a Hann window (to
+reduce spectral leakage) and a sinc (to broaden the peak to cover the
+frequency bin). Specifically, if there are :math:`n` output channels and
+:math:`t` taps in the polyphase filter bank (PFB), then the filter has length
+:math:`w = 2nt`, with coefficients
+
+.. math::
+
+   x_i = A\sin^2\left(\frac{\pi i}{w - 1}\right)
+         \operatorname{sinc}\left(w_c\cdot \frac{i + \tfrac 12 - nt}{2n}\right),
+
+where :math:`i` runs from 0 to :math:`w - 1`. Here :math:`A` is a
+normalisation factor which is chosen such that :math:`\sum_i x_i^2 = 1`. This
+ensures that given white Gaussian noise as input, the expected output power
+in a channel is the same as the expected input power in a digitised sample.
+Note that the input and output are treated as integers rather than as
+fixed-point values.
+
+The tuning parameter :math:`w_c` (specified by the :option:`!--w-cutoff`
+command-line option) scales the width of the response in the frequency domain.
+The default value is 1, which makes the width of the response (at -6dB)
+approximately equal the channel spacing.

--- a/doc/signal_path.rst
+++ b/doc/signal_path.rst
@@ -63,10 +63,10 @@ The figure below shows the signal path for wide-band channelisation.
    \node[control, right=of pfbx] (delays) {Delays};
    \node[control, right=of eqx] (eq) {Eq coefficients};
    \draw[->] (receive)
-     -| node[lbl, very near start, auto, swap] {V}
+     -| node[lbl, very near start, auto, swap] {pol0}
         node[lbl, near end, auto, swap] {i10} (unpackx);
    \draw[->] (receive)
-     -| node[lbl, very near start, auto] {H}
+     -| node[lbl, very near start, auto] {pol1}
         node[lbl, near end, auto] {i10} (unpacky);
    \draw[->, dotted] (delays) to[lbl, auto, edge label'=i32] (cdelayx);
    \draw[->, dotted] (delays) to[lbl, auto, edge label=f32] (eqx);
@@ -208,10 +208,10 @@ The figure below shows the modified signal path.
    \node[control, right=of pfbx] (delays) {Delays};
    \node[control, right=of eqx] (eq) {Eq coefficients};
    \draw[->] (receive)
-     -| node[lbl, very near start, auto, swap] {V}
+     -| node[lbl, very near start, auto, swap] {pol0}
         node[lbl, near end, auto, swap] {i10} (unpackx);
    \draw[->] (receive)
-     -| node[lbl, very near start, auto] {H}
+     -| node[lbl, very near start, auto] {pol1}
         node[lbl, near end, auto] {i10} (unpacky);
    \draw[->, dotted] (delays) to[lbl, auto, edge label'=i32] (cdelayx);
    \draw[->, dotted] (delays) to[lbl, auto, edge label=f32] (eqx);
@@ -259,7 +259,7 @@ The figure below shows the signal path.
      every join/.style={draw,->},
      >=latex,
    }
-   \begin{scope}[start chain=going right]
+   \begin{scope}[start chain=going below]
      \node[op, on chain] {Receive};
      \node[op, on chain, join=by {lbl,edge label=ci8}] {Correlate\\ Accumulate};
      \node[op, on chain, join=by {lbl,edge label=ci64}] {Saturate};
@@ -286,17 +286,17 @@ during quantisation (which saturates).
      every join/.style={draw,->},
      >=latex,
    }
-   \begin{scope}[start chain=going right]
+   \begin{scope}[start chain=going below]
      \node[op, on chain] {Receive};
      \node[op, on chain, join=by {lbl,edge label=ci8}] (mult) {Taper/Scale\\ Delay};
      \node[op, on chain, join=by {lbl,edge label=cf32}] {Sum};
      \node[op, on chain, join=by {lbl,edge label=cf32}] {Dither};
      \node[op, on chain, join=by {lbl,edge label=cf32}] {Quantise};
      \node[op, on chain, join=by {lbl,edge label=ci8}] {Transmit};
-     \node[control, below left=of mult] (taper) {Tapering\\ coefficients};
-     \node[control, below=of mult] (gain) {Requantisation\\ gain};
+     \node[control, above right=of mult] (taper) {Tapering\\ coefficients};
+     \node[control, right=of mult] (gain) {Requantisation\\ gain};
      \node[control, below right=of mult] (delay) {Delays};
-     \draw[->, dotted] (taper) to[lbl, edge label=f32] (mult);
+     \draw[->, dotted] (taper) to[lbl, near start, edge label=f32] (mult);
      \draw[->, dotted] (gain) to[lbl, edge label=f32] (mult);
-     \draw[->, dotted] (delay) to[lbl, edge label'=f32] (mult);
+     \draw[->, dotted] (delay) to[lbl, near start, edge label'=f32] (mult);
    \end{scope}

--- a/doc/signal_path.rst
+++ b/doc/signal_path.rst
@@ -20,8 +20,8 @@ are used:
 Dotted boxes and arrows represent control parameters that can be adjusted at
 runtime.
 
-Channelisation
---------------
+Channelisation and delay correction
+-----------------------------------
 Note that the input and output bit depths (shown as ``i10`` and ``ci8`` on the
 diagram) are configurable. Between unpacking and quantisation, all
 calculations are performed in single precision. Since the input has a bounded

--- a/doc/xbgpu.design.rst
+++ b/doc/xbgpu.design.rst
@@ -1,4 +1,4 @@
-XB-engine design
+XB-Engine design
 ================
 
 Similar to the F-engine, the XB-engine supports receiving one set of input and


### PR DESCRIPTION
The built documentation can be seen at https://katgpucbf.readthedocs.io/en/ngc-1432-signal-path-docs/signal_path.html

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] (n/a) Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1432.
