### PR TITLE
Move pip to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,7 @@ RUN pip install pip==24.2 setuptools==72.1.0 wheel==0.44.0
 # Jenkins image has a clean environment to start from).
 WORKDIR /tmp/katgpucbf
 COPY requirements.txt .
+COPY requirements-dev.txt .
 RUN pip install --no-deps -c /tmp/katgpucbf/requirements.txt pycuda && \
     pip uninstall -y pycuda
 
@@ -100,6 +101,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
     texlive-latex-extra \
     texlive-latex-recommended \
     texlive-science
+
+# Install required packages for testing to be able to run
+RUN pip install -r requirements.txt -r requirements-dev.txt
 
 # Jenkins runs the containers with the `-u 1000:1000` option, not as root.
 RUN chown -Rf +1000:+1000 /venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
     texlive-latex-recommended \
     texlive-science
 
+# Jenkins runs the containers with the `-u 1000:1000` option, not as root.
+RUN chown -Rf +1000:+1000 /venv
+
 #######################################################################
 
 # The above image is independent of the contents of this package (except

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,12 +57,6 @@ pipeline {
   }
 
   stages {
-    stage('Install Python packages') {
-      steps {
-        sh 'pip install -r requirements.txt -r requirements-dev.txt'
-      }
-    }
-
     stage('Install katgpucbf package') {
       steps {
         sh 'pip install --no-deps ".[test]" && pip check'


### PR DESCRIPTION
to benefit from the caching of docker builds.

Also, chown the venv in the jenkins build to 1000:1000 so that jenkins-test can run it without any hackery of who is running what.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A)  If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [ ] Ensure copyright notices are present and up-to-date
- [x] (N/A)  If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

