### PR TITLE
Compare like pols in test_gain

### DIFF
--- a/qualification/tied_array_channelised_voltage/test_gain.py
+++ b/qualification/tied_array_channelised_voltage/test_gain.py
@@ -79,9 +79,9 @@ async def test_gain(
     pdf_report.step("Compare beams to each other.")
     # Compare like pols because the dithering is independent between pols and may rarely cause
     # differences greater than expected.
-    for i in [2, 4]:
-        scale = gains[i] / gains[0]
-        expected = data[0] * scale
+    for i in range(2, len(gains)):
+        scale = gains[i] / gains[i % 2]
+        expected = data[i % 2] * scale
         # The actual data gets clamped, so we should clamp expected values too
         max_value = 2 ** (receiver.n_bits_per_sample - 1) - 1
         expected = np.clip(expected, -max_value, max_value)

--- a/qualification/tied_array_channelised_voltage/test_gain.py
+++ b/qualification/tied_array_channelised_voltage/test_gain.py
@@ -48,8 +48,8 @@ async def test_gain(
     await cbf.dsim_clients[0].request("signals", f"common=nodither(wgn({amplitude}));common;common;")
     pdf_report.detail(f"Set D-sim with wgn amplitude={amplitude}.")
 
-    gains = [0.5, 1.0, 2.0]
-    stream_names = receiver.stream_names[: len(gains)]  # Only need 3 half-beams for the test
+    gains = [0.5, 0.5, 1.0, 1.0, 2.0, 2.0]
+    stream_names = receiver.stream_names[: len(gains)]  # Only need 3 beams for the test
     pdf_report.step("Set weights to 1/n_ants")
     weights = (1.0 / receiver.n_ants,) * receiver.n_ants
     client = cbf.product_controller_client
@@ -77,7 +77,9 @@ async def test_gain(
         assert power == pytest.approx(expected_power, rel=0.05)
 
     pdf_report.step("Compare beams to each other.")
-    for i in range(1, len(gains)):
+    # Compare like pols because the dithering is independent between pols and may rarely cause
+    # differences greater than expected.
+    for i in [2, 4]:
         scale = gains[i] / gains[0]
         expected = data[0] * scale
         # The actual data gets clamped, so we should clamp expected values too


### PR DESCRIPTION
The qualification/tied_array_channelised_voltage/test_gain test occasionally shows a difference one greater expected for a single value in the test every now and then. It's very intermittent. To a first approximation this shouldn't be possible because the tolerance for each test should be taken into account and there's no way for dithering to cause a bigger difference assuming that the incoming signal is the same.

We think that this is caused by separate dithering for each pol in the F-engine which means that despite having the same d-sim input, the F-engine output for pol0 and pol1 may be ever so slightly different from each other, just different to cause the error.

In this commit I adjust the test to using the same pol in three different beams for comparison, rather than three half-beams which would have been pol0, pol1, pol0.

This appears to solve the problem.

Closes NGC-1473.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [ ] If qualification tests are changed: attach a sample qualification report **No significant change in report.**
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
