### PR TITLE
Add qualification test for ?gain -> ?capture-start

### DIFF
--- a/qualification/antenna_channelised_voltage/test_gain.py
+++ b/qualification/antenna_channelised_voltage/test_gain.py
@@ -129,14 +129,15 @@ async def test_gains_capture_start(
     pdf_report.step("Inject white noise on first antenna.")
     signals = "common = wgn(0.1); common; common;"
     await cbf.dsim_clients[0].request("signals", signals)
-    pdf_report.detail(f"Set dsim signals to {signals}.")
+    dsim_timestamp = await cbf.dsim_clients[0].sensor_value("steady-state-timestamp", int)
+    pdf_report.detail(f"Set dsim signals to {signals}, starting with timestamp {dsim_timestamp}.")
 
     pdf_report.step("Wait for injected signal to reach F-engine.")
     label = receiver.input_labels[0]
     for _ in range(10):
-        power = await pcc.sensor_value(f"antenna-channelised-voltage.{label}.dig-rms-dbfs", float)
-        pdf_report.detail(f"dig-rms-dbfs = {power:.3g} dBFS")
-        if power > -1000:
+        rx_timestamp = await pcc.sensor_value(f"antenna-channelised-voltage.{label}.rx.timestamp", int)
+        pdf_report.detail(f"rx.timestamp = {rx_timestamp}")
+        if rx_timestamp >= dsim_timestamp:
             break
         else:
             pdf_report.detail("Sleep for 0.5s.")

--- a/qualification/antenna_channelised_voltage/test_gain.py
+++ b/qualification/antenna_channelised_voltage/test_gain.py
@@ -107,3 +107,57 @@ async def test_gains(
     # quantisation, since gain is handled as single-precision float.
     with check:
         assert max_rel_error < 0.1, "Maximum error exceeds 0.5 dB"
+
+
+@pytest.mark.name("Ordering of gains and capture-start")
+@pytest.mark.no_capture_start("baseline-correlation-products")
+async def test_gains_capture_start(
+    cbf: CBFRemoteControl,
+    receive_baseline_correlation_products: BaselineCorrelationProductsReceiver,
+    pdf_report: Reporter,
+) -> None:
+    r"""Test that gains applied before capture-start are not delayed.
+
+    Verification methods
+    --------------------
+    Verified by test. Change the gains, then immediately issue a capture-start
+    request. Verify that the received data reflects the change in gains.
+    """
+    receiver = receive_baseline_correlation_products
+    pcc = cbf.product_controller_client
+
+    pdf_report.step("Inject white noise on first antenna.")
+    signals = "common = wgn(0.1); common; common;"
+    await cbf.dsim_clients[0].request("signals", signals)
+    pdf_report.detail(f"Set dsim signals to {signals}.")
+
+    pdf_report.step("Wait for injected signal to reach F-engine.")
+    label = receiver.input_labels[0]
+    for _ in range(10):
+        power = await pcc.sensor_value(f"antenna-channelised-voltage.{label}.dig-rms-dbfs", float)
+        pdf_report.detail(f"dig-rms-dbfs = {power:.3g} dBFS")
+        if power > -1000:
+            break
+        else:
+            pdf_report.detail("Sleep for 0.5s.")
+            await asyncio.sleep(0.5)
+    else:
+        pytest.fail("Digitiser signal did not reach F-engine.")
+
+    pdf_report.step("Set gains on input 0")
+    gains = np.ones(receiver.n_chans)
+    cut = receiver.n_chans // 2
+    gains[cut:] = 0  # Zero out the upper half of the band
+    await pcc.request("gain", "antenna-channelised-voltage", label, *gains)
+    pdf_report.detail(f"Upper half of band on {label} set to zero gain.")
+
+    pdf_report.step("Capture and verify output")
+    await pcc.request("capture-start", "baseline-correlation-products")
+    _, data = await receiver.next_complete_chunk(min_timestamp=0)
+    bls_idx = receiver.bls_ordering.index((label, label))
+    data = data[:, bls_idx, 0]  # 0 to take just the real part (these are auto-correlations)
+    assert np.max(data[cut:]) == 0
+    # It's random, so technically it's possible for any of the values to be
+    # zero, but exceedingly unlikely.
+    assert np.min(data[:cut]) > 0
+    pdf_report.detail("Output reflects effects of gains.")

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -117,7 +117,7 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line("markers", "name(name): human-readable name for the test")
     config.addinivalue_line("markers", "wideband_only: do not run the test in narrowband configurations")
     config.addinivalue_line(
-        "markers", "no_capture_start([streams]): do not issue capture-start (on all streams if none specified)"
+        "markers", "no_capture_start([stream, ...]): do not issue capture-start (on all streams if none specified)"
     )
     for option in ini_options:
         assert config.getini(option.name) is not None, f"{option.name} missing from pytest.ini"

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -42,6 +42,7 @@ from .reporter import Reporter, custom_report_log
 logger = logging.getLogger(__name__)
 FULL_ANTENNAS = [1, 4, 8, 10, 16, 20, 32, 40, 55, 64, 65, 80]
 pdf_report_data_key = pytest.StashKey[dict]()
+_CAPTURE_TYPES = {"gpucbf.baseline_correlation_products", "gpucbf.tied_array_channelised_voltage"}
 
 
 # Storing ini options this way makes pytest.ini easier to validate up-front.
@@ -115,6 +116,9 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line("markers", "requirements(reqs): indicate which system engineering requirements are tested")
     config.addinivalue_line("markers", "name(name): human-readable name for the test")
     config.addinivalue_line("markers", "wideband_only: do not run the test in narrowband configurations")
+    config.addinivalue_line(
+        "markers", "no_capture_start([streams]): do not issue capture-start (on all streams if none specified)"
+    )
     for option in ini_options:
         assert config.getini(option.name) is not None, f"{option.name} missing from pytest.ini"
 
@@ -427,10 +431,27 @@ async def cbf_cache(pytestconfig: pytest.Config) -> AsyncGenerator[CBFCache, Non
 
 
 @pytest.fixture
+async def capture_start_streams(request: pytest.FixtureRequest, cbf_config: dict) -> list[str]:
+    """List of streams for which capture-start will automatically be issued."""
+    no_capture_start: set[str] = set()
+    for marker in request.node.iter_markers("no_capture_start"):
+        if marker.args == ():
+            return []  # Requests no streams be automatically started
+        no_capture_start.update(marker.args)
+
+    out = []
+    for name, conf in cbf_config["outputs"].items():
+        if name not in no_capture_start and conf["type"] in _CAPTURE_TYPES:
+            out.append(name)
+    return out
+
+
+@pytest.fixture
 async def cbf(
     cbf_cache: CBFCache,
     cbf_config: dict,
     cbf_mode_config: dict,
+    capture_start_streams: list[str],
     pdf_report: Reporter,
 ) -> AsyncGenerator[CBFRemoteControl, None]:
     """Set up a CBF for a single test.
@@ -448,7 +469,6 @@ async def cbf(
     async with asyncio.TaskGroup() as tg:
         for client in cbf.dsim_clients:
             tg.create_task(client.request("signals", "0;0;"))
-    capture_types = {"gpucbf.baseline_correlation_products", "gpucbf.tied_array_channelised_voltage"}
     for name, conf in cbf.config["outputs"].items():
         if conf["type"] == "gpucbf.antenna_channelised_voltage":
             n_inputs = len(conf["src_streams"])
@@ -461,13 +481,14 @@ async def cbf(
             await pcc.request("beam-quant-gains", name, 1.0)
             await pcc.request("beam-delays", name, *(("0:0",) * n_inputs))
             await pcc.request("beam-weights", name, *((1.0,) * n_inputs))
-        if conf["type"] in capture_types:
-            await pcc.request("capture-start", name)
+
+    for name in capture_start_streams:
+        await pcc.request("capture-start", name)
 
     yield cbf
 
     for name, conf in cbf.config["outputs"].items():
-        if conf["type"] in capture_types:
+        if conf["type"] in _CAPTURE_TYPES:
             await pcc.request("capture-stop", name)
 
 
@@ -544,6 +565,7 @@ def receive_baseline_correlation_products_manual_start(
 @pytest.fixture
 async def receive_baseline_correlation_products(
     receive_baseline_correlation_products_manual_start: BaselineCorrelationProductsReceiver,
+    capture_start_streams: list[str],
 ) -> BaselineCorrelationProductsReceiver:
     """Create a spead2 receive stream for ingesting X-engine output."""
     receiver = receive_baseline_correlation_products_manual_start
@@ -552,7 +574,8 @@ async def receive_baseline_correlation_products(
     # predates the start of this test (to prevent any state leaks from previous
     # tests). The timeout is increased since it may take some time to get the
     # data flowing at the start.
-    await receiver.wait_complete_chunk(max_delay=0, timeout=3 * DEFAULT_TIMEOUT)
+    if "baseline-correlation_products" in capture_start_streams:
+        await receiver.wait_complete_chunk(max_delay=0, timeout=3 * DEFAULT_TIMEOUT)
     return receiver
 
 
@@ -605,6 +628,8 @@ def receive_tied_array_channelised_voltage_manual_start(
 @pytest.fixture
 async def receive_tied_array_channelised_voltage(
     receive_tied_array_channelised_voltage_manual_start: TiedArrayChannelisedVoltageReceiver,
+    cbf_config: dict,
+    capture_start_streams: list[str],
 ) -> TiedArrayChannelisedVoltageReceiver:
     """Create a spead2 receive stream for ingest the tied-array-channelised-voltage streams."""
     receiver = receive_tied_array_channelised_voltage_manual_start
@@ -613,5 +638,10 @@ async def receive_tied_array_channelised_voltage(
     # predates the start of this test (to prevent any state leaks from previous
     # tests). The timeout is increased since it may take some time to get the
     # data flowing at the start.
-    await receiver.wait_complete_chunk(max_delay=0, timeout=3 * DEFAULT_TIMEOUT)
+    if all(
+        name in capture_start_streams
+        for name, config in cbf_config["outputs"].items()
+        if config["type"] == "gpucbf.tied_array_channelised_voltage"
+    ):
+        await receiver.wait_complete_chunk(max_delay=0, timeout=3 * DEFAULT_TIMEOUT)
     return receiver


### PR DESCRIPTION
Test that after changing F-engine gain, a ?capture-start only begins transmitting data that contains the effect. See NGC-1462.

This does not yet cover beamformer requests, which will be in a separate test in the appropriate directory.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report: [report.pdf](https://github.com/user-attachments/files/17378038/report.pdf)
- [x] If design has changed: ensure documentation is up to date
- [x] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
