### PR TITLE
Qualification: pin threads to cores

### DIFF
--- a/doc/qualification.rst
+++ b/doc/qualification.rst
@@ -51,7 +51,8 @@ Configuration
 You will need to create a :file:`qualification/pytest.ini` file.
 It is specific to your test environment, so do not commit it to
 git. You'll need to set it up only once per machine that you're deploying on,
-and it'll look something like this:
+and it'll look something like this (but refer to
+:file:`qualification/pytest-jenkins.ini` for an up-to-date example):
 
 .. code:: ini
 

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -477,7 +477,7 @@ class CoreAllocator:
 
     It is initialised with a list of cores (from pytest config), with earlier
     entries considered better than later ones. Cores are allocated in this
-    order. There is no mechanism to return cores; simplify create a new
+    order. There is no mechanism to return cores; simply create a new
     allocator to start fresh.
     """
 

--- a/qualification/pytest-jenkins.ini
+++ b/qualification/pytest-jenkins.ini
@@ -8,7 +8,7 @@ product_name = jenkins_qualification_cbf
 interface = enp193s0np0
 interface_gbps = 150
 use_ibv = true
-# This core ordering distributes load across the CCDs
+# This core ordering distributes load across the CCDs of an Epyc 7313P
 cores = 0 4 8 12 1 5 9 13 2 6 10 14 3 7 11 15
 log_cli = true
 log_cli_level = info

--- a/qualification/pytest-jenkins.ini
+++ b/qualification/pytest-jenkins.ini
@@ -8,6 +8,8 @@ product_name = jenkins_qualification_cbf
 interface = enp193s0np0
 interface_gbps = 150
 use_ibv = true
+# This core ordering distributes load across the CCDs
+cores = 0 4 8 12 1 5 9 13 2 6 10 14 3 7 11 15
 log_cli = true
 log_cli_level = info
 log_cli_format = %(asctime)s.%(msecs)03d  %(levelname)-8s %(name)s:%(filename)s:%(lineno)d %(message)s

--- a/qualification/recv.py
+++ b/qualification/recv.py
@@ -275,7 +275,9 @@ class XBReceiver:
 class BaselineCorrelationProductsReceiver(XBReceiver):
     """Wrap a baseline-correlation-products stream with helper functions."""
 
-    def __init__(self, cbf: CBFRemoteControl, stream_name: str, interface_address: str, use_ibv: bool = False) -> None:
+    def __init__(
+        self, cbf: CBFRemoteControl, stream_name: str, core: int, interface_address: str, use_ibv: bool = False
+    ) -> None:
         super().__init__(cbf, [stream_name])
 
         # Fill in extra sensors specific to baseline-correlation-products
@@ -289,6 +291,7 @@ class BaselineCorrelationProductsReceiver(XBReceiver):
         self.stream = create_baseline_correlation_product_receive_stream(
             interface_address,
             multicast_endpoints=self.multicast_endpoints[0],
+            core=core,
             n_bls=self.n_bls,
             n_chans=self.n_chans,
             n_chans_per_substream=self.n_chans_per_substream,
@@ -321,7 +324,12 @@ class TiedArrayChannelisedVoltageReceiver(XBReceiver):
     """Wrap a tied-array-channelised-voltage stream with helper functions."""
 
     def __init__(
-        self, cbf: CBFRemoteControl, stream_names: Sequence[str], interface_address: str, use_ibv: bool = False
+        self,
+        cbf: CBFRemoteControl,
+        stream_names: Sequence[str],
+        cores: Sequence[int],
+        interface_address: str,
+        use_ibv: bool = False,
     ) -> None:
         super().__init__(cbf, stream_names)
 
@@ -335,6 +343,7 @@ class TiedArrayChannelisedVoltageReceiver(XBReceiver):
         self.stream = create_tied_array_channelised_voltage_receive_stream(
             interface_address,
             multicast_endpoints=self.multicast_endpoints,
+            cores=cores,
             n_chans=self.n_chans,
             n_chans_per_substream=self.n_chans_per_substream,
             n_bits_per_sample=self.n_bits_per_sample,
@@ -347,7 +356,8 @@ class TiedArrayChannelisedVoltageReceiver(XBReceiver):
 
 def _create_receive_stream_group(
     interface_address: str,
-    multicast_endpoints: list[list[tuple[str, int]]],
+    multicast_endpoints: Sequence[list[tuple[str, int]]],
+    cores: Sequence[int],
     use_ibv: bool,
     stream_config: spead2.recv.StreamConfig,
     max_chunks: int,
@@ -364,6 +374,8 @@ def _create_receive_stream_group(
     multicast_endpoints
         List of list of (group, port) pairs. Each list corresponds to a single
         stream.
+    cores
+        CPU cores to bind to, of the same length as `multicast_endpoints`.
     use_ibv
         If true, use ibverbs.
     stream_config
@@ -398,7 +410,7 @@ def _create_receive_stream_group(
 
     # Needed for placing the individual heaps within the chunk.
     items = [FREQUENCY_ID, TIMESTAMP_ID, BEAM_ANTS_ID, spead2.HEAP_LENGTH_ID]
-    for i, endpoints in enumerate(multicast_endpoints):
+    for i, (endpoints, core) in enumerate(zip(multicast_endpoints, cores)):
         user_data = np.array([i], np.int64)
         chunk_stream_config = spead2.recv.ChunkStreamConfig(
             items=items,
@@ -410,11 +422,11 @@ def _create_receive_stream_group(
                 user_data=user_data.ctypes.data_as(ctypes.c_void_p),
             ),
         )
-        stream = group.emplace_back(spead2.ThreadPool(), stream_config, chunk_stream_config)
+        stream = group.emplace_back(spead2.ThreadPool(1, [core]), stream_config, chunk_stream_config)
 
         if use_ibv:
             config = spead2.recv.UdpIbvConfig(
-                endpoints=endpoints, interface_address=interface_address, buffer_size=64 * 1024 * 1024, comp_vector=-1
+                endpoints=endpoints, interface_address=interface_address, buffer_size=64 * 1024 * 1024, comp_vector=core
             )
             stream.add_udp_ibv_reader(config)
         else:
@@ -429,6 +441,7 @@ def _create_receive_stream_group(
 def create_baseline_correlation_product_receive_stream(
     interface_address: str,
     multicast_endpoints: list[tuple[str, int]],
+    core: int,
     n_bls: int,
     n_chans: int,
     n_chans_per_substream: int,
@@ -469,6 +482,7 @@ def create_baseline_correlation_product_receive_stream(
     return _create_receive_stream_group(
         interface_address,
         [multicast_endpoints],
+        [core],
         use_ibv,
         stream_config,
         max_chunks,
@@ -484,7 +498,8 @@ def create_baseline_correlation_product_receive_stream(
 
 def create_tied_array_channelised_voltage_receive_stream(
     interface_address: str,
-    multicast_endpoints: list[list[tuple[str, int]]],
+    multicast_endpoints: Sequence[list[tuple[str, int]]],
+    cores: Sequence[int],
     n_chans: int,
     n_chans_per_substream: int,
     n_bits_per_sample: int,
@@ -531,6 +546,7 @@ def create_tied_array_channelised_voltage_receive_stream(
     return _create_receive_stream_group(
         interface_address,
         multicast_endpoints,
+        cores,
         use_ibv,
         stream_config,
         max_chunks,


### PR DESCRIPTION
This should make the performance of qualification tests a little more predictable by always running the same tasks on the same cores.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Possibly helps with NGC-938.
