### PR TITLE
fgpu: add a knob to allow dithering to be disabled

### DIFF
--- a/scratch/fgpu/benchmarks/compute_bench.py
+++ b/scratch/fgpu/benchmarks/compute_bench.py
@@ -38,6 +38,7 @@ def main():  # noqa: C901
     parser.add_argument("--send-sample-bits", type=int, default=8, choices=[4, 8])
     parser.add_argument("--passes", type=int, default=1000)
     parser.add_argument("--ddc-taps", type=int)  # Default is computed from decimation
+    parser.add_argument("--no-dither", dest="dither", action="store_false")
     parser.add_argument("--narrowband", action="store_true")
     parser.add_argument("--narrowband-decimation", type=int, default=8)
     parser.add_argument("--kernel", choices=["all", "ddc", "pfb_fir", "fft", "postproc"], default="all")
@@ -77,7 +78,13 @@ def main():  # noqa: C901
             spectra_samples = 2 * args.channels
             window = args.taps * spectra_samples
         template = ComputeTemplate(
-            context, args.taps, args.channels, args.dig_sample_bits, args.send_sample_bits, narrowband=narrowband_config
+            context,
+            args.taps,
+            args.channels,
+            args.dig_sample_bits,
+            args.send_sample_bits,
+            dither=args.dither,
+            narrowband=narrowband_config,
         )
         command_queue = context.create_tuning_command_queue()
         out_spectra = accel.roundup(args.send_chunk_jones // args.channels, spectra_per_heap)

--- a/scratch/fgpu/benchmarks/compute_bench.py
+++ b/scratch/fgpu/benchmarks/compute_bench.py
@@ -25,6 +25,7 @@ from katgpucbf import DEFAULT_JONES_PER_BATCH, DIG_SAMPLE_BITS
 from katgpucbf.fgpu.compute import ComputeTemplate, NarrowbandConfig
 from katgpucbf.fgpu.engine import generate_ddc_weights, generate_pfb_weights
 from katgpucbf.fgpu.main import DEFAULT_DDC_TAPS_RATIO
+from katgpucbf.utils import DitherType, parse_dither
 
 
 def main():  # noqa: C901
@@ -38,7 +39,7 @@ def main():  # noqa: C901
     parser.add_argument("--send-sample-bits", type=int, default=8, choices=[4, 8])
     parser.add_argument("--passes", type=int, default=1000)
     parser.add_argument("--ddc-taps", type=int)  # Default is computed from decimation
-    parser.add_argument("--no-dither", dest="dither", action="store_false")
+    parser.add_argument("--dither", type=parse_dither, default=DitherType.UNIFORM)
     parser.add_argument("--narrowband", action="store_true")
     parser.add_argument("--narrowband-decimation", type=int, default=8)
     parser.add_argument("--kernel", choices=["all", "ddc", "pfb_fir", "fft", "postproc"], default="all")

--- a/src/katgpucbf/fgpu/compute.py
+++ b/src/katgpucbf/fgpu/compute.py
@@ -28,6 +28,7 @@ from katsdpsigproc import accel, fft
 from katsdpsigproc.abc import AbstractCommandQueue, AbstractContext
 
 from .. import N_POLS
+from ..utils import DitherType
 from . import ddc, pfb, postproc
 
 
@@ -64,7 +65,7 @@ class ComputeTemplate:
     out_bits
         Number of bits per output real component.
     dither
-        Whether to add uniform dithering before quantisation.
+        Type of dithering to apply before quantisation.
     narrowband
         Configuration for narrowband operation. If ``None``, wideband is assumed.
     """
@@ -76,7 +77,7 @@ class ComputeTemplate:
         channels: int,
         dig_sample_bits: int,
         out_bits: int,
-        dither: bool,
+        dither: DitherType,
         narrowband: NarrowbandConfig | None,
     ) -> None:
         self.context = context

--- a/src/katgpucbf/fgpu/compute.py
+++ b/src/katgpucbf/fgpu/compute.py
@@ -63,6 +63,8 @@ class ComputeTemplate:
         Number of bits per digitiser sample.
     out_bits
         Number of bits per output real component.
+    dither
+        Whether to add uniform dithering before quantisation.
     narrowband
         Configuration for narrowband operation. If ``None``, wideband is assumed.
     """
@@ -74,6 +76,7 @@ class ComputeTemplate:
         channels: int,
         dig_sample_bits: int,
         out_bits: int,
+        dither: bool,
         narrowband: NarrowbandConfig | None,
     ) -> None:
         self.context = context
@@ -84,7 +87,7 @@ class ComputeTemplate:
         if narrowband is None:
             self.internal_channels = channels
             self.postproc = postproc.PostprocTemplate(
-                context, channels, self.unzip_factor, complex_pfb=False, out_bits=out_bits
+                context, channels, self.unzip_factor, complex_pfb=False, out_bits=out_bits, dither=dither
             )
             self.pfb_fir = pfb.PFBFIRTemplate(
                 context, taps, channels, dig_sample_bits, self.unzip_factor, n_pols=N_POLS
@@ -98,6 +101,7 @@ class ComputeTemplate:
                 self.unzip_factor,
                 complex_pfb=True,
                 out_bits=out_bits,
+                dither=dither,
                 out_channels=(channels // 2, 3 * channels // 2),
             )
             self.pfb_fir = pfb.PFBFIRTemplate(

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -494,6 +494,7 @@ class Pipeline:
             output.channels,
             engine.recv_layout.sample_bits,
             engine.send_sample_bits,
+            output.dither,
             narrowband=narrowband_config,
         )
         self._compute = template.instantiate(

--- a/src/katgpucbf/fgpu/output.py
+++ b/src/katgpucbf/fgpu/output.py
@@ -22,6 +22,8 @@ from typing import TYPE_CHECKING
 
 from katsdptelstate.endpoint import Endpoint
 
+from ..utils import DitherType
+
 
 @dataclass
 class Output(ABC):
@@ -33,7 +35,7 @@ class Output(ABC):
     taps: int
     w_cutoff: float
     dst: list[Endpoint]
-    dither: bool
+    dither: DitherType
 
     def __post_init__(self) -> None:
         if self.channels % len(self.dst) != 0:

--- a/src/katgpucbf/fgpu/output.py
+++ b/src/katgpucbf/fgpu/output.py
@@ -33,6 +33,7 @@ class Output(ABC):
     taps: int
     w_cutoff: float
     dst: list[Endpoint]
+    dither: bool
 
     def __post_init__(self) -> None:
         if self.channels % len(self.dst) != 0:

--- a/src/katgpucbf/fgpu/postproc.py
+++ b/src/katgpucbf/fgpu/postproc.py
@@ -51,6 +51,8 @@ class PostprocTemplate:
     out_bits
         Bits per real/imaginary value. Only 4 or 8 are currently supported.
         When 4, the real part is in the most-significant bits.
+    dither
+        Whether to add uniform dithering before quantisation.
     out_channels
         Range of channels to write to the output (defaults to all).
     """
@@ -63,6 +65,7 @@ class PostprocTemplate:
         *,
         complex_pfb: bool,
         out_bits: int,
+        dither: bool,
         out_channels: tuple[int, int] | None = None,
     ) -> None:
         self.block = 16
@@ -71,6 +74,7 @@ class PostprocTemplate:
         self.channels = channels
         self.unzip_factor = unzip_factor
         self.out_bits = out_bits
+        self.dither = dither
         self.groups_x = accel.divup(channels // unzip_factor // 2 + 1, self.block * self.vtx)
         if channels <= 0 or channels & (channels - 1):
             raise ValueError("channels must be a power of 2")
@@ -101,6 +105,7 @@ class PostprocTemplate:
                     "out_bits": self.out_bits,
                     "unzip_factor": unzip_factor,
                     "complex_pfb": complex_pfb,
+                    "dither": dither,
                 },
                 extra_dirs=[str(resource_dir), str(resource_dir.parent)],
             )
@@ -150,7 +155,8 @@ class Postproc(accel.Operation):
         Per-channel gain (one value per pol).
     **rand_states** : implementation-defined
         Random states. This slot is set up by the constructor and should
-        normally not need to be touched.
+        normally not need to be touched. It is only present if dithering
+        is enabled.
 
     Parameters
     ----------
@@ -206,15 +212,16 @@ class Postproc(accel.Operation):
         self.slots["fine_delay"] = accel.IOSlot((spectra, pols), np.float32)
         self.slots["phase"] = accel.IOSlot((spectra, pols), np.float32)
         self.slots["gains"] = accel.IOSlot((n_out_channels, pols), np.complex64)
-        # This could be seen as multi-dimensional, but we flatten it to 1D as an
-        # easy way to guarantee that it is not padded.
-        rand_states_shape = (template.groups_x * self._groups_y * template.block * template.block,)
-        self.slots["rand_states"] = accel.IOSlot(rand_states_shape, RAND_STATE_DTYPE)
-        builder = RandomStateBuilder(command_queue.context)
-        rand_states = builder.make_states(
-            command_queue, rand_states_shape, seed=seed, sequence_first=sequence_first, sequence_step=sequence_step
-        )
-        self.bind(rand_states=rand_states)
+        if template.dither:
+            # This could be seen as multi-dimensional, but we flatten it to 1D as an
+            # easy way to guarantee that it is not padded.
+            rand_states_shape = (template.groups_x * self._groups_y * template.block * template.block,)
+            self.slots["rand_states"] = accel.IOSlot(rand_states_shape, RAND_STATE_DTYPE)
+            builder = RandomStateBuilder(command_queue.context)
+            rand_states = builder.make_states(
+                command_queue, rand_states_shape, seed=seed, sequence_first=sequence_first, sequence_step=sequence_step
+            )
+            self.bind(rand_states=rand_states)
 
     def _run(self) -> None:
         out = self.buffer("out")
@@ -230,7 +237,9 @@ class Postproc(accel.Operation):
                 self.buffer("fine_delay").buffer,
                 self.buffer("phase").buffer,
                 self.buffer("gains").buffer,
-                self.buffer("rand_states").buffer,
+            ]
+            + ([self.buffer("rand_states").buffer] if self.template.dither else [])
+            + [
                 np.int32(out.padded_shape[1] * out.padded_shape[2]),  # out_stride_z
                 np.int32(out.padded_shape[2]),  # out_stride
                 np.int32(np.prod(in_.padded_shape[1:])),  # in_stride

--- a/src/katgpucbf/utils.py
+++ b/src/katgpucbf/utils.py
@@ -17,6 +17,7 @@
 """A collection of utility functions for katgpucbf."""
 
 import asyncio
+import enum
 import gc
 import ipaddress
 import logging
@@ -49,6 +50,13 @@ TIME_MAXERROR_WARN = 10e-3
 TIME_MAXERROR_ERROR = 0.1
 
 logger = logging.getLogger(__name__)
+
+
+class DitherType(enum.Enum):
+    """Type of dithering to apply prior to quantisation."""
+
+    NONE = 0  # Don't change this value: we rely on it being falsey
+    UNIFORM = 1
 
 
 def add_signal_handlers(server: aiokatcp.DeviceServer) -> None:
@@ -94,6 +102,15 @@ def add_gc_stats() -> None:
             gc_time.labels(str(info["generation"])).observe(elapsed)
 
     gc.callbacks.append(callback)
+
+
+def parse_dither(value: str) -> DitherType:
+    """Parse a string into a dither type."""
+    table = {member.name.lower(): member for member in DitherType}
+    try:
+        return table[value]
+    except KeyError:
+        raise ValueError(f"Invalid dither value {value} (valid values are {list(table.keys())})") from None
 
 
 def parse_source(value: str) -> list[tuple[str, int]] | str:

--- a/test/fgpu/test_compute.py
+++ b/test/fgpu/test_compute.py
@@ -25,7 +25,8 @@ pytestmark = [pytest.mark.cuda_only]
 
 
 @pytest.mark.parametrize("mode", ["wideband", "narrowband"])
-def test_compute(context: AbstractContext, command_queue: AbstractCommandQueue, mode: str) -> None:
+@pytest.mark.parametrize("dither", [True, False])
+def test_compute(context: AbstractContext, command_queue: AbstractCommandQueue, mode: str, dither: bool) -> None:
     """Test creation and running of :class:`Compute`.
 
     .. todo:: This isn't a proper test, just a smoke test.
@@ -52,7 +53,7 @@ def test_compute(context: AbstractContext, command_queue: AbstractCommandQueue, 
         )
         spectra = nb_spectra
         internal_channels = 2 * channels
-    template = compute.ComputeTemplate(context, pfb_taps, channels, dig_sample_bits, out_bits, narrowband)
+    template = compute.ComputeTemplate(context, pfb_taps, channels, dig_sample_bits, out_bits, dither, narrowband)
     # The sample count is the minimum that will produce the required number of
     # output spectra for narrowband mode. For wideband there is more headroom.
     fn = template.instantiate(

--- a/test/fgpu/test_compute.py
+++ b/test/fgpu/test_compute.py
@@ -20,13 +20,14 @@ from katsdpsigproc.abc import AbstractCommandQueue, AbstractContext
 
 from katgpucbf.fgpu import compute
 from katgpucbf.fgpu.engine import generate_ddc_weights
+from katgpucbf.utils import DitherType
 
 pytestmark = [pytest.mark.cuda_only]
 
 
 @pytest.mark.parametrize("mode", ["wideband", "narrowband"])
-@pytest.mark.parametrize("dither", [True, False])
-def test_compute(context: AbstractContext, command_queue: AbstractCommandQueue, mode: str, dither: bool) -> None:
+@pytest.mark.parametrize("dither", DitherType)
+def test_compute(context: AbstractContext, command_queue: AbstractCommandQueue, mode: str, dither: DitherType) -> None:
     """Test creation and running of :class:`Compute`.
 
     .. todo:: This isn't a proper test, just a smoke test.

--- a/test/fgpu/test_main.py
+++ b/test/fgpu/test_main.py
@@ -29,6 +29,7 @@ from katgpucbf.fgpu.main import (
     parse_narrowband,
 )
 from katgpucbf.fgpu.output import NarrowbandOutput, WidebandOutput
+from katgpucbf.utils import DitherType
 
 
 class TestParseNarrowband:
@@ -44,7 +45,7 @@ class TestParseNarrowband:
             centre_frequency=400e6,
             decimation=8,
             dst=[Endpoint("239.1.2.3", 7148), Endpoint("239.1.2.4", 7148)],
-            dither=True,
+            dither=DitherType.UNIFORM,
             weight_pass=DEFAULT_WEIGHT_PASS,
             taps=DEFAULT_TAPS,
             ddc_taps=DEFAULT_DDC_TAPS_RATIO * 8,
@@ -56,7 +57,7 @@ class TestParseNarrowband:
         """Test with all valid arguments."""
         assert parse_narrowband(
             "name=foo,channels=1024,centre_frequency=400e6,decimation=8,taps=8,w_cutoff=0.5,"
-            "dst=239.1.2.3+1:7148,dither=false,ddc_taps=128,weight_pass=0.3,jones_per_batch=262144"
+            "dst=239.1.2.3+1:7148,dither=none,ddc_taps=128,weight_pass=0.3,jones_per_batch=262144"
         ) == NarrowbandOutput(
             name="foo",
             channels=1024,
@@ -65,7 +66,7 @@ class TestParseNarrowband:
             taps=8,
             w_cutoff=0.5,
             dst=[Endpoint("239.1.2.3", 7148), Endpoint("239.1.2.4", 7148)],
-            dither=False,
+            dither=DitherType.NONE,
             ddc_taps=128,
             weight_pass=0.3,
             jones_per_batch=262144,
@@ -91,13 +92,6 @@ class TestParseNarrowband:
         with pytest.raises(ValueError, match="--narrowband: channels specified twice"):
             parse_narrowband("name=foo,channels=8,channels=9,centre_frequency=400e6,decimation=8,dst=239.1.2.3+1:7148")
 
-    def test_bad_bool(self) -> None:
-        """Test setting a boolean to something other than true or false."""
-        with pytest.raises(ValueError, match="dither must be set to 'true' or 'false'"):
-            parse_narrowband(
-                "dither=spam,name=foo,channels=1024,centre_frequency=400e6,decimation=8,dst=239.1.2.3+1:7148"
-            )
-
 
 class TestParseArgs:
     """Test :func:`.katgpucbf.fgpu.main.parse_args`."""
@@ -110,7 +104,7 @@ class TestParseArgs:
             "--adc-sample-rate=1712000000.0",
             "--sync-time=0",
             (
-                "--wideband=name=wideband,dst=239.0.3.0+1:7148,dither=false,"
+                "--wideband=name=wideband,dst=239.0.3.0+1:7148,dither=none,"
                 "channels=1024,taps=64,w_cutoff=0.9,jones_per_batch=262144"
             ),
             (
@@ -126,7 +120,7 @@ class TestParseArgs:
             WidebandOutput(
                 name="wideband",
                 dst=[Endpoint("239.0.3.0", 7148), Endpoint("239.0.3.1", 7148)],
-                dither=False,
+                dither=DitherType.NONE,
                 channels=1024,
                 taps=64,
                 w_cutoff=0.9,
@@ -135,7 +129,7 @@ class TestParseArgs:
             NarrowbandOutput(
                 name="nb0",
                 dst=[Endpoint("239.1.0.0", 7148), Endpoint("239.1.0.1", 7148)],
-                dither=True,
+                dither=DitherType.UNIFORM,
                 channels=32768,
                 centre_frequency=400e6,
                 decimation=8,
@@ -148,7 +142,7 @@ class TestParseArgs:
             NarrowbandOutput(
                 name="nb1",
                 dst=[Endpoint("239.2.0.0", 7149)],
-                dither=True,
+                dither=DitherType.UNIFORM,
                 channels=8192,
                 centre_frequency=300e6,
                 decimation=16,

--- a/test/fgpu/test_postproc.py
+++ b/test/fgpu/test_postproc.py
@@ -25,6 +25,7 @@ from numpy.typing import DTypeLike
 
 from katgpucbf import N_POLS
 from katgpucbf.fgpu import postproc
+from katgpucbf.utils import DitherType
 
 from .. import unpack_complex
 
@@ -142,7 +143,7 @@ def _make_complex(func: Callable[[], np.ndarray], dtype: DTypeLike = np.complex6
 @pytest.mark.parametrize("complex_pfb", [False, True])
 @pytest.mark.parametrize("out_channels", [(0, 4096), (1024, 3072), (123, 3456)])
 @pytest.mark.parametrize("out_bits", [4, 8])
-@pytest.mark.parametrize("dither", [True, False])
+@pytest.mark.parametrize("dither", DitherType)
 def test_postproc(
     context: AbstractContext,
     command_queue: AbstractCommandQueue,
@@ -150,7 +151,7 @@ def test_postproc(
     complex_pfb: bool,
     out_channels: tuple[int, int],
     out_bits: int,
-    dither: bool,
+    dither: DitherType,
 ) -> None:
     """Test GPU Postproc for numerical correctness."""
     channels = 4096

--- a/test/fgpu/test_postproc.py
+++ b/test/fgpu/test_postproc.py
@@ -142,6 +142,7 @@ def _make_complex(func: Callable[[], np.ndarray], dtype: DTypeLike = np.complex6
 @pytest.mark.parametrize("complex_pfb", [False, True])
 @pytest.mark.parametrize("out_channels", [(0, 4096), (1024, 3072), (123, 3456)])
 @pytest.mark.parametrize("out_bits", [4, 8])
+@pytest.mark.parametrize("dither", [True, False])
 def test_postproc(
     context: AbstractContext,
     command_queue: AbstractCommandQueue,
@@ -149,6 +150,7 @@ def test_postproc(
     complex_pfb: bool,
     out_channels: tuple[int, int],
     out_bits: int,
+    dither: bool,
 ) -> None:
     """Test GPU Postproc for numerical correctness."""
     channels = 4096
@@ -176,7 +178,13 @@ def test_postproc(
     )
 
     template = postproc.PostprocTemplate(
-        context, channels, unzip_factor, complex_pfb=complex_pfb, out_channels=out_channels, out_bits=out_bits
+        context,
+        channels,
+        unzip_factor,
+        complex_pfb=complex_pfb,
+        out_channels=out_channels,
+        out_bits=out_bits,
+        dither=dither,
     )
     fn = template.instantiate(command_queue, spectra, spectra_per_heap_out, seed=123, sequence_first=456)
     fn.ensure_all_bound()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -27,7 +27,14 @@ import async_solipsism
 import pytest
 from aiokatcp import DeviceStatus
 
-from katgpucbf.utils import DeviceStatusSensor, TimeConverter, TimeoutSensorStatusObserver, comma_split
+from katgpucbf.utils import (
+    DeviceStatusSensor,
+    DitherType,
+    TimeConverter,
+    TimeoutSensorStatusObserver,
+    comma_split,
+    parse_dither,
+)
 
 
 class TestDeviceStatusSensor:
@@ -203,3 +210,22 @@ class TestCommaSplit:
         assert splitter("3") == [3, 3]
         with pytest.raises(ValueError, match="Expected 2 comma-separated fields, received 3"):
             splitter("3,5,7")
+
+
+class TestParseDither:
+    @pytest.mark.parametrize(
+        "input, output",
+        [("none", DitherType.NONE), ("uniform", DitherType.UNIFORM)],
+    )
+    def test_success(self, input: str, output: DitherType) -> None:
+        """Test with valid inputs."""
+        assert parse_dither(input) == output
+
+    @pytest.mark.parametrize("input", ["", "false", "UnIFoRM", "NONE"])
+    def test_invalid(self, input: str) -> None:
+        """Test with invalid inputs."""
+        with pytest.raises(
+            ValueError,
+            match=rf"Invalid dither value {input} \(valid values are \['none', 'uniform'\]\)",
+        ):
+            parse_dither(input)


### PR DESCRIPTION
The --wideband and --narrowband options can now be passed dither=false to disable dithering.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Contributes to NGC-1429.
