### PR TITLE
Add copy-mk script

### DIFF
--- a/scratch/copy-mk.py
+++ b/scratch/copy-mk.py
@@ -127,7 +127,7 @@ async def async_main(args) -> int:
         "band": band,
     }
 
-    out_cmd = [str(os.path.join(os.path.dirname(__file__), "sim_correlator.py"))]
+    out_cmd = [os.path.join(os.path.dirname(__file__), "sim_correlator.py")]
 
     for k, v in out_kwargs.items():
         out_cmd.append(f"--{k}={v}")

--- a/scratch/copy-mk.py
+++ b/scratch/copy-mk.py
@@ -45,7 +45,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser()
     parser.add_argument("cmc_host", help="Hostname / IP address of the CMC.")
-    parser.add_argument("--cmc_port", type=int, default=7147, help="KATCP port of the CMC. [%(default)s]")
+    parser.add_argument("--cmc-port", type=int, default=7147, help="KATCP port of the CMC. [%(default)s]")
     parser.add_argument("--target", type=str, required=True, help="Which subordinate to copy.")
     parser.add_argument(
         "--develop",

--- a/scratch/copy-mk.py
+++ b/scratch/copy-mk.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 ################################################################################
-# Copyright (c) 2024, National Research Foundation (SARAO)
+# Copyright (c) 2024-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -85,7 +85,7 @@ async def async_main(args) -> int:
         n_antennas = len(mcast_groups) // 2
         for n, grp in enumerate(mcast_groups[1:]):
             if grp == mcast_groups[0]:
-                # MK is not using a full power-of-2 size array, there are dummies from here onwards.
+                # MK is not using a full power-of-2 size array. There are dummies from here onwards.
                 print("Dummy antenna found starting at ", (n + 1) // 2)
                 n_antennas = (n + 1) // 2
                 break
@@ -142,7 +142,7 @@ async def async_main(args) -> int:
 
     out_cmd.append("cbf-mc.cbf.mkat.karoo.kat.ac.za")
 
-    print(f"Executing: {out_cmd}", "\n")
+    print(f"Executing: {out_cmd}\n")
     execv(out_cmd[0], out_cmd[1:])
 
 

--- a/scratch/copy-mk.py
+++ b/scratch/copy-mk.py
@@ -104,11 +104,11 @@ async def async_main(args) -> int:
     try:
         target = subordinates[args.target]
     except KeyError:
-        print(f"{args.target} is not among the subordinates currently running. Options are: {subordinates.keys()}")
+        print(f"{args.target} is not among the subordinates currently running. Options are: {subordinates.keys()}", file=sys.stderr)
         return 1
 
     # connect to the corr2_servlet itself to see the sync time, n_chans and bandwidth
-    corr2_client = await aiokatcp.Client.connect(args.cmc_host, control_port)
+    corr2_client = await aiokatcp.Client.connect(args.cmc_host, target.control_port)
     sync_time = await get_sensor_value(corr2_client, "sync-time", float)
     channels = await get_sensor_value(corr2_client, "antenna-channelised-voltage-n-chans", int)
     bandwidth = await get_sensor_value(corr2_client, "antenna-channelised-voltage-bandwidth", float)

--- a/scratch/copy-mk.py
+++ b/scratch/copy-mk.py
@@ -24,10 +24,10 @@ instead of a simulated one, it gets the parameters from a live MK correlator.
 
 import argparse
 import asyncio
+import os
 import sys
 from collections.abc import Sequence
 from dataclasses import dataclass
-from os import execv
 
 import aiokatcp
 
@@ -56,6 +56,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="Pass development options in the config. Use comma separation, or omit the arg to enable all.",
     )
     parser.add_argument("--image-override", action="append", metavar="NAME:IMAGE:TAG", help="Override a single image")
+    parser.add_argument("--controller", help="Hostname of the SDP master controller")
     args = parser.parse_args(argv)
     return args
 
@@ -126,9 +127,7 @@ async def async_main(args) -> int:
         "band": band,
     }
 
-    out_cmd = [
-        "./sim_correlator.py",
-    ]
+    out_cmd = [str(os.path.join(os.path.dirname(__file__), "sim_correlator.py"))]
 
     for k, v in out_kwargs.items():
         out_cmd.append(f"--{k}={v}")
@@ -140,10 +139,10 @@ async def async_main(args) -> int:
         for override in args.image_override:
             out_cmd.append(f"--image-override={override}")
 
-    out_cmd.append("cbf-mc.cbf.mkat.karoo.kat.ac.za")
+    out_cmd.append(args.controller)
 
-    print(f"Executing: {out_cmd}\n")
-    execv(out_cmd[0], out_cmd[1:])
+    print(f"Executing: {out_cmd}", "\n")
+    os.execv(out_cmd[0], out_cmd[1:])
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/scratch/copy-mk.py
+++ b/scratch/copy-mk.py
@@ -72,7 +72,7 @@ async def async_main(args) -> int:
     cmc_client = await aiokatcp.Client.connect(args.cmc_host, args.cmc_port)
 
     try:
-        reply, informs = await cmc_client.request("subordinate-list")
+        _, informs = await cmc_client.request("subordinate-list")
     except (aiokatcp.FailReply, ConnectionError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1

--- a/scratch/copy-mk.py
+++ b/scratch/copy-mk.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+
+################################################################################
+# Copyright (c) 2024, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Copy a running MK correlator.
+
+This script makes use of sim_correlator.py in order to start a correlator, but
+instead of a simulated one, it gets the parameters from a live MK correlator.
+"""
+
+import argparse
+import asyncio
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+import aiokatcp
+
+
+@dataclass
+class Subordinate:
+    name: str
+    control_port: int
+    monitor_port: int
+    digitiser_address: str
+    n_antennas: int
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("cmc_host", help="Hostname / IP address of the CMC.")
+    parser.add_argument("--cmc_port", type=int, default=7147, help="KATCP port of the CMC. [%(default)s]")
+    parser.add_argument("--target", type=str, required=True, help="Which subordinate to copy.")
+
+    args = parser.parse_args(argv)
+    return args
+
+
+async def get_sensor_value(client: aiokatcp.Client, sensor_name: str, sensor_type: Callable):
+    """Retrieve a sensor value from a katcp client."""
+    try:
+        _, informs = await client.request("sensor-value", sensor_name)
+    except (aiokatcp.FailReply, ConnectionError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    return sensor_type(informs[0].arguments[4].decode())
+
+
+async def async_main(args) -> int:
+    cmc_client = await aiokatcp.Client.connect(args.cmc_host, args.cmc_port)
+
+    try:
+        reply, informs = await cmc_client.request("subordinate-list")
+    except (aiokatcp.FailReply, ConnectionError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    if len(informs) == 0:
+        print(f"No subarrays currently running on {args.cmc_host}")
+        return 1
+
+    subordinates = {}
+    for inform in informs:
+        name = inform.arguments[0].decode()
+        control_port, monitor_port = inform.arguments[1].decode().split(",")
+        control_port = int(control_port)
+        monitor_port = int(monitor_port)
+        mcast_groups = []
+        for grp in inform.arguments[2:]:
+            mcast_groups.append(grp.decode())
+        n_antennas = len(mcast_groups) // 2
+        for n, grp in enumerate(mcast_groups[1:]):
+            if grp == mcast_groups[0]:
+                # MK is not using a full power-of-2 size array, there are dummies from here onwards.
+                print("Dummy antenna found starting at ", (n + 1) // 2)
+                n_antennas = (n + 1) // 2
+                break
+        digitiser_address = mcast_groups[0].split("+")[0]
+
+        subordinates[name] = Subordinate(name, control_port, monitor_port, digitiser_address, n_antennas)
+
+    try:
+        target = subordinates[args.target]
+    except KeyError:
+        print(f"{args.target} is not among the subordinates currently running. Options are: {subordinates.keys()}")
+        return 1
+
+    # connect to the corr2_servlet itself to see the sync time, n_chans and bandwidth
+    corr2_client = await aiokatcp.Client.connect(args.cmc_host, control_port)
+    sync_time = await get_sensor_value(corr2_client, "sync-time", float)
+    channels = await get_sensor_value(corr2_client, "antenna-channelised-voltage-n-chans", int)
+    bandwidth = await get_sensor_value(corr2_client, "antenna-channelised-voltage-bandwidth", float)
+    # TODO: this could probably be better, and doesn't support S-band yet.
+    match bandwidth:
+        case 544000000.0:
+            band = "u"
+        case 85600000.0:
+            band = "l"
+        case _:
+            print(f"Unable to determine which band we are in. Bandwidth reported as {bandwidth}", file=sys.stderr)
+            return 1
+
+    out_kwargs = {
+        "name": target.name.replace(".", "_"),
+        "antennas": target.n_antennas,
+        "channels": channels,
+        "digitiser-address": mcast_groups[0].split("+")[0],
+        "sync-time": sync_time,
+        "band": band,
+    }
+
+    out_cmd = [
+        "python",
+        "sim_correlator.py",
+        "cbf-mc.cbf.mkat.karoo.kat.ac.za",
+    ]
+
+    for k, v in out_kwargs.items():
+        out_cmd.append(f"--{k}={v}")
+
+    output = subprocess.run(out_cmd, capture_output=True)
+    print(output)
+
+    return output.returncode
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    return asyncio.run(async_main(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scratch/copy-mk.py
+++ b/scratch/copy-mk.py
@@ -47,7 +47,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("cmc_host", help="Hostname / IP address of the CMC.")
     parser.add_argument("--cmc_port", type=int, default=7147, help="KATCP port of the CMC. [%(default)s]")
     parser.add_argument("--target", type=str, required=True, help="Which subordinate to copy.")
-
+    parser.add_argument(
+        "--develop",
+        nargs="?",
+        const=True,
+        help="Pass development options in the config. Use comma separation, or omit the arg to enable all.",
+    )
+    parser.add_argument("--image-override", action="append", metavar="NAME:IMAGE:TAG", help="Override a single image")
     args = parser.parse_args(argv)
     return args
 
@@ -133,6 +139,13 @@ async def async_main(args) -> int:
 
     for k, v in out_kwargs.items():
         out_cmd.append(f"--{k}={v}")
+
+    if args.develop is not None:
+        out_cmd.append(f"--develop={args.develop}")
+
+    if args.image_override is not None:
+        for override in args.image_override:
+            out_cmd.append(f"--image-override={override}")
 
     output = subprocess.run(out_cmd, capture_output=True)
     print(output)

--- a/scratch/copy-mk.py
+++ b/scratch/copy-mk.py
@@ -56,7 +56,9 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="Pass development options in the config. Use comma separation, or omit the arg to enable all.",
     )
     parser.add_argument("--image-override", action="append", metavar="NAME:IMAGE:TAG", help="Override a single image")
-    parser.add_argument("--controller", help="Hostname of the SDP master controller")
+    parser.add_argument(
+        "--controller", default="cbf-mc.cbf.mkat.karoo.kat.ac.za", help="Hostname of the SDP master controller"
+    )
     args = parser.parse_args(argv)
     return args
 

--- a/scratch/copy-mk.py
+++ b/scratch/copy-mk.py
@@ -116,7 +116,7 @@ async def async_main(args) -> int:
     match bandwidth:
         case 544000000.0:
             band = "u"
-        case 85600000.0:
+        case 856000000.0:
             band = "l"
         case _:
             print(f"Unable to determine which band we are in. Bandwidth reported as {bandwidth}", file=sys.stderr)

--- a/scratch/copy-mk.py
+++ b/scratch/copy-mk.py
@@ -46,7 +46,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("cmc_host", help="Hostname / IP address of the CMC.")
     parser.add_argument("--cmc-port", type=int, default=7147, help="KATCP port of the CMC. [%(default)s]")
-    parser.add_argument("--target", type=str, required=True, help="Which subordinate to copy.")
+    parser.add_argument("--subordinate", type=str, required=True, help="Which subordinate to copy.")
     parser.add_argument(
         "--develop",
         nargs="?",
@@ -102,9 +102,9 @@ async def async_main(args) -> int:
         subordinates[name] = Subordinate(name, control_port, monitor_port, digitiser_address, n_antennas)
 
     try:
-        target = subordinates[args.target]
+        target = subordinates[args.subordinate]
     except KeyError:
-        print(f"{args.target} is not among the subordinates currently running. Options are: {subordinates.keys()}", file=sys.stderr)
+        print(f"{args.subordinate} is not among the subordinates currently running. Options are: {subordinates.keys()}")
         return 1
 
     # connect to the corr2_servlet itself to see the sync time, n_chans and bandwidth

--- a/scratch/copy-mk.py
+++ b/scratch/copy-mk.py
@@ -103,7 +103,7 @@ async def async_main(args) -> int:
     corr2_client = await aiokatcp.Client.connect(args.cmc_host, target.control_port)
     sync_time = await corr2_client.sensor_value("sync-time", float)
     channels = await corr2_client.sensor_value("antenna-channelised-voltage-n-chans", int)
-    sample_rate = await corr2_client.sensor_value("antenna-channelised-voltage-bandwidth", float) * 2
+    sample_rate = await corr2_client.sensor_value("adc-sample-rate", float)
 
     # This won't distinguish between the different kinds of S-band. It'll be wrong. I'm not quite
     # sure at this point how to match up the centre_frequency values in katgpucbf.meerkat.BANDS with

--- a/scratch/sim_correlator.py
+++ b/scratch/sim_correlator.py
@@ -207,6 +207,19 @@ def generate_sdp(args: argparse.Namespace, outputs: dict) -> None:
         }
 
 
+def parse_develop_options(develop_argument: str) -> dict:
+    """Separate complex develop options into a dictionary."""
+    out_dict = {}
+    for item in develop_argument.split(","):
+        # data_timeout option isn't boolean, unlike the rest
+        if "data_timeout" in item:
+            k, v = item.split("=")
+            out_dict[k] = float(v)
+        else:
+            out_dict[item] = True
+    return out_dict
+
+
 def generate_config(args: argparse.Namespace) -> dict:
     """Produce the configuration dict from the parsed command-line arguments."""
     config: dict = {
@@ -225,22 +238,11 @@ def generate_config(args: argparse.Namespace) -> dict:
         config["config"]["image_overrides"] = image_overrides
     if args.develop is not None:
         if args.develop is True or args.develop == "":
-            # Use passed --develop with no argument or --develop= with empty argument
+            # User passed --develop with no argument or --develop= with empty argument
             config["config"]["develop"] = True
         else:
             # User passed a comma-separated list of options
-            def process_develop_options() -> dict:
-                out_dict = {}
-                for item in args.develop.split(","):
-                    # data_timeout option isn't boolean, unlike the rest
-                    if item.startswith("data_timeout="):
-                        k, v = item.split("=")
-                        out_dict[k] = float(v)
-                    else:
-                        out_dict[item] = True
-                return out_dict
-
-            config["config"]["develop"] = process_develop_options()
+            config["config"]["develop"] = parse_develop_options(args.develop)
 
     dig_names = generate_digitisers(args, config)
     if args.last_stage == "d":

--- a/scratch/sim_correlator.py
+++ b/scratch/sim_correlator.py
@@ -235,7 +235,7 @@ def generate_config(args: argparse.Namespace) -> dict:
                     # data_timeout option isn't boolean, unlike the rest
                     if "data_timeout" in item:
                         k, v = item.split("=")
-                        out_dict[k] = v
+                        out_dict[k] = float(v)
                     else:
                         out_dict[item] = True
                 return out_dict

--- a/scratch/sim_correlator.py
+++ b/scratch/sim_correlator.py
@@ -210,7 +210,7 @@ def generate_sdp(args: argparse.Namespace, outputs: dict) -> None:
 def generate_config(args: argparse.Namespace) -> dict:
     """Produce the configuration dict from the parsed command-line arguments."""
     config: dict = {
-        "version": "4.0",
+        "version": "4.3",
         "config": {},
         "inputs": {},
         "outputs": {},

--- a/scratch/sim_correlator.py
+++ b/scratch/sim_correlator.py
@@ -233,7 +233,7 @@ def generate_config(args: argparse.Namespace) -> dict:
                 out_dict = {}
                 for item in args.develop.split(","):
                     # data_timeout option isn't boolean, unlike the rest
-                    if "data_timeout" in item:
+                    if item.startswith("data_timeout="):
                         k, v = item.split("=")
                         out_dict[k] = float(v)
                     else:

--- a/scratch/sim_correlator.py
+++ b/scratch/sim_correlator.py
@@ -229,7 +229,18 @@ def generate_config(args: argparse.Namespace) -> dict:
             config["config"]["develop"] = True
         else:
             # User passed a comma-separated list of options
-            config["config"]["develop"] = {key: True for key in args.develop.split(",")}
+            def process_develop_options() -> dict:
+                out_dict = {}
+                for item in args.develop.split(","):
+                    # data_timeout option isn't boolean, unlike the rest
+                    if "data_timeout" in item:
+                        k, v = item.split("=")
+                        out_dict[k] = v
+                    else:
+                        out_dict[item] = True
+                return out_dict
+
+            config["config"]["develop"] = process_develop_options()
 
     dig_names = generate_digitisers(args, config)
     if args.last_stage == "d":


### PR DESCRIPTION
This script connects to a running MK CMC, figures out some particulars from it, and leverages sim_correlator.py in order to fire up a similar correlator on MK+.

Relates to NGC-1551.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (N/A) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (N/A) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (N/A) If qualification tests are changed: attach a sample qualification report
- [x] (N/A) If design has changed: ensure documentation is up to date
- [x] (N/A) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
