### PR TITLE
Add more information when general/control qual test fails

### DIFF
--- a/qualification/general/test_control.py
+++ b/qualification/general/test_control.py
@@ -204,6 +204,17 @@ def check_timestamps(
     expected = (timestamps[-1] - timestamps[0]) // receiver.timestamp_step + 1
     missing = expected - len(timestamps)
     pdf_report.detail(f"{name}: missed {missing} of {expected} chunks (ignoring first {STARTUP_TIME}s).")
+    if missing > 0:
+        last_missing = -1
+        ptr = 0
+        for i in range(expected):
+            t = timestamps[0] + i * receiver.timestamp_step
+            while ptr < len(timestamps) and timestamps[ptr] < t:
+                ptr += 1
+            if ptr == len(timestamps) or timestamps[ptr] > t:
+                last_missing = i
+        last_missing_time = (last_missing + start_pos) * receiver.timestamp_step / receiver.scale_factor_timestamp
+        pdf_report.detail(f"Last missing chunk is #{last_missing} ({last_missing_time:.6f} s after original start).")
     with check:
         assert missing <= 1, f"{missing} of {expected} chunks missing for {name}"
 


### PR DESCRIPTION
This should shed some light on whether it just needs more time for transmission to stabilise or is a more serious issue.

See NGC-1265.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [ ] If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match