### PR TITLE
Reduce xbgpu startup GPU mem usage

### DIFF
--- a/src/katgpucbf/xbgpu/correlation.py
+++ b/src/katgpucbf/xbgpu/correlation.py
@@ -292,7 +292,7 @@ class Correlation(accel.Operation):
 
     def zero_visibilities(self) -> None:
         """Zero all the values in the internal buffer."""
-        self.ensure_all_bound()
+        self.ensure_bound("mid_visibilities")
         self.buffer("mid_visibilities").zero(self.command_queue)
 
     @staticmethod


### PR DESCRIPTION
It calls ensure_all_bound (via zero_visibilities) on the Correlation op early in gpu_proc_loop, before binding any input item. This causes a temporary input buffer to be created, which will subsequently be garbage collected.

Fix by having zero_visibilities only ensure_bound the required buffer.

Possibly contributes to NGC-938.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
