### PR TITLE
Add multicw signal to dsim

### DIFF
--- a/doc/dsim.rst
+++ b/doc/dsim.rst
@@ -61,6 +61,12 @@ final semi-colon. The following functions are available:
     currently no way to directly control phase, although the ``delay``
     function below gives limited control.
 
+:samp:`multicw({m}, {amplitude0}, {amplitude_step}, {frequency0}, {frequency_step})`
+    Sum of :samp:`{m}` multiple continuous waves. This is equivalent to
+    summing :samp:`cw({amplitude0} + {i}*{amplitude_step}, {frequency0} +
+    i*{frequency_step})` where :samp:`{i}` ranges from 0 (inclusive) to
+    :samp:`{m}` (exclusive), but with better accuracy.
+
 :samp:`comb({amplitude}, {frequency})`
     A comb of impulses, each one sample wide with the given amplitude. Note
     that if the frequency doesn't correspond to an integer number of samples,


### PR DESCRIPTION
This will be used for qualification tests for NGC-1464.

The implementation is pretty slow and naive. In future it may be implemented using an FFT for large values of m.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match