### PR TITLE
Throw a bigger receive buffer at xbgpu

### DIFF
--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -329,9 +329,9 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--recv-buffer",
         type=int,
-        default=32 * 1024 * 1024,
+        default=128 * 1024 * 1024,
         metavar="BYTES",
-        help="Size of network receive buffer [32MiB]",
+        help="Size of network receive buffer [128MiB]",
     )
     parser.add_argument(
         "--send-affinity", type=int, default=-1, help="Core to which the sender thread will be bound [not bound]."


### PR DESCRIPTION
Over the weekend there were some out-of-buffer errors.

Relates to NGC-1265.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
