### PR TITLE
Qualification: use multiple cores for baseline-correlation-products

### DIFF
--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -531,7 +531,7 @@ async def receive_baseline_correlation_products(
     receiver = BaselineCorrelationProductsReceiver(
         cbf=cbf,
         stream_name="baseline-correlation-products",
-        core=core_allocator.allocate(1)[0],
+        cores=core_allocator.allocate(4),
         interface_address=interface_address,
         use_ibv=use_ibv,
     )


### PR DESCRIPTION
This should hopefully reduce the number of dropped heaps.

See NGC-938.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
