### PR TITLE
Remove need for garbage collection between unit tests

### DIFF
--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -261,7 +261,7 @@ class Pipeline(Generic[_O, _T]):
         # These queues are extended in the monitor class, allowing for the
         # monitor to track the number of items on each queue.
         # - The _in_queue receives items from :meth:`.XBEngine._receiver_loop`
-        #   to be used by :meth:`_gpu_proc_loop`.
+        #   to be used by :meth:`gpu_proc_loop`.
         # - The _out_queue receives items from :meth:`gpu_proc_loop` to be
         #   used by :meth:`sender_loop`.
         # Once the destination function is finished with an item, it will pass

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -1500,3 +1500,4 @@ class XBEngine(DeviceServer):
             for task in self.service_tasks:
                 if task not in self._cancel_tasks:
                     await task
+        self._pipelines.clear()  # Breaks circular references

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -148,7 +148,9 @@ def mock_send_stream_network() -> IPv4Network:
 
 
 @pytest.fixture
-def mock_send_stream(mocker, mock_send_stream_network: IPv4Network) -> list[spead2.InprocQueue]:
+def mock_send_stream(
+    monkeypatch: pytest.MonkeyPatch, mock_send_stream_network: IPv4Network
+) -> list[spead2.InprocQueue]:
     """Mock out creation of the send stream.
 
     Each time a :class:`spead2.send.asyncio.UdpStream` is created, it instead
@@ -169,7 +171,7 @@ def mock_send_stream(mocker, mock_send_stream_network: IPv4Network) -> list[spea
         )
         return spead2.send.asyncio.InprocStream(thread_pool, stream_queues, config)
 
-    mocker.patch("spead2.send.asyncio.UdpStream", autospec=True, side_effect=constructor)
+    monkeypatch.setattr("spead2.send.asyncio.UdpStream", constructor)
     return queues
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -41,7 +41,6 @@ is given a dictionary mapping names to values, and returns true if that
 combination is a candidate.
 """
 
-import gc
 import itertools
 from dataclasses import dataclass
 from ipaddress import IPv4Address, IPv4Network
@@ -183,20 +182,6 @@ def time_converter() -> TimeConverter:
     closely related to make tests easily readable.
     """
     return TimeConverter(1.0, 1000.0)
-
-
-@pytest.fixture(autouse=True)
-def force_gc():
-    """Force garbage collection before each test.
-
-    This is needed because cyclic garbage can keep significant GPU resources
-    tied up, and the memory allocator isn't aware of it and so doesn't try
-    to free any of it when GPU allocations fail.
-    """
-    # Multiple passes because sometimes freeing some garbage allows more
-    # garbage to be detected.
-    for _ in range(3):
-        gc.collect()
 
 
 @pytest.fixture(scope="session")

--- a/test/dsim/test_send.py
+++ b/test/dsim/test_send.py
@@ -22,6 +22,7 @@ import time
 from collections.abc import Sequence
 
 import numpy as np
+import pytest
 import spead2.recv.asyncio
 import spead2.send.asyncio
 from spead2 import ItemGroup
@@ -67,7 +68,7 @@ async def test_sender(
     inproc_queues: Sequence[spead2.InprocQueue],
     sender: send.Sender,
     heap_sets: Sequence[send.HeapSet],
-    mocker,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Send random data via a :class:`~katgpucbf.dsim.send.Sender` and check it."""
     # Tweak the sending so that we can interrupt the sender after sending a
@@ -110,9 +111,7 @@ async def test_sender(
 
     # Note: only do this after dealing with the descriptors, as otherwise
     # they interfere with the countdown.
-    mocker.patch.object(
-        spead2.send.asyncio.InprocStream, "async_send_heaps", side_effect=wrapped_send_heaps, autospec=True
-    )
+    monkeypatch.setattr(spead2.send.asyncio.InprocStream, "async_send_heaps", wrapped_send_heaps)
 
     # Stop the descriptor queue
     for queue in descriptor_inproc_queues:

--- a/test/fgpu/conftest.py
+++ b/test/fgpu/conftest.py
@@ -32,7 +32,7 @@ from katgpucbf.fgpu.main import make_engine, parse_args
 
 
 @pytest.fixture
-def recv_max_chunks_one(monkeypatch) -> None:
+def recv_max_chunks_one(monkeypatch: pytest.MonkeyPatch) -> None:
     """Change :data:`.recv.MAX_CHUNKS` to 1 for the test.
 
     This simplifies the process of reliably injecting data.
@@ -41,7 +41,7 @@ def recv_max_chunks_one(monkeypatch) -> None:
 
 
 @pytest.fixture
-def mock_recv_stream(mocker) -> spead2.InprocQueue:
+def mock_recv_stream(monkeypatch: pytest.MonkeyPatch) -> spead2.InprocQueue:
     """Mock out :func:`katgpucbf.recv.add_reader` to use an in-process queue.
 
     Returns
@@ -67,7 +67,7 @@ def mock_recv_stream(mocker) -> spead2.InprocQueue:
         stream.add_inproc_reader(queue)
         have_reader = True
 
-    mocker.patch("katgpucbf.recv.add_reader", autospec=True, side_effect=add_reader)
+    monkeypatch.setattr("katgpucbf.recv.add_reader", add_reader)
     return queue
 
 

--- a/test/xbgpu/conftest.py
+++ b/test/xbgpu/conftest.py
@@ -27,7 +27,7 @@ def n_recv_streams() -> int:  # noqa: D401
 
 
 @pytest.fixture
-def mock_recv_streams(mocker, n_recv_streams: int) -> list[spead2.InprocQueue]:
+def mock_recv_streams(monkeypatch: pytest.MonkeyPatch, n_recv_streams: int) -> list[spead2.InprocQueue]:
     """Mock out :func:`katgpucbf.recv.add_reader` to use in-process queues.
 
     Returns
@@ -52,5 +52,5 @@ def mock_recv_streams(mocker, n_recv_streams: int) -> list[spead2.InprocQueue]:
         queue = next(queue_iter)
         stream.add_inproc_reader(queue)
 
-    mocker.patch("katgpucbf.recv.add_reader", autospec=True, side_effect=add_reader)
+    monkeypatch.setattr("katgpucbf.recv.add_reader", add_reader)
     return queues


### PR DESCRIPTION
Address the various underlying causes of reference cycles, so that now CPython's reference counting is sufficient to free up the CUDA contexts as soon as the test framework drops its references.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1325.
