### PR TITLE
Disable concurrent builds in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,7 @@ pipeline {
   agent { label 'katgpucbf' }
   options {
     timeout(time: 2, unit: 'HOURS')
+    disableConcurrentBuilds()
   }
 
   stages {


### PR DESCRIPTION
The intention is to check whether we can concurrently run separate branches on an agent with two executors.

On test-Jenkins it appears to work, different branches run happily side-by-side, the same branch however sits and waits for its predecessor to complete.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) f dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Contributes to NGC-1447.
