### PR TITLE
Rearrange SPEAD items to match MeerKAT

### DIFF
--- a/src/katgpucbf/xbgpu/bsend.py
+++ b/src/katgpucbf/xbgpu/bsend.py
@@ -62,16 +62,16 @@ def make_item_group(bf_raw_shape: tuple[int, ...]) -> spead2.send.ItemGroup:
     """Create an item group (with no values)."""
     item_group = spead2.send.ItemGroup(flavour=FLAVOUR)
     item_group.add_item(
-        FREQUENCY_ID,
-        "frequency",  # Misleading name, but it's what the ICD specifies
-        "Value of the first channel in collections stored here.",
+        TIMESTAMP_ID,
+        "timestamp",
+        "Timestamp provided by the MeerKAT digitisers and scaled to the digitiser sampling rate.",
         shape=[],
         format=IMMEDIATE_FORMAT,
     )
     item_group.add_item(
-        TIMESTAMP_ID,
-        "timestamp",
-        "Timestamp provided by the MeerKAT digitisers and scaled to the digitiser sampling rate.",
+        FREQUENCY_ID,
+        "frequency",  # Misleading name, but it's what the ICD specifies
+        "Value of the first channel in collections stored here.",
         shape=[],
         format=IMMEDIATE_FORMAT,
     )

--- a/src/katgpucbf/xbgpu/xsend.py
+++ b/src/katgpucbf/xbgpu/xsend.py
@@ -67,16 +67,16 @@ def make_item_group(xeng_raw_shape: tuple[int, ...]) -> spead2.send.ItemGroup:
     """Create an item group (with no values)."""
     item_group = spead2.send.ItemGroup(flavour=FLAVOUR)
     item_group.add_item(
-        FREQUENCY_ID,
-        "frequency",  # Misleading name, but it's what the ICD specifies
-        "Value of first channel in collections stored here.",
+        TIMESTAMP_ID,
+        "timestamp",
+        "Timestamp provided by the MeerKAT digitisers and scaled to the digitiser sampling rate.",
         shape=[],
         format=IMMEDIATE_FORMAT,
     )
     item_group.add_item(
-        TIMESTAMP_ID,
-        "timestamp",
-        "Timestamp provided by the MeerKAT digitisers and scaled to the digitiser sampling rate.",
+        FREQUENCY_ID,
+        "frequency",  # Misleading name, but it's what the ICD specifies
+        "Value of first channel in collections stored here.",
         shape=[],
         format=IMMEDIATE_FORMAT,
     )


### PR DESCRIPTION
This brings MK+'s implmentation in line with MeerKAT's ones, at least in terms of the ordering of the timestamp and frequency items.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] (N/A) Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

