### PR TITLE
Modify qualification Jenkinsfile for saner agents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
     docker-buildx \
     fonts-liberation2 \
     latexmk \
+    libcap2-dev \
+    libcap2-bin \
     lmodern \
     pdf2svg \
     tex-gyre \
@@ -100,6 +102,12 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
     texlive-latex-extra \
     texlive-latex-recommended \
     texlive-science
+
+# spead2_net_raw is needed so that qualification tests can use ibverbs
+RUN wget https://raw.githubusercontent.com/ska-sa/spead2/master/src/spead2_net_raw.cpp && \
+    gcc -Wall -O2 -o spead2_net_raw spead2_net_raw.cpp -lcap && \
+    mv spead2_net_raw /usr/local/bin && \
+    setcap cap_net_raw+p /usr/local/bin/spead2_net_raw
 
 # Install required packages for testing to be able to run
 COPY requirements-dev.txt .

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,11 +113,10 @@ RUN chown -R +1000:+1000 /venv
 # spead2_net_raw is needed so that qualification tests can use ibverbs
 RUN SPEAD2_VERSION=$(grep ^spead2== requirements.txt | cut -d= -f3) && \
     cd /tmp && \
-    wget https://github.com/ska-sa/spead2/releases/download/v$SPEAD2_VERSION/spead2-$SPEAD2_VERSION.tar.gz && \
-    tar -zxf "spead2-$SPEAD2_VERSION.tar.gz" && \
-    cd "spead2-$SPEAD2_VERSION/src" %&& \
+    wget https://raw.githubusercontent.com/ska-sa/spead2/refs/tags/v$SPEAD2_VERSION/src/spead2_net_raw.cpp && \
     gcc -Wall -O2 -o /usr/local/bin/spead2_net_raw spead2_net_raw.cpp -lcap && \
-    setcap cap_net_raw+p /usr/local/bin/spead2_net_raw
+    setcap cap_net_raw+p /usr/local/bin/spead2_net_raw && \
+    rm spead2_net_raw.cpp
 
 #######################################################################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,17 +103,21 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
     texlive-latex-recommended \
     texlive-science
 
-# spead2_net_raw is needed so that qualification tests can use ibverbs
-RUN wget https://raw.githubusercontent.com/ska-sa/spead2/master/src/spead2_net_raw.cpp && \
-    gcc -Wall -O2 -o /usr/local/bin/spead2_net_raw spead2_net_raw.cpp -lcap && \
-    setcap cap_net_raw+p /usr/local/bin/spead2_net_raw
-
 # Install required packages for testing to be able to run
 COPY requirements-dev.txt .
 RUN pip install -r requirements.txt -r requirements-dev.txt
 
 # Jenkins runs the containers with the `-u 1000:1000` option, not as root.
 RUN chown -R +1000:+1000 /venv
+
+# spead2_net_raw is needed so that qualification tests can use ibverbs
+RUN SPEAD2_VERSION=$(grep ^spead2== requirements.txt | cut -d= -f3) && \
+    cd /tmp && \
+    wget https://github.com/ska-sa/spead2/releases/download/v$SPEAD2_VERSION/spead2-$SPEAD2_VERSION.tar.gz && \
+    tar -zxf "spead2-$SPEAD2_VERSION.tar.gz" && \
+    cd "spead2-$SPEAD2_VERSION/src" %&& \
+    gcc -Wall -O2 -o /usr/local/bin/spead2_net_raw spead2_net_raw.cpp -lcap && \
+    setcap cap_net_raw+p /usr/local/bin/spead2_net_raw
 
 #######################################################################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,8 +105,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
 
 # spead2_net_raw is needed so that qualification tests can use ibverbs
 RUN wget https://raw.githubusercontent.com/ska-sa/spead2/master/src/spead2_net_raw.cpp && \
-    gcc -Wall -O2 -o spead2_net_raw spead2_net_raw.cpp -lcap && \
-    mv spead2_net_raw /usr/local/bin && \
+    gcc -Wall -O2 -o /usr/local/bin/spead2_net_raw spead2_net_raw.cpp -lcap && \
     setcap cap_net_raw+p /usr/local/bin/spead2_net_raw
 
 # Install required packages for testing to be able to run

--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -86,7 +86,7 @@ pipeline {
           * tests and mark the build as unstable.
           */
          sh '''
-           spead2_net_raw pytest -v -c qualification/pytest-jenkins.ini qualification\
+           spead2_net_raw pytest -v -c qualification/pytest-jenkins.ini qualification \
            --suppress-tests-failed-exit-code \
            --image-override katgpucbf:${katgpucbf_image} \
            --image-override katsdpcontroller:${katsdpcontroller_image} \

--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -86,7 +86,7 @@ pipeline {
           * tests and mark the build as unstable.
           */
          sh '''
-           pytest -v -c qualification/pytest-jenkins.ini qualification\
+           spead2_net_raw pytest -v -c qualification/pytest-jenkins.ini qualification\
            --suppress-tests-failed-exit-code \
            --image-override katgpucbf:${katgpucbf_image} \
            --image-override katsdpcontroller:${katsdpcontroller_image} \

--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -61,6 +61,7 @@ pipeline {
   }
 
   options {
+    disableConcurrentBuilds()
     timeout(time: 16, unit: 'HOURS')
   }
 


### PR DESCRIPTION
In the Jenkins setup that our former colleague put together, we had "clouds" rather than Nodes, which ran their containers as root. It was a rather complicated setup and we've simplified things, but in the new regime containers don't get run as root anymore so they need slightly different capabilities.

This commit adds spead2_net_raw into the Jenkins image so that the agent that runs qualification can use its magic to enable ibverbs. In order for that to work, we need to install a couple more libraries in the `jenkins` docker image. We also add usage of the spead2_net_raw executable to endow pytest with ibverbs.

Contribures to NGC-1447.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

