### PR TITLE
Fix documentation of type of rand_states slot

### DIFF
--- a/src/katgpucbf/xbgpu/beamform.py
+++ b/src/katgpucbf/xbgpu/beamform.py
@@ -99,7 +99,7 @@ class Beamform(accel.Operation):
         the channel number and :math:`d` is the delay value. Note
         that this will not apply any rotation to the first channel
         in the data; any such rotation needs to be baked into **weights**.
-    **rand_states** : n_batches × n_channels_per_substream × n_spectra_per_batch, curandStateXORWOW_t (packed)
+    **rand_states** : n_batches × n_channels_per_substream × n_spectra_per_batch, randState_t (packed)
         Independent random states for generating dither values. This is set
         up by the constructor and should not normally need to be touched.
 


### PR DESCRIPTION
The actual type was changed in #825, but this bit of documentation was missed.
