### PR TITLE
Add qualification tests for capture-start after beam-*

### DIFF
--- a/qualification/antenna_channelised_voltage/test_gain.py
+++ b/qualification/antenna_channelised_voltage/test_gain.py
@@ -116,10 +116,10 @@ async def test_gains_capture_start(
     receive_baseline_correlation_products: BaselineCorrelationProductsReceiver,
     pdf_report: Reporter,
 ) -> None:
-    r"""Test that gains applied before capture-start are not delayed.
+    """Test that gains applied before capture-start are not delayed.
 
-    Verification methods
-    --------------------
+    Verification method
+    -------------------
     Verified by test. Change the gains, then immediately issue a capture-start
     request. Verify that the received data reflects the change in gains.
     """
@@ -157,7 +157,7 @@ async def test_gains_capture_start(
     _, data = await receiver.next_complete_chunk(min_timestamp=0)
     bls_idx = receiver.bls_ordering.index((label, label))
     data = data[:, bls_idx, 0]  # 0 to take just the real part (these are auto-correlations)
-    assert np.max(data[cut:]) == 0
+    np.testing.assert_equal(data[cut:], 0)
     # It's random, so technically it's possible for any of the values to be
     # zero, but exceedingly unlikely.
     assert np.min(data[:cut]) > 0

--- a/qualification/recv.py
+++ b/qualification/recv.py
@@ -345,6 +345,7 @@ class BaselineCorrelationProductsReceiver(XBReceiver):
         self.int_time = cbf.init_sensors[f"{stream_name}.int-time"].value
         self.bls_ordering = ast.literal_eval(cbf.init_sensors[f"{stream_name}.bls-ordering"].value.decode())
         self.timestamp_step = self.n_samples_between_spectra * self.n_spectra_per_acc
+        self.n_xengs = cbf.init_sensors[f"{stream_name}.n-xengs"].value
 
         self.stream_group = create_baseline_correlation_product_receive_stream_group(
             interface_address,
@@ -407,6 +408,7 @@ class TiedArrayChannelisedVoltageReceiver(XBReceiver):
             ast.literal_eval(cbf.init_sensors[f"{stream_name}.source-indices"].value.decode())
             for stream_name in stream_names
         ]
+        self.n_bengs = cbf.init_sensors[f"{stream_names[0]}.n-bengs"].value
 
         self.stream_group = create_tied_array_channelised_voltage_receive_stream_group(
             interface_address,

--- a/qualification/tied_array_channelised_voltage/test_steady_state.py
+++ b/qualification/tied_array_channelised_voltage/test_steady_state.py
@@ -1,0 +1,165 @@
+################################################################################
+# Copyright (c) 2024, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Test capture-start following state change requests."""
+
+import asyncio
+from typing import Awaitable, Callable
+
+import numpy as np
+import pytest
+
+from ..cbf import CBFRemoteControl
+from ..recv import TiedArrayChannelisedVoltageReceiver
+from ..reporter import Reporter
+
+
+async def _test_capture_start(
+    cbf: CBFRemoteControl,
+    receiver: TiedArrayChannelisedVoltageReceiver,
+    pdf_report: Reporter,
+    prepare: Callable[[], Awaitable],
+) -> np.ndarray:
+    """Implementation for tests of capture-start sequencing.
+
+    Each test provides a callback that issues a request to the product
+    controller. The received data is returned for the test to do
+    verification.
+    """
+    pcc = cbf.product_controller_client
+
+    # Note: because the beam quant gains are not adjusted, this will easily
+    # saturate with large numbers of antennas, but that doesn't affect the
+    # validity of any of the tests that use this function.
+    pdf_report.step("Inject white noise signal.")
+    signals = "common = nodither(wgn(0.1)); common; common;"
+    await cbf.dsim_clients[0].request("signals", signals)
+    dsim_timestamp = await cbf.dsim_clients[0].sensor_value("steady-state-timestamp", int)
+    pdf_report.detail(f"Set dsim signals to {signals}, starting with timestamp {dsim_timestamp}.")
+
+    pdf_report.step("Wait for injected signal to reach XB-engines.")
+    # Only need to query one stream, since it's the same engine backing
+    # all of them.
+    stream_name = receiver.stream_names[0]
+    for _ in range(10):
+        tasks = []
+        async with asyncio.TaskGroup() as tg:
+            for i in range(receiver.n_bengs):
+                tasks.append(tg.create_task(pcc.sensor_value(f"{stream_name}.{i}.rx.timestamp")))
+        min_timestamp = min(task.result() for task in tasks)
+        pdf_report.detail(f"minimum rx.timestamp = {min_timestamp}.")
+        if min_timestamp >= dsim_timestamp:
+            break
+        else:
+            pdf_report.detail("Sleep for 0.5s.")
+            await asyncio.sleep(0.5)
+    else:
+        pytest.fail("Digitiser signal did not reach XB-engines.")
+
+    await prepare()
+
+    pdf_report.step("Capture and verify output")
+    async with asyncio.TaskGroup() as tg:
+        for stream in receiver.stream_names:
+            tg.create_task(pcc.request("capture-start", stream))
+    _, data = await receiver.next_complete_chunk(min_timestamp=0)
+    return data
+
+
+@pytest.mark.name("Ordering of beam-quant-gains and capture-start")
+@pytest.mark.no_capture_start
+async def test_beam_quant_gains_capture_start(
+    cbf: CBFRemoteControl,
+    receive_tied_array_channelised_voltage: TiedArrayChannelisedVoltageReceiver,
+    pdf_report: Reporter,
+) -> None:
+    """Test that beam-quant-gains issued before capture-start is not delayed.
+
+    Verification method
+    -------------------
+    Verified by test. Issue a request, then immediately issue a capture-start
+    request. Verify that the received data reflects the change.
+    """
+    receiver = receive_tied_array_channelised_voltage
+
+    async def prepare() -> None:
+        pdf_report.step("Send request.")
+        pdf_report.detail("Set beam-quant-gains to 0 on first beam.")
+        await cbf.product_controller_client.request("beam-quant-gains", receiver.stream_names[0], 0.0)
+
+    data = await _test_capture_start(cbf, receiver, pdf_report, prepare)
+    assert np.all(data[0] == 0)
+    assert np.sum(data[1] != 0) >= data[1].size // 2  # Should be mostly non-zero
+    pdf_report.detail("Output reflects effects of beam-quant-gains.")
+
+
+@pytest.mark.name("Ordering of beam-weights and capture-start")
+@pytest.mark.no_capture_start
+async def test_beam_weights_capture_start(
+    cbf: CBFRemoteControl,
+    receive_tied_array_channelised_voltage: TiedArrayChannelisedVoltageReceiver,
+    pdf_report: Reporter,
+) -> None:
+    """Test that beam-weights issued before capture-start is not delayed.
+
+    Verification method
+    -------------------
+    Verified by test. Issue a request, then immediately issue a capture-start
+    request. Verify that the received data reflects the change.
+    """
+    receiver = receive_tied_array_channelised_voltage
+
+    async def prepare() -> None:
+        pdf_report.step("Send request.")
+        pdf_report.detail("Set beam-weights to 0 on first beam.")
+        weights = [0.0] * len(receiver.source_indices[0])
+        await cbf.product_controller_client.request("beam-weights", receiver.stream_names[0], *weights)
+
+    data = await _test_capture_start(cbf, receiver, pdf_report, prepare)
+    assert np.all(data[0] == 0)
+    assert np.sum(data[1] != 0) >= data[1].size // 2  # Should be mostly non-zero
+    pdf_report.detail("Output reflects effects of beam-weights.")
+
+
+@pytest.mark.name("Ordering of beam-delays and capture-start")
+@pytest.mark.no_capture_start
+async def test_beam_delays_capture_start(
+    cbf: CBFRemoteControl,
+    receive_tied_array_channelised_voltage: TiedArrayChannelisedVoltageReceiver,
+    pdf_report: Reporter,
+) -> None:
+    """Test that beam-delays issued before capture-start is not delayed.
+
+    Verification method
+    -------------------
+    Verified by test. Issue a request, then immediately issue a capture-start
+    request. Verify that the received data reflects the change.
+    """
+    receiver = receive_tied_array_channelised_voltage
+
+    async def prepare() -> None:
+        pdf_report.step("Send request.")
+        pdf_report.detail("Set beam-delays to phase π on first beam.")
+        delays = [f"0:{np.pi}"] * len(receiver.source_indices[0])
+        await cbf.product_controller_client.request("beam-delays", receiver.stream_names[0], *delays)
+
+    data = await _test_capture_start(cbf, receiver, pdf_report, prepare)
+    assert np.sum(data[0] != 0) >= data[0].size // 2  # Should be mostly non-zero
+    # We use data[2] instead of data[1], because data[1] is the other
+    # polarisation and so experiences different F-engine dithering. The
+    # tolerance allows for some rounding error plus dithered quantisation.
+    np.testing.assert_allclose(data[0], -data[2], atol=2)
+    pdf_report.detail("Output reflects effects of beam-delays.")


### PR DESCRIPTION
Closes NGC-1462.

Note that this requires ska-sa/katsdpcontroller#774.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report: [report.pdf](https://github.com/user-attachments/files/17392930/report.pdf)
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
