### PR TITLE
sim_correlator: set valid values for 'band' in config

### DIFF
--- a/scratch/sim_correlator.py
+++ b/scratch/sim_correlator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 ################################################################################
-# Copyright (c) 2021-2024, National Research Foundation (SARAO)
+# Copyright (c) 2021-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -117,7 +117,7 @@ def generate_digitisers(args: argparse.Namespace, config: dict) -> list[str]:
             if args.digitiser_address is None:
                 config["outputs"][name] = {
                     "type": "sim.dig.baseband_voltage",
-                    "band": args.band,
+                    "band": args.band[:1],
                     "adc_sample_rate": args.adc_sample_rate,
                     "centre_frequency": args.centre_frequency,
                     "antenna": f"m{number}, 0:0:0, 0:0:0, 0, 0",
@@ -128,7 +128,7 @@ def generate_digitisers(args: argparse.Namespace, config: dict) -> list[str]:
                 config["inputs"][name] = {
                     "type": "dig.baseband_voltage",
                     "sync_time": args.sync_time,
-                    "band": args.band,
+                    "band": args.band[:1],
                     "adc_sample_rate": args.adc_sample_rate,
                     "centre_frequency": args.centre_frequency,
                     "antenna": f"m{number}",


### PR DESCRIPTION
The command-line interface takes band names like s0, s1 etc to select both the receiver and the centre frequency, but product-config dictionary should just have 's'.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
