### PR TITLE
Test the filter-group-delay sensor

### DIFF
--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -571,13 +571,12 @@ async def test_phase_rate(
     )
 
 
-@pytest.mark.wideband_only
 async def test_group_delay(
     cbf: CBFRemoteControl,
     receive_tied_array_channelised_voltage: TiedArrayChannelisedVoltageReceiver,
     pdf_report: Reporter,
 ) -> None:
-    r"""Test the ``pfb-group-delay`` sensor.
+    r"""Test the ``filter-group-delay`` sensor.
 
     Verification method
     -------------------
@@ -724,7 +723,7 @@ async def test_group_delay(
     std = std2
     pdf_report.detail(f"Measured delay is {delay} ± {std} samples.")
 
-    reported_delay = await client.sensor_value("antenna-channelised-voltage.pfb-group-delay", float)
+    reported_delay = await client.sensor_value("antenna-channelised-voltage.filter-group-delay", float)
     pdf_report.detail(f"Reported delay is {reported_delay}.")
     assert abs(reported_delay - delay) < 5 * std
     pdf_report.detail("Measured value agrees with reported value to within 5 sigma.")

--- a/qualification/pytest-jenkins.ini
+++ b/qualification/pytest-jenkins.ini
@@ -15,7 +15,7 @@ log_cli = true
 log_cli_level = info
 log_cli_format = %(asctime)s.%(msecs)03d  %(levelname)-8s %(name)s:%(filename)s:%(lineno)d %(message)s
 addopts = --report-log=report.json
-default_antennas = 24
+default_antennas = 32
 max_antennas = 80
 wideband_channels = 1024 4096 8192 32768
 narrowband_channels = 32768


### PR DESCRIPTION
This required something of a rewrite of the test to improve the sensitivity. See the relevant commit for more details. I'm not completely happy that the sensitivity of the test depends on the number of antennas used (`default_antennas` setting). A potential alternative would be to fix the number of channels per dsim, then set the number of seconds of data to collect in inverse proportion to the number of antennas, which means that the test run-time would be variable and the precision would be fixed, rather than vice versa.

Note that the dsim image used needs #869, and the product controller needs ska-sa/katsdpcontroller#773.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report: [report8.pdf](https://github.com/user-attachments/files/17374113/report8.pdf)
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1464.
