### PR TITLE
Add timestamp argument to ?capture-start

### DIFF
--- a/doc/control.rst
+++ b/doc/control.rst
@@ -252,11 +252,14 @@ fgpu
 
 xbgpu
 ^^^^^
-:samp:`?capture-start {stream}`, :samp:`?capture-stop {stream}`
+:samp:`?capture-start {stream} [{timestamp}]`, :samp:`?capture-stop {stream}`
     Enable or disable transmission of output data. This does not affect
     transmission of descriptors, which cannot be disabled. In the initial
     state transmission is disabled, unless the :option:`!--send-enabled`
     command-line option has been passed.
+
+    If :samp:`{timestamp}` is specified, heaps with timestamps less than this
+    ADC timestamp will not be transmitted.
 
 :samp:`?beam-weights {stream} {weights}...`, :samp:`?beam-delays {stream} {delays}...`, :samp:`?beam-quant-gains {stream} {gain}`
     These have the same semantics as the equivalent katsdpcontroller

--- a/src/katgpucbf/xbgpu/xsend.py
+++ b/src/katgpucbf/xbgpu/xsend.py
@@ -255,6 +255,7 @@ class XSend(Send):
 
         self.output_name = output_name
         self.send_enabled = send_enabled
+        self.send_enabled_timestamp = 0
 
         # Array Configuration Parameters
         self.n_ants: Final[int] = n_ants
@@ -301,7 +302,7 @@ class XSend(Send):
         heap
             Heap to send
         """
-        if self.send_enabled:
+        if self.send_enabled and heap.timestamp >= self.send_enabled_timestamp:
             saturated = int(heap.saturated)  # Save a copy before giving away the heap
             heap.future = self.stream.async_send_heap(heap.heap)
             self._heaps_queue.put_nowait(heap)

--- a/test/xbgpu/test_xsend.py
+++ b/test/xbgpu/test_xsend.py
@@ -68,6 +68,7 @@ class TestXSend:
         n_engines: int,
         n_channels_per_substream: int,
         n_baselines: int,
+        first_heap: int,
     ) -> None:
         """Receive data transmitted from :func:`_send_data`.
 
@@ -83,7 +84,7 @@ class TestXSend:
         assert items == {}, "This heap contains item values not just the expected descriptors."
 
         # Check the data heaps
-        for i in range(TOTAL_HEAPS):
+        for i in range(first_heap, TOTAL_HEAPS):
             heap = await recv_stream.get()
             items = ig.update(heap)
             assert set(items.keys()) == {"timestamp", "frequency", "xeng_raw"}
@@ -156,6 +157,7 @@ class TestXSend:
             ),
             send_enabled=True,
         )
+        send_stream.send_enabled_timestamp = int(TIMESTAMP_SCALE * 1.5)
         await self._send_data(send_stream)
         # Stop the queue, to ensure that if recv_data tries to read more heaps
         # than were sent, it will error out rather than hanging.
@@ -163,4 +165,4 @@ class TestXSend:
 
         recv_stream = spead2.recv.asyncio.Stream(spead2.ThreadPool(), spead2.recv.StreamConfig())
         recv_stream.add_inproc_reader(queue)
-        await self._recv_data(recv_stream, n_engines, n_channels_per_substream, n_baselines)
+        await self._recv_data(recv_stream, n_engines, n_channels_per_substream, n_baselines, 2)

--- a/test/xbgpu/test_xsend.py
+++ b/test/xbgpu/test_xsend.py
@@ -165,4 +165,4 @@ class TestXSend:
 
         recv_stream = spead2.recv.asyncio.Stream(spead2.ThreadPool(), spead2.recv.StreamConfig())
         recv_stream.add_inproc_reader(queue)
-        await self._recv_data(recv_stream, n_engines, n_channels_per_substream, n_baselines, 2)
+        await self._recv_data(recv_stream, n_engines, n_channels_per_substream, n_baselines, first_heap=2)


### PR DESCRIPTION
This will be used by katsdpcontroller to ensure that only heaps reflecting changes from prior requests are transmitted.

It will still benefit from qualification testing, but that will be in a later PR.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1462.
