### PR TITLE
Qual: remove the xfail from test_control

### DIFF
--- a/qualification/general/test_control.py
+++ b/qualification/general/test_control.py
@@ -215,7 +215,6 @@ def check_timestamps(
 
 # TODO: once requirements spec is finalised, note which requirements
 # this corresponds to.
-@pytest.mark.xfail(reason="Not 100% reliable yet (NGC-1265)")
 async def test_control(
     cbf: CBFRemoteControl,
     receive_baseline_correlation_products_manual_start: BaselineCorrelationProductsReceiver,


### PR DESCRIPTION
It's now at least somewhat reliable, and having the test outcome tell me when it's failing would be useful at this point.

Ony merge after #862.

See NGC-1265.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [ ] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

I haven't attached a qualification report - I feel this change doesn't really need a report to evaluate it.