### PR TITLE
Qual: remove xfail mark from test_accum_length

### DIFF
--- a/qualification/baseline_correlation_products/test_accum_length.py
+++ b/qualification/baseline_correlation_products/test_accum_length.py
@@ -26,7 +26,6 @@ from ..reporter import Reporter
 
 
 @pytest.mark.requirements("CBF-REQ-0096")
-@pytest.mark.xfail(reason="requirement needs to be updated")
 async def test_accum_length(
     cbf: CBFRemoteControl,
     receive_baseline_correlation_products: BaselineCorrelationProductsReceiver,


### PR DESCRIPTION
We originally added the mark when some narrowband modes didn't meet the 500ms±200ms (and didn't in MeerKAT). Since the changes to spectra-per-heap, all modes now meet the requirement, and so we don't need to mark them as xfail. The requirement probably still needs to be changed to accomodate MeerKAT, but that's a separate issue.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [ ] If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
