### PR TITLE
Increase qualification test time to 16 hours

### DIFF
--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
   }
 
   options {
-    timeout(time: 12, unit: 'HOURS')
+    timeout(time: 16, unit: 'HOURS')
   }
 
   stages {


### PR DESCRIPTION
Hopefully this is only needed temporarily, to figure out why the tests are currently running slow.
