### PR TITLE
Add dither option to xbgpu

### DIFF
--- a/scratch/fgpu/benchmarks/compute_bench.py
+++ b/scratch/fgpu/benchmarks/compute_bench.py
@@ -39,7 +39,7 @@ def main():  # noqa: C901
     parser.add_argument("--send-sample-bits", type=int, default=8, choices=[4, 8])
     parser.add_argument("--passes", type=int, default=1000)
     parser.add_argument("--ddc-taps", type=int)  # Default is computed from decimation
-    parser.add_argument("--dither", type=parse_dither, default=DitherType.UNIFORM)
+    parser.add_argument("--dither", type=parse_dither, default=DitherType.DEFAULT)
     parser.add_argument("--narrowband", action="store_true")
     parser.add_argument("--narrowband-decimation", type=int, default=8)
     parser.add_argument("--kernel", choices=["all", "ddc", "pfb_fir", "fft", "postproc"], default="all")

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -133,7 +133,7 @@ def _parse_stream(value: str, kws: _OD, field_callback: Callable[[_OD, str, str]
             case _:
                 raise ValueError(f"missing '=' in {part}")
     # ignore due to https://github.com/python/mypy/issues/17674
-    kws.setdefault("dither", DitherType.UNIFORM)  # type: ignore
+    kws.setdefault("dither", DitherType.DEFAULT)  # type: ignore
     for key in ["name", "channels", "dst"]:
         if key not in kws:
             raise ValueError(f"{key} is missing")

--- a/src/katgpucbf/fgpu/postproc.py
+++ b/src/katgpucbf/fgpu/postproc.py
@@ -172,7 +172,8 @@ class Postproc(accel.Operation):
     spectra_per_heap: int
         Number of spectra to send out per heap.
     seed, sequence_first, sequence_step
-        See :class:`.RandomStateBuilder`.
+        See :class:`.RandomStateBuilder`. These are ignored if the template
+        disables dithering.
     """
 
     def __init__(

--- a/src/katgpucbf/utils.py
+++ b/src/katgpucbf/utils.py
@@ -57,6 +57,7 @@ class DitherType(enum.Enum):
 
     NONE = 0  # Don't change this value: we rely on it being falsey
     UNIFORM = 1
+    DEFAULT = 1  # Alias used to determine default when none is specified
 
 
 def add_signal_handlers(server: aiokatcp.DeviceServer) -> None:
@@ -106,6 +107,7 @@ def add_gc_stats() -> None:
 
 def parse_dither(value: str) -> DitherType:
     """Parse a string into a dither type."""
+    # Note: this allows only the non-aliases, so excludes DEFAULT
     table = {member.name.lower(): member for member in DitherType}
     try:
         return table[value]

--- a/src/katgpucbf/xbgpu/beamform.py
+++ b/src/katgpucbf/xbgpu/beamform.py
@@ -17,6 +17,7 @@
 """Implement the calculations for beamforming."""
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 from importlib import resources
 
 import numpy as np
@@ -25,6 +26,28 @@ from katsdpsigproc.abc import AbstractCommandQueue, AbstractContext
 
 from .. import COMPLEX, N_POLS
 from ..curand_helpers import RAND_STATE_DTYPE, RandomStateBuilder
+from ..utils import DitherType
+
+
+@dataclass
+class Beam:
+    """Compile-time parameters for a single-polarisation beam.
+
+    Attributes
+    ----------
+    pol
+        Either 0 or 1, to indicate which input polarisation to use in the beam.
+    dither
+        The type of dithering to apply before quantisation.
+    """
+
+    pol: int
+    dither: DitherType
+
+    def __post_init__(self) -> None:
+        assert self.pol in {0, 1}
+        # These are the only implemented types so far
+        assert self.dither in {DitherType.NONE, DitherType.UNIFORM}
 
 
 class BeamformTemplate:
@@ -34,18 +57,20 @@ class BeamformTemplate:
     ----------
     context
         The GPU context that we'll operate in.
-    beam_pols
-        One entry per single-polarisation output beam. Each entry is either
-        0 or 1, to indicate which input polarisation to use in the beam.
+    beams
+        One entry per single-polarisation output beam.
     n_spectra_per_batch
         Number of samples in time axis for each batch (fine time dimension)
         - see :class:`Beamform`.
+    dither
+        One entry per single-polarisation output beam. Each entry indicates
+        the type of dithering to apply before quantisation.
     """
 
-    def __init__(self, context: AbstractContext, beam_pols: Sequence[int], n_spectra_per_batch: int) -> None:
+    def __init__(self, context: AbstractContext, beams: Sequence[Beam], n_spectra_per_batch: int) -> None:
         # TODO: tune these.
         self.block_spectra = min(128, n_spectra_per_batch)
-        self.beam_pols = beam_pols
+        self.beams = beams
         self.n_spectra_per_batch = n_spectra_per_batch
         with resources.as_file(resources.files(__package__)) as resource_dir:
             program = accel.build(
@@ -53,7 +78,8 @@ class BeamformTemplate:
                 "kernels/beamform.mako",
                 {
                     "block_spectra": self.block_spectra,
-                    "beam_pols": self.beam_pols,
+                    "beams": beams,
+                    "DitherType": DitherType,
                 },
                 extra_dirs=[str(resource_dir), str(resource_dir.parent)],
             )
@@ -101,7 +127,8 @@ class Beamform(accel.Operation):
         in the data; any such rotation needs to be baked into **weights**.
     **rand_states** : n_batches × n_channels_per_substream × n_spectra_per_batch, curandStateXORWOW_t (packed)
         Independent random states for generating dither values. This is set
-        up by the constructor and should not normally need to be touched.
+        up by the constructor and should not normally need to be touched. It
+        is only present if dithering is enabled on at least one beam.
 
     Parameters
     ----------
@@ -116,7 +143,8 @@ class Beamform(accel.Operation):
     n_channels_per_substream
         Number of frequency channels
     seed, sequence_first, sequence_step
-        See :class:`.RandomStateBuilder`.
+        See :class:`.RandomStateBuilder`. These are ignored if the template
+        disables dithering.
     """
 
     def __init__(
@@ -134,7 +162,7 @@ class Beamform(accel.Operation):
         self.template = template
         pol_dim = accel.Dimension(N_POLS, exact=True)
         complex_dim = accel.Dimension(COMPLEX, exact=True)
-        n_beams = len(template.beam_pols)
+        n_beams = len(template.beams)
         n_spectra_per_batch = template.n_spectra_per_batch
         builder = RandomStateBuilder(command_queue.context)
         self.slots["in"] = accel.IOSlot(
@@ -147,22 +175,27 @@ class Beamform(accel.Operation):
         weights_dims = (n_ants, accel.Dimension(n_beams, exact=True))
         self.slots["weights"] = accel.IOSlot(weights_dims, np.complex64)
         self.slots["delays"] = accel.IOSlot(weights_dims, np.float32)
-        self.slots["rand_states"] = accel.IOSlot(
-            (
-                accel.Dimension(n_batches, exact=True),
-                accel.Dimension(n_channels_per_substream, exact=True),
-                accel.Dimension(n_spectra_per_batch, exact=True),
-            ),
-            RAND_STATE_DTYPE,
-        )
-        rand_states = builder.make_states(
-            command_queue,
-            (n_batches, n_channels_per_substream, n_spectra_per_batch),
-            seed=seed,
-            sequence_first=sequence_first,
-            sequence_step=sequence_step,
-        )
-        self.bind(rand_states=rand_states)
+        if self._dither_enabled:
+            self.slots["rand_states"] = accel.IOSlot(
+                (
+                    accel.Dimension(n_batches, exact=True),
+                    accel.Dimension(n_channels_per_substream, exact=True),
+                    accel.Dimension(n_spectra_per_batch, exact=True),
+                ),
+                RAND_STATE_DTYPE,
+            )
+            rand_states = builder.make_states(
+                command_queue,
+                (n_batches, n_channels_per_substream, n_spectra_per_batch),
+                seed=seed,
+                sequence_first=sequence_first,
+                sequence_step=sequence_step,
+            )
+            self.bind(rand_states=rand_states)
+
+    @property
+    def _dither_enabled(self) -> bool:
+        return any(beam.dither != DitherType.NONE for beam in self.template.beams)
 
     def _run(self) -> None:
         in_buffer = self.buffer("in")
@@ -175,7 +208,9 @@ class Beamform(accel.Operation):
                 in_buffer.buffer,
                 self.buffer("weights").buffer,
                 self.buffer("delays").buffer,
-                self.buffer("rand_states").buffer,
+            ]
+            + ([self.buffer("rand_states").buffer] if self._dither_enabled else [])
+            + [
                 np.int32(out_buffer.padded_shape[3]),
                 np.int32(out_buffer.padded_shape[2] * out_buffer.padded_shape[3]),
                 np.int32(out_buffer.padded_shape[1] * out_buffer.padded_shape[2] * out_buffer.padded_shape[3]),

--- a/src/katgpucbf/xbgpu/beamform.py
+++ b/src/katgpucbf/xbgpu/beamform.py
@@ -31,17 +31,11 @@ from ..utils import DitherType
 
 @dataclass
 class Beam:
-    """Compile-time parameters for a single-polarisation beam.
+    """Compile-time parameters for a single-polarisation beam."""
 
-    Attributes
-    ----------
-    pol
-        Either 0 or 1, to indicate which input polarisation to use in the beam.
-    dither
-        The type of dithering to apply before quantisation.
-    """
-
+    #: Either 0 or 1, to indicate which input polarisation to use in the beam.
     pol: int
+    #: The type of dithering to apply before quantisation.
     dither: DitherType
 
     def __post_init__(self) -> None:

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -60,7 +60,7 @@ from ..ringbuffer import ChunkRingbuffer
 from ..send import DescriptorSender
 from ..utils import DeviceStatusSensor, TimeConverter, add_time_sync_sensors, steady_state_timestamp_sensor
 from . import DEFAULT_BPIPELINE_NAME, DEFAULT_N_IN_ITEMS, DEFAULT_N_OUT_ITEMS, DEFAULT_XPIPELINE_NAME, recv
-from .beamform import BeamformTemplate
+from .beamform import Beam, BeamformTemplate
 from .bsend import BSend
 from .bsend import make_stream as make_bstream
 from .correlation import CorrelationTemplate
@@ -354,7 +354,7 @@ class BPipeline(Pipeline[BOutput, BOutQueueItem]):
 
         template = BeamformTemplate(
             context,
-            [output.pol for output in outputs],
+            [Beam(pol=output.pol, dither=output.dither) for output in outputs],
             n_spectra_per_batch=engine.recv_layout.n_spectra_per_heap,
         )
         self._beamform = template.instantiate(

--- a/src/katgpucbf/xbgpu/kernels/beamform.mako
+++ b/src/katgpucbf/xbgpu/kernels/beamform.mako
@@ -17,7 +17,6 @@
 <%
 n_beams = len(beams)
 batch_beams = min(16, n_beams)
-any_dither = any(beam.dither != DitherType.NONE for beam in beams)
 %>
 
 #define N_BEAMS ${n_beams}
@@ -28,7 +27,7 @@ any_dither = any(beam.dither != DitherType.NONE for beam in beams)
 // Number of beams processed at a time
 #define BATCH_BEAMS ${batch_beams}
 // Whether any dithering is enabled
-#define DITHER ${int(any_dither)}
+#define DITHER ${int(dither_enabled)}
 
 <%include file="/port.mako"/>
 <%include file="/kernels/complex.mako"/>

--- a/src/katgpucbf/xbgpu/output.py
+++ b/src/katgpucbf/xbgpu/output.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2023, National Research Foundation (SARAO)
+# Copyright (c) 2023-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katgpucbf/xbgpu/output.py
+++ b/src/katgpucbf/xbgpu/output.py
@@ -21,6 +21,8 @@ from dataclasses import dataclass
 
 from katsdptelstate.endpoint import Endpoint
 
+from ..utils import DitherType
+
 
 @dataclass
 class Output(ABC):
@@ -42,3 +44,4 @@ class BOutput(Output):
     """Static configuration for an output beam stream."""
 
     pol: int
+    dither: DitherType

--- a/test/fgpu/test_main.py
+++ b/test/fgpu/test_main.py
@@ -45,7 +45,7 @@ class TestParseNarrowband:
             centre_frequency=400e6,
             decimation=8,
             dst=[Endpoint("239.1.2.3", 7148), Endpoint("239.1.2.4", 7148)],
-            dither=DitherType.UNIFORM,
+            dither=DitherType.DEFAULT,
             weight_pass=DEFAULT_WEIGHT_PASS,
             taps=DEFAULT_TAPS,
             ddc_taps=DEFAULT_DDC_TAPS_RATIO * 8,
@@ -129,7 +129,7 @@ class TestParseArgs:
             NarrowbandOutput(
                 name="nb0",
                 dst=[Endpoint("239.1.0.0", 7148), Endpoint("239.1.0.1", 7148)],
-                dither=DitherType.UNIFORM,
+                dither=DitherType.DEFAULT,
                 channels=32768,
                 centre_frequency=400e6,
                 decimation=8,
@@ -142,7 +142,7 @@ class TestParseArgs:
             NarrowbandOutput(
                 name="nb1",
                 dst=[Endpoint("239.2.0.0", 7149)],
-                dither=DitherType.UNIFORM,
+                dither=DitherType.DEFAULT,
                 channels=8192,
                 centre_frequency=300e6,
                 decimation=16,

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -221,7 +221,7 @@ class TestParseDither:
         """Test with valid inputs."""
         assert parse_dither(input) == output
 
-    @pytest.mark.parametrize("input", ["", "false", "UnIFoRM", "NONE"])
+    @pytest.mark.parametrize("input", ["", "false", "UnIFoRM", "NONE", "default"])
     def test_invalid(self, input: str) -> None:
         """Test with invalid inputs."""
         with pytest.raises(

--- a/test/xbgpu/test_beamform.py
+++ b/test/xbgpu/test_beamform.py
@@ -67,7 +67,7 @@ def beamform_host(
                 p = beam_pols[beam]
                 w = weights[:, beam]
                 w = w * np.exp(delays[:, beam] * channel * np.complex64(1j) * np.float32(np.pi))
-                tol = 0.5 if beam_dither[beam] else 0.001  # Allowed deviation from GPU result
+                tol = 0.5 if beam_dither[beam] else 0.002  # Allowed deviation from GPU result
                 for time in range(n_times):
                     # .copy() is added because otherwise we get a warning that np.dot is
                     # more efficient on C-contiguous arrays.

--- a/test/xbgpu/test_bsend.py
+++ b/test/xbgpu/test_bsend.py
@@ -30,7 +30,7 @@ from katsdptelstate.endpoint import Endpoint
 
 from katgpucbf import COMPLEX
 from katgpucbf.spead import BEAM_ANTS_ID, BF_RAW_ID, FREQUENCY_ID, TIMESTAMP_ID
-from katgpucbf.utils import TimeConverter
+from katgpucbf.utils import DitherType, TimeConverter
 from katgpucbf.xbgpu.bsend import SEND_DTYPE, BSend
 from katgpucbf.xbgpu.output import BOutput
 
@@ -50,8 +50,8 @@ def time_converter() -> TimeConverter:
 def outputs() -> Sequence[BOutput]:
     """Simulate `--beam` configuration."""
     return [
-        BOutput(name="foo", dst=Endpoint("239.10.11.0", 7149), pol=0),
-        BOutput(name="bar", dst=Endpoint("239.10.12.0", 7149), pol=1),
+        BOutput(name="foo", dst=Endpoint("239.10.11.0", 7149), pol=0, dither=DitherType.DEFAULT),
+        BOutput(name="bar", dst=Endpoint("239.10.12.0", 7149), pol=1, dither=DitherType.DEFAULT),
     ]
 
 

--- a/test/xbgpu/test_main.py
+++ b/test/xbgpu/test_main.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2023, National Research Foundation (SARAO)
+# Copyright (c) 2023-2024, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/xbgpu/test_main.py
+++ b/test/xbgpu/test_main.py
@@ -19,6 +19,7 @@
 import pytest
 from katsdptelstate.endpoint import Endpoint
 
+from katgpucbf.utils import DitherType
 from katgpucbf.xbgpu.main import parse_beam, parse_corrprod
 from katgpucbf.xbgpu.output import BOutput, XOutput
 
@@ -28,10 +29,20 @@ class TestParseBeam:
 
     def test_maximal(self) -> None:
         """Test with all valid arguments."""
+        assert parse_beam("name=beam1,dst=239.1.2.3:7148,pol=1,dither=none") == BOutput(
+            name="beam1",
+            dst=Endpoint("239.1.2.3", 7148),
+            pol=1,
+            dither=DitherType.NONE,
+        )
+
+    def test_minimal(self) -> None:
+        """Test with only required arguments."""
         assert parse_beam("name=beam1,dst=239.1.2.3:7148,pol=1") == BOutput(
             name="beam1",
             dst=Endpoint("239.1.2.3", 7148),
             pol=1,
+            dither=DitherType.DEFAULT,
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
The kernel code is more complex than for fgpu, because one kernel
handles multiple beams, and they could have individual choices of
dithering. This is already handled for the polarisations, so we use the
same pattern: the choice is baked into the BeamformTemplate, and encoded
into the kernel source as a constant array generated at compile time.
The indices into the array should also be known to the compiler
(assuming it unrolls loops well) and hence it shouldn't add any cost.
In addition to this mechanism, if none of the beams have dithering, we
remove the random state array entirely.

Closes NGC-1429.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
