### PR TITLE
Skip some slow tests for branch testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -125,12 +125,13 @@ pipeline {
          * 2. -v: Increases verbosity
          * 3. --junitxml=reports/result.xml' Writes the results to a file for later
          *    examination.
+         * 4. -m "not slow": skip slow tests
          */
         stage('Run pytest (quick)') {
           when { not { anyOf { changeRequest target: 'main'; branch 'main' } } }
           options { timeout(time: 30, unit: 'MINUTES') }
           steps {
-            sh 'pytest -n 4 -v -ra --junitxml=reports/result.xml --cov=katgpucbf --cov=test --cov-report=xml --cov-branch --suppress-tests-failed-exit-code'
+            sh 'pytest -n 4 -v -ra -m "not slow" --junitxml=reports/result.xml --cov=katgpucbf --cov=test --cov-report=xml --cov-branch --suppress-tests-failed-exit-code'
           }
         }
         stage('Run pytest (full)') {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ known_local_folder = ["noisy_search", "remote", "sighandler"]
 [tool.pytest.ini_options]
 testpaths = "test"
 addopts = "--cov-context=test --cov-report html --import-mode=prepend"
-markers = ["mask_timestamp", "use_vkgdr", "cmdline_args", "spectra_per_heap"]
+markers = ["mask_timestamp", "use_vkgdr", "cmdline_args", "spectra_per_heap", "slow"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 

--- a/test/dsim/test_send.py
+++ b/test/dsim/test_send.py
@@ -60,6 +60,7 @@ async def descriptor_recv(
     return ig
 
 
+@pytest.mark.slow
 async def test_sender(
     descriptor_recv_streams: Sequence[spead2.recv.asyncio.Stream],
     descriptor_inproc_queues: Sequence[spead2.InprocQueue],

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -652,7 +652,9 @@ class TestEngine:
     @pytest.mark.parametrize(
         "dig_sample_bits,send_sample_bits",
         [
-            pytest.param(DIG_SAMPLE_BITS, 4, marks=pytest.mark.cmdline_args("--send-sample-bits=4")),
+            pytest.param(
+                DIG_SAMPLE_BITS, 4, marks=[pytest.mark.cmdline_args("--send-sample-bits=4"), pytest.mark.slow]
+            ),
             pytest.param(12, 8, marks=pytest.mark.cmdline_args("--dig-sample-bits=12", "--send-sample-bits=8")),
         ],
     )
@@ -805,6 +807,7 @@ class TestEngine:
                 np.testing.assert_allclose(sensor_values[3], expected_phase)
 
     @pytest.mark.parametrize("delay_samples", [0.0, 8192.0, 234.5, 42.8])
+    @pytest.mark.slow
     async def test_delay_slope(
         self,
         mock_recv_stream: spead2.InprocQueue,
@@ -887,6 +890,7 @@ class TestEngine:
     # CHUNK_SAMPLES) to ensure narrowband windows fit.
     @pytest.mark.spectra_per_heap(32)
     @pytest.mark.cmdline_args("--recv-chunk-samples=8388608")
+    @pytest.mark.slow
     async def test_missing_heaps(
         self,
         mock_recv_stream: spead2.InprocQueue,


### PR DESCRIPTION
When pushing to a branch, skip a few tests that take a long time to run, to allow for quicker iteration. PRs and the main branch still run those tests, so we should still be kept honest.

This is a workaround for NGC-1466.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
