### PR TITLE
dsim: speed up multicw

### DIFF
--- a/doc/dsim.rst
+++ b/doc/dsim.rst
@@ -65,7 +65,8 @@ final semi-colon. The following functions are available:
     Sum of :samp:`{m}` multiple continuous waves. This is equivalent to
     summing :samp:`cw({amplitude0} + {i}*{amplitude_step}, {frequency0} +
     i*{frequency_step})` where :samp:`{i}` ranges from 0 (inclusive) to
-    :samp:`{m}` (exclusive), but with better accuracy.
+    :samp:`{m}` (exclusive), but with better accuracy. It is also much
+    faster when :samp:`{m}` is large.
 
 :samp:`comb({amplitude}, {frequency})`
     A comb of impulses, each one sample wide with the given amplitude. Note

--- a/src/katgpucbf/dsim/signal.py
+++ b/src/katgpucbf/dsim/signal.py
@@ -32,6 +32,7 @@ import dask.array as da
 import numba
 import numpy as np
 import pyparsing as pp
+import scipy.fft
 import xarray as xr
 
 from .. import BYTE_BITS
@@ -335,7 +336,7 @@ class MultiCW(Signal):
                 spectrum[neg] += 0.5 * amp
 
         # Inverse FFT to get time domain
-        v = np.fft.irfft(spectrum, n=n, norm="forward")
+        v = scipy.fft.irfft(spectrum, n=n, norm="forward")
         return da.asarray(v, chunks=CHUNK_SIZE)
 
     def __str__(self) -> str:

--- a/src/katgpucbf/dsim/signal.py
+++ b/src/katgpucbf/dsim/signal.py
@@ -320,21 +320,23 @@ class MultiCW(Signal):
         return accum.astype(np.float32)
 
     def sample(self, n: int, sample_rate: float) -> da.Array:  # noqa: D102
-        frequencies = np.arange(self.m) * self.frequency_step + self.frequency0
-        amplitudes = np.arange(self.m) * self.amplitude_step + self.amplitude0
-        # Round target frequencies to fit an integer number of waves into signal_heaps
-        waves = np.maximum(1.0, np.rint(n * frequencies / sample_rate))
+        # Build the frequency domain
+        spectrum = np.zeros(n // 2 + 1, np.float32)
+        for i in range(self.m):
+            f = i * self.frequency_step + self.frequency0
+            # Round target frequency to fit an integer number of waves into signal_heaps
+            waves = max(1, round(n * f / sample_rate))
+            pos = waves % n  # Positive frequency component
+            neg = (-waves) % n  # Negative frequency component
+            amp = i * self.amplitude_step + self.amplitude0
+            if 0 <= pos < len(spectrum):
+                spectrum[pos] += 0.5 * amp
+            if 0 <= neg < len(spectrum):
+                spectrum[neg] += 0.5 * amp
 
-        # Index of the first element of each chunk
-        offsets = da.arange(0, n, CHUNK_SIZE, chunks=1, dtype=np.int64)
-        return _sample_helper(
-            n,
-            offsets,
-            self._sample_chunk,
-            amplitudes=amplitudes,
-            frequencies=waves / n,
-            meta=np.array((), np.float32),
-        )
+        # Inverse FFT to get time domain
+        v = np.fft.irfft(spectrum, n=n, norm="forward")
+        return da.asarray(v, chunks=CHUNK_SIZE)
 
     def __str__(self) -> str:
         return (

--- a/test/dsim/test_signal.py
+++ b/test/dsim/test_signal.py
@@ -76,9 +76,9 @@ class TestCW:
 class TestMultiCW:
     """Tests for :class:`katgpucbf.dsim.signal.MultiCW`."""
 
-    def test_sample(self) -> None:
+    def test_even(self) -> None:
         adc_sample_rate = 1e9
-        sig = MultiCW(3, 0.5, 0.25, 100e6, 200e6)
+        sig = MultiCW(4, 0.5, 0.25, 100e6, 200e6)
         n = 10000
         out = sig.sample(n, adc_sample_rate)
         timestamps = np.arange(0, n)
@@ -86,6 +86,20 @@ class TestMultiCW:
             0.5 * np.cos(timestamps * (2 * np.pi * 0.1))
             + 0.75 * np.cos(timestamps * (2 * np.pi * 0.3))
             + 1.0 * np.cos(timestamps * (2 * np.pi * 0.5))
+            + 1.25 * np.cos(timestamps * (2 * np.pi * 0.7))
+        )
+        np.testing.assert_allclose(out, expected, atol=1e-6)
+
+    def test_odd(self) -> None:
+        adc_sample_rate = 1e9
+        sig = MultiCW(3, 0.5, 0.25, 200e6, 400e6)
+        n = 25
+        out = sig.sample(n, adc_sample_rate)
+        timestamps = np.arange(0, n)
+        expected = (
+            0.5 * np.cos(timestamps * (2 * np.pi * 0.2))
+            + 0.75 * np.cos(timestamps * (2 * np.pi * 0.6))
+            + 1.0 * np.cos(timestamps * (2 * np.pi * 1.0))
         )
         np.testing.assert_allclose(out, expected, atol=1e-6)
 


### PR DESCRIPTION
Implement it using an FFT (actually a DCT), instead of manually adding all the signals together. This significant reduces the time when there are a large number of CWs to add.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Relates to NGC-1464.
