### PR TITLE
Fix UnboundLocalError in qualification test

### DIFF
--- a/qualification/cbf.py
+++ b/qualification/cbf.py
@@ -355,10 +355,10 @@ class CBFCache:
         if self._cbf is not None and self._cbf.config == cbf_config:
             return self._cbf
 
+        product_name = self._pytestconfig.getini("product_name")
         try:
             await self._close_cbf()
             master_controller_client = await self._get_master_controller_client()
-            product_name = self._pytestconfig.getini("product_name")
             try:
                 reply, _ = await master_controller_client.request(
                     "product-configure", product_name, json.dumps(cbf_config)


### PR DESCRIPTION
If get_cbf failed early enough, the `product_name` variable won't have been initialised yet, which in turn breaks the attempt to cache the FailedCBF and properly log the failure message.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
