### PR TITLE
Attempt to make qual test start more robust

### DIFF
--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -36,7 +36,7 @@ from katsdpservices import get_interface_address
 from katgpucbf.meerkat import BANDS
 
 from .cbf import CBFCache, CBFRemoteControl, FailedCBF
-from .recv import BaselineCorrelationProductsReceiver, TiedArrayChannelisedVoltageReceiver
+from .recv import DEFAULT_TIMEOUT, BaselineCorrelationProductsReceiver, TiedArrayChannelisedVoltageReceiver
 from .reporter import Reporter, custom_report_log
 
 logger = logging.getLogger(__name__)
@@ -550,8 +550,9 @@ async def receive_baseline_correlation_products(
     receiver.start()
     # Ensure that the data is flowing, and that we throw away any data that
     # predates the start of this test (to prevent any state leaks from previous
-    # tests).
-    await receiver.next_complete_chunk(max_delay=0)
+    # tests). The timeout is increased since it may take some time to get the
+    # data flowing at the start.
+    await receiver.wait_complete_chunk(max_delay=0, timeout=3 * DEFAULT_TIMEOUT)
     return receiver
 
 
@@ -610,6 +611,7 @@ async def receive_tied_array_channelised_voltage(
     receiver.start()
     # Ensure that the data is flowing, and that we throw away any data that
     # predates the start of this test (to prevent any state leaks from previous
-    # tests).
-    await receiver.next_complete_chunk(max_delay=0)
+    # tests). The timeout is increased since it may take some time to get the
+    # data flowing at the start.
+    await receiver.wait_complete_chunk(max_delay=0, timeout=3 * DEFAULT_TIMEOUT)
     return receiver

--- a/qualification/general/test_control.py
+++ b/qualification/general/test_control.py
@@ -96,7 +96,7 @@ async def control_acv_delays(rng: np.random.Generator, cbf: CBFRemoteControl, pd
     Raises
     ------
     AssertionError
-        if it takes more than 1s to set the delays
+        If it takes more than 1s to set the delays
     """
     pcc = cbf.product_controller_client
     n_inputs = len(cbf.config["outputs"][name]["input_labels"])
@@ -137,7 +137,7 @@ async def control_tacv_delays(rng: np.random.Generator, cbf: CBFRemoteControl, p
     Raises
     ------
     AssertionError
-        if it takes more than 1s to set the delays
+        If it takes more than 1s to set the delays
     """
     pcc = cbf.product_controller_client
     src_stream = cbf.config["outputs"][name]["src_streams"][0]

--- a/qualification/recv.py
+++ b/qualification/recv.py
@@ -225,7 +225,9 @@ class XBReceiver:
     ) -> int:
         """Wait for a complete chunk, but do not return it.
 
-        Only the timestamp is returned.
+        Only the timestamp is returned. This is more efficient than
+        :meth:`next_complete_chunk` because it does not need to copy the data
+        from the chunk.
 
         Parameters
         ----------

--- a/qualification/recv.py
+++ b/qualification/recv.py
@@ -44,6 +44,7 @@ from katgpucbf.utils import TimeConverter
 
 from .cbf import DEFAULT_MAX_DELAY, CBFRemoteControl
 
+DEFAULT_TIMEOUT = 10.0
 logger = logging.getLogger(__name__)
 
 
@@ -189,7 +190,7 @@ class XBReceiver:
         min_timestamp: int | None = None,
         *,
         max_delay: int = DEFAULT_MAX_DELAY,
-        timeout: float | None = 10.0,
+        timeout: float | None = DEFAULT_TIMEOUT,
     ) -> tuple[int, np.ndarray]:
         """Return the data from the next complete chunk from the stream.
 
@@ -199,11 +200,51 @@ class XBReceiver:
         ----------
         min_timestamp, max_delay
             See :meth:`complete_chunks`
+        timeout
+            Maximum time to wait
+
+        Raises
+        ------
+        TimeoutError
+            if a complete chunk is not received in time
+        RuntimeError
+            if the stream is stopped before a complete chunk is received
         """
         async with asyncio.timeout(timeout):
             async for timestamp, chunk in self.complete_chunks(min_timestamp=min_timestamp, max_delay=max_delay):
                 with chunk:
                     return timestamp, np.array(chunk.data)  # Makes a copy before we return the chunk
+        raise RuntimeError("stream was shut down before we received a complete chunk")
+
+    async def wait_complete_chunk(
+        self,
+        min_timestamp: int | None = None,
+        *,
+        max_delay: int = DEFAULT_MAX_DELAY,
+        timeout: float | None = DEFAULT_TIMEOUT,
+    ) -> int:
+        """Wait for a complete chunk, but do not return it.
+
+        Only the timestamp is returned.
+
+        Parameters
+        ----------
+        min_timestamp, max_delay
+            See :meth:`complete_chunks`
+        timeout
+            Maximum time to wait
+
+        Raises
+        ------
+        TimeoutError
+            if a complete chunk is not received in time
+        RuntimeError
+            if the stream is stopped before a complete chunk is received
+        """
+        async with asyncio.timeout(timeout):
+            async for timestamp, chunk in self.complete_chunks(min_timestamp=min_timestamp, max_delay=max_delay):
+                chunk.recycle()
+                return timestamp
         raise RuntimeError("stream was shut down before we received a complete chunk")
 
     async def consecutive_chunks(
@@ -212,7 +253,7 @@ class XBReceiver:
         min_timestamp: int | None = None,
         *,
         max_delay: int = DEFAULT_MAX_DELAY,
-        timeout: float | None = 10.0,
+        timeout: float | None = DEFAULT_TIMEOUT,
     ) -> list[tuple[int, katgpucbf.recv.Chunk]]:
         """Obtain `n` consecutive complete chunks from the stream.
 
@@ -340,7 +381,7 @@ class BaselineCorrelationProductsReceiver(XBReceiver):
             min_timestamp: int | None = None,
             *,
             max_delay: int = DEFAULT_MAX_DELAY,
-            timeout: float | None = 10.0,
+            timeout: float | None = DEFAULT_TIMEOUT,
         ) -> tuple[int, NDArray[np.int32]]:  # noqa: D102
             ...
 

--- a/qualification/recv.py
+++ b/qualification/recv.py
@@ -206,9 +206,9 @@ class XBReceiver:
         Raises
         ------
         TimeoutError
-            if a complete chunk is not received in time
+            If a complete chunk is not received in time
         RuntimeError
-            if the stream is stopped before a complete chunk is received
+            If the stream is stopped before a complete chunk is received
         """
         async with asyncio.timeout(timeout):
             async for timestamp, chunk in self.complete_chunks(min_timestamp=min_timestamp, max_delay=max_delay):
@@ -239,9 +239,9 @@ class XBReceiver:
         Raises
         ------
         TimeoutError
-            if a complete chunk is not received in time
+            If a complete chunk is not received in time
         RuntimeError
-            if the stream is stopped before a complete chunk is received
+            If the stream is stopped before a complete chunk is received
         """
         async with asyncio.timeout(timeout):
             async for timestamp, chunk in self.complete_chunks(min_timestamp=min_timestamp, max_delay=max_delay):

--- a/src/katgpucbf/fgpu/accum.py
+++ b/src/katgpucbf/fgpu/accum.py
@@ -121,11 +121,11 @@ class Accum(Generic[_T]):
         Raises
         ------
         ValueError
-            if `start_timestamp` > `end_timestamp`
+            If `start_timestamp` > `end_timestamp`
         ValueError
-            if the new data overlaps or preceeds previous data
+            If the new data overlaps or preceeds previous data
         ValueError
-            if [start_timestamp, end_timestamp) crosses a window boundary
+            If [start_timestamp, end_timestamp) crosses a window boundary
         """
         if start_timestamp > end_timestamp:
             raise ValueError("start_timestamp ({start_timestamp}) > end_timestamp ({end_timestamp})")

--- a/src/katgpucbf/fgpu/delay.py
+++ b/src/katgpucbf/fgpu/delay.py
@@ -135,7 +135,7 @@ class LinearDelayModel(AbstractDelayModel):
     Raises
     ------
     ValueError
-        if `rate` is greater than or equal to 1 or `start` is negative
+        If `rate` is greater than or equal to 1 or `start` is negative
     """
 
     def __init__(self, start: int, delay: float, delay_rate: float, phase: float, phase_rate: float) -> None:


### PR DESCRIPTION
- Introduce DEFAULT_TIMEOUT to replace the hard-coded 10s timeout
- Have the receiver fixtures wait 3 * DEFAULT_TIMEOUT, to account for occasionally slow startup of a correlator
- Introduce wait_complete_chunk, which is more efficient that next_complete_chunk because it doesn't make and return a copy of the data.
- Improve docstring for next_complete_chunk.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [ ] If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match