### PR TITLE
Simplify treatment of vkgdr in benchmark script

### DIFF
--- a/scratch/benchmarks/benchmark_fgpu.py
+++ b/scratch/benchmarks/benchmark_fgpu.py
@@ -120,12 +120,8 @@ def fgpu_factory(
     hstep = step // 2
     qstep = step // 4
     my_cpus = server_info.cpus[index * step : (index + 1) * step]
-    if args.use_vkgdr:
-        recv_chunk_samples = 2**24 // scaling_n
-        send_chunk_jones = recv_chunk_samples // 2
-    else:
-        recv_chunk_samples = 2**27 // scaling_n
-        send_chunk_jones = recv_chunk_samples // 4
+    recv_chunk_samples = 2**27 // scaling_n
+    send_chunk_jones = recv_chunk_samples // 4
     if n == 1:
         interface = ",".join(server.interfaces[:2])
         recv_affinity = f"0,1,{qstep},{qstep + 1}"
@@ -172,7 +168,7 @@ def fgpu_factory(
         f"--prometheus-port={prometheus_port} "
         f"--sync-time={sync_time} "
         f"--feng-id={index} "
-        f"{'--use-vkgdr --max-delay-diff=65536' if args.use_vkgdr else ''} "
+        f"{'--use-vkgdr' if args.use_vkgdr else ''} "
         f"--wideband={wideband_arg} "
         f"239.102.{index}.64+15:7148 "
     )


### PR DESCRIPTION
Remove special handling from benchmark_fgpu when running with --use-vkgdr. Previously this was needed because we only had a 256 MiB BAR, but with a BIOS update we get a full-sized BAR and no longer need these options.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Relates to NGC-1477
