### PR TITLE
Qual: use np.ones to create chunks

### DIFF
--- a/qualification/recv.py
+++ b/qualification/recv.py
@@ -524,9 +524,10 @@ def create_baseline_correlation_product_receive_stream(
         max_chunks,
         0,
         chunk_place.ctypes,
+        # np.ones is used to ensure that the memory is paged in
         lambda stream: katgpucbf.recv.Chunk(
-            present=np.empty(HEAPS_PER_CHUNK, np.uint8),
-            data=np.empty((n_chans, n_bls, COMPLEX), dtype=np.dtype(f"int{n_bits_per_sample}")),
+            present=np.ones(HEAPS_PER_CHUNK, np.uint8),
+            data=np.ones((n_chans, n_bls, COMPLEX), dtype=np.dtype(f"int{n_bits_per_sample}")),
             sink=stream,
         ),
     )
@@ -588,10 +589,11 @@ def create_tied_array_channelised_voltage_receive_stream(
         max_chunks,
         beam_ants_dtype.itemsize,
         chunk_place.ctypes,
+        # np.ones is used to ensure that the memory is paged in
         lambda stream: katgpucbf.recv.Chunk(
-            present=np.empty((n_beams, n_substreams), np.uint8),
-            extra=np.zeros((n_beams, n_substreams), beam_ants_dtype),
-            data=np.empty((n_beams, n_chans, n_spectra_per_heap, COMPLEX), dtype=np.dtype(f"int{n_bits_per_sample}")),
+            present=np.ones((n_beams, n_substreams), np.uint8),
+            extra=np.ones((n_beams, n_substreams), beam_ants_dtype),
+            data=np.ones((n_beams, n_chans, n_spectra_per_heap, COMPLEX), dtype=np.dtype(f"int{n_bits_per_sample}")),
             sink=stream,
         ),
     )


### PR DESCRIPTION
It guarantees paged-in memory, which should reduce the amount of data lost once we actually subscribe to the streams.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Relates to NGC-1265 (but might have no effect).
