### PR TITLE
Bump aiokatcp version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
         types_or: [python, pyi]
         additional_dependencies: [
             'aioconsole==0.7.0',
-            'aiokatcp==1.10.0',
+            'aiokatcp==2.0.0',
             'aiomonitor==0.7.0',
             'asyncssh==2.14.2',
             'dask==2023.12.0',

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -20,7 +20,7 @@ aiohttp==3.10.3
     #   -c qualification/../requirements.txt
     #   aiomonitor
     #   prometheus-async
-aiokatcp==1.10.0
+aiokatcp==2.0.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,6 +35,7 @@ appdirs==1.4.4
     # via
     #   -c requirements.txt
     #   katsdpsigproc
+    #   pycuda
 asttokens==2.4.1
     # via stack-data
 async-solipsism==0.7
@@ -232,7 +233,6 @@ pip-tools==7.3.0
 platformdirs==4.2.2
     # via
     #   -c requirements.txt
-    #   pycuda
     #   pytools
     #   virtualenv
 pluggy==1.5.0
@@ -263,7 +263,7 @@ pybtex==0.24.0
     #   sphinxcontrib-bibtex
 pybtex-docutils==1.0.3
     # via sphinxcontrib-bibtex
-pycuda==2024.1.2
+pycuda==2023.1
     # via
     #   -c requirements.txt
     #   katsdpsigproc

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ aiohttp==3.10.3
     #   -c requirements.txt
     #   aiomonitor
     #   prometheus-async
-aiokatcp==1.10.0
+aiokatcp==2.0.0
     # via
     #   -c requirements.txt
     #   katgpucbf (setup.cfg)
@@ -35,7 +35,6 @@ appdirs==1.4.4
     # via
     #   -c requirements.txt
     #   katsdpsigproc
-    #   pycuda
 asttokens==2.4.1
     # via stack-data
 async-solipsism==0.7
@@ -230,9 +229,10 @@ pexpect==4.9.0
     # via ipython
 pip-tools==7.3.0
     # via -r requirements-dev.in
-platformdirs==4.1.0
+platformdirs==4.2.2
     # via
     #   -c requirements.txt
+    #   pycuda
     #   pytools
     #   virtualenv
 pluggy==1.5.0
@@ -263,7 +263,7 @@ pybtex==0.24.0
     #   sphinxcontrib-bibtex
 pybtex-docutils==1.0.3
     # via sphinxcontrib-bibtex
-pycuda==2023.1
+pycuda==2024.1.2
     # via
     #   -c requirements.txt
     #   katsdpsigproc
@@ -303,7 +303,7 @@ python-dateutil==2.9.0.post0
     # via
     #   -c requirements.txt
     #   pandas
-pytools==2023.1.1
+pytools==2024.1.13
     # via
     #   -c requirements.txt
     #   pycuda
@@ -403,6 +403,7 @@ typing-extensions==4.12.0
     #   aiomonitor
     #   janus
     #   katsdpsigproc
+    #   pytools
 tzdata==2023.3
     # via
     #   -c requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,23 +12,21 @@ aiohttp==3.10.3
     # via
     #   aiomonitor
     #   prometheus-async
-aiokatcp==1.10.0
+aiokatcp==2.0.0
     # via katgpucbf (setup.cfg)
 aiomonitor==0.7.0
     # via katsdpservices
 aiosignal==1.3.1
     # via aiohttp
 appdirs==1.4.4
-    # via
-    #   katsdpsigproc
-    #   pycuda
+    # via katsdpsigproc
 async-timeout==4.0.3
     # via aiokatcp
 attrs==23.1.0
     # via
     #   aiohttp
     #   aiomonitor
-cffi==1.16.0
+cffi==1.17.0
     # via vkgdr
 click==8.1.7
     # via
@@ -110,8 +108,10 @@ pandas==2.1.4
     #   xarray
 partd==1.4.1
     # via dask
-platformdirs==4.1.0
-    # via pytools
+platformdirs==4.2.2
+    # via
+    #   pycuda
+    #   pytools
 prometheus-async==22.2.0
     # via katgpucbf (setup.cfg)
 prometheus-client==0.19.0
@@ -122,9 +122,9 @@ prompt-toolkit==3.0.43
     # via aiomonitor
 psutil==5.9.6
     # via -r requirements.in
-pycparser==2.21
+pycparser==2.22
     # via cffi
-pycuda==2023.1
+pycuda==2024.1.2
     # via katsdpsigproc
 pygelf==0.4.2
     # via katsdpservices
@@ -132,7 +132,7 @@ pyparsing==3.0.9
     # via katgpucbf (setup.cfg)
 python-dateutil==2.9.0.post0
     # via pandas
-pytools==2023.1.1
+pytools==2024.1.13
     # via pycuda
 pytz==2023.3.post1
     # via pandas
@@ -164,6 +164,7 @@ typing-extensions==4.12.0
     #   aiomonitor
     #   janus
     #   katsdpsigproc
+    #   pytools
 tzdata==2023.3
     # via pandas
 vkgdr==0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,9 @@ aiomonitor==0.7.0
 aiosignal==1.3.1
     # via aiohttp
 appdirs==1.4.4
-    # via katsdpsigproc
+    # via
+    #   katsdpsigproc
+    #   pycuda
 async-timeout==4.0.3
     # via aiokatcp
 attrs==23.1.0
@@ -109,9 +111,7 @@ pandas==2.1.4
 partd==1.4.1
     # via dask
 platformdirs==4.2.2
-    # via
-    #   pycuda
-    #   pytools
+    # via pytools
 prometheus-async==22.2.0
     # via katgpucbf (setup.cfg)
 prometheus-client==0.19.0
@@ -124,7 +124,7 @@ psutil==5.9.6
     # via -r requirements.in
 pycparser==2.22
     # via cffi
-pycuda==2024.1.2
+pycuda==2023.1
     # via katsdpsigproc
 pygelf==0.4.2
     # via katsdpservices

--- a/scratch/benchmarks/requirements.txt
+++ b/scratch/benchmarks/requirements.txt
@@ -30,7 +30,7 @@ attrs==23.1.0
     #   -c scratch/benchmarks/../../requirements-dev.txt
     #   -c scratch/benchmarks/../../requirements.txt
     #   aiohttp
-cffi==1.16.0
+cffi==1.17.0
     # via
     #   -c scratch/benchmarks/../../requirements.txt
     #   cryptography
@@ -87,7 +87,7 @@ prometheus-client==0.19.0
     #   -c scratch/benchmarks/../../requirements-dev.txt
     #   -c scratch/benchmarks/../../requirements.txt
     #   -r scratch/benchmarks/requirements.in
-pycparser==2.21
+pycparser==2.22
     # via
     #   -c scratch/benchmarks/../../requirements.txt
     #   cffi

--- a/scratch/benchmarks/requirements.txt
+++ b/scratch/benchmarks/requirements.txt
@@ -34,7 +34,7 @@ cffi==1.17.0
     # via
     #   -c scratch/benchmarks/../../requirements.txt
     #   cryptography
-cryptography==42.0.4
+cryptography==43.0.1
     # via asyncssh
 frozenlist==1.4.0
     # via

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ package_dir =
     = src
 packages = find:
 install_requires =
-    aiokatcp>=2.0.0
+    aiokatcp>=1.9.0
     dask
     katsdpservices[aiomonitor]
     katsdpsigproc>=1.8.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ package_dir =
     = src
 packages = find:
 install_requires =
-    aiokatcp>=1.9.0
+    aiokatcp>=2.0.0
     dask
     katsdpservices[aiomonitor]
     katsdpsigproc>=1.8.0


### PR DESCRIPTION
As per the release of aiokatcp version 2.0.0. 

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes: NGC-1062.
