### PR TITLE
Add window_function option for ACV streams

### DIFF
--- a/doc/signal_path.rst
+++ b/doc/signal_path.rst
@@ -97,7 +97,7 @@ Polyphase filter bank (PFB)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 A finite impulse response (FIR) filter is applied to the signal to condition
 the frequency-domain response. The filter is the product of a window function
-Hann window (to reduce spectral leakage) and a sinc (to broaden the peak to
+(to reduce spectral leakage) and a sinc (to broaden the peak to
 cover the frequency bin). Specifically, if there are :math:`n` output channels
 and :math:`t` taps in the polyphase filter bank, then the filter has length
 :math:`w = 2nt`, with coefficients

--- a/doc/signal_path.rst
+++ b/doc/signal_path.rst
@@ -96,28 +96,37 @@ phasors are done in single precision.
 Polyphase filter bank (PFB)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 A finite impulse response (FIR) filter is applied to the signal to condition
-the frequency-domain response. The filter is the product of a Hann window (to
-reduce spectral leakage) and a sinc (to broaden the peak to cover the
-frequency bin). Specifically, if there are :math:`n` output channels and
-:math:`t` taps in the polyphase filter bank, then the filter has length
+the frequency-domain response. The filter is the product of a window function
+Hann window (to reduce spectral leakage) and a sinc (to broaden the peak to
+cover the frequency bin). Specifically, if there are :math:`n` output channels
+and :math:`t` taps in the polyphase filter bank, then the filter has length
 :math:`w = 2nt`, with coefficients
 
 .. math::
 
-   x_i = A\sin^2\left(\frac{\pi i}{w - 1}\right)
-         \operatorname{sinc}\left(w_c\cdot \frac{i + \tfrac 12 - nt}{2n}\right),
+   x_i = AW_i\operatorname{sinc}\left(w_c\cdot \frac{i + \tfrac 12 - nt}{2n}\right),
 
-where :math:`i` runs from 0 to :math:`w - 1`. Here :math:`A` is a
-normalisation factor which is chosen such that :math:`\sum_i x_i^2 = 1`. This
-ensures that given white Gaussian noise as input, the expected output power
-in a channel is the same as the expected input power in a digitised sample.
-Note that the input and output are treated as integers rather than as
-fixed-point values.
+where :math:`i` runs from 0 to :math:`w - 1`, and :math:`W` is the window function,
+for which there are two choices:
+
+- Hann: :math:`W_i = \sin^2\left(\frac{\pi i}{w - 1}\right)`
+- Rect: :math:`W_i = 1`.
+
+:math:`A` is a normalisation factor which is chosen such that :math:`\sum_i
+x_i^2 = 1`. This ensures that given white Gaussian noise as input, the
+expected output power in a channel is the same as the expected input power in
+a digitised sample. Note that the input and output are treated as integers
+rather than as fixed-point values.
 
 The tuning parameter :math:`w_c` (specified by the :option:`!--w-cutoff`
 command-line option) scales the width of the response in the frequency domain.
 The default value is 1, which makes the width of the response (at -6dB)
 approximately equal the channel spacing.
+
+In some cases spectral leakage is less important than the ability to
+reconstruct the original signal. Setting :math:`t = 1`, :math:`w_c = 0` and
+using the rectangular window function gives a degenerate PFB in which each
+block of :math:`2n` samples is Fourier transformed.
 
 .. _signal-path.narrow:
 

--- a/scratch/fgpu/benchmarks/compute_bench.py
+++ b/scratch/fgpu/benchmarks/compute_bench.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 ################################################################################
-# Copyright (c) 2022-2024, National Research Foundation (SARAO)
+# Copyright (c) 2022-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -25,6 +25,7 @@ from katgpucbf import DEFAULT_JONES_PER_BATCH, DIG_SAMPLE_BITS
 from katgpucbf.fgpu.compute import ComputeTemplate, NarrowbandConfig
 from katgpucbf.fgpu.engine import generate_ddc_weights, generate_pfb_weights
 from katgpucbf.fgpu.main import DEFAULT_DDC_TAPS_RATIO
+from katgpucbf.fgpu.output import WindowFunction
 from katgpucbf.utils import DitherType, parse_dither
 
 
@@ -102,7 +103,7 @@ def main():  # noqa: C901
         fn.ensure_all_bound()
 
         h_weights = fn.buffer("weights").empty_like()
-        h_weights[:] = generate_pfb_weights(2 * args.channels, args.taps, 1.0)
+        h_weights[:] = generate_pfb_weights(2 * args.channels, args.taps, 1.0, WindowFunction.DEFAULT)
         fn.buffer("weights").set(command_queue, h_weights)
 
         h_gains = fn.buffer("gains").empty_like()

--- a/src/katgpucbf/fgpu/output.py
+++ b/src/katgpucbf/fgpu/output.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2023-2024, National Research Foundation (SARAO)
+# Copyright (c) 2023-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -18,11 +18,20 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from enum import Enum
 from typing import TYPE_CHECKING
 
 from katsdptelstate.endpoint import Endpoint
 
 from ..utils import DitherType
+
+
+class WindowFunction(Enum):
+    """Window function to use in :func:`.generate_pfb_weights`."""
+
+    HANN = 1
+    RECT = 2
+    DEFAULT = 1  # Alias used to determine default when none is specified
 
 
 @dataclass
@@ -34,6 +43,7 @@ class Output(ABC):
     jones_per_batch: int
     taps: int
     w_cutoff: float
+    window_function: WindowFunction
     dst: list[Endpoint]
     dither: DitherType
 

--- a/src/katgpucbf/utils.py
+++ b/src/katgpucbf/utils.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2024, National Research Foundation (SARAO)
+# Copyright (c) 2020-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -36,6 +36,7 @@ from katsdptelstate.endpoint import endpoint_list_parser
 from . import MIN_SENSOR_UPDATE_PERIOD, TIME_SYNC_TASK_NAME
 from .spead import DEFAULT_PORT
 
+_E = TypeVar("_E", bound=enum.Enum)
 _T = TypeVar("_T")
 
 # Sensor status threshold. These are mostly thumb-sucks.
@@ -105,14 +106,19 @@ def add_gc_stats() -> None:
     gc.callbacks.append(callback)
 
 
-def parse_dither(value: str) -> DitherType:
-    """Parse a string into a dither type."""
-    # Note: this allows only the non-aliases, so excludes DEFAULT
-    table = {member.name.lower(): member for member in DitherType}
+def parse_enum(name: str, value: str, cls: type[_E]) -> _E:
+    """Parse a command-line argument into an enum type."""
+    table = {member.name.lower(): member for member in cls}
     try:
         return table[value]
     except KeyError:
-        raise ValueError(f"Invalid dither value {value} (valid values are {list(table.keys())})") from None
+        raise ValueError(f"Invalid {name} value {value} (valid values are {list(table.keys())})") from None
+
+
+def parse_dither(value: str) -> DitherType:
+    """Parse a string into a dither type."""
+    # Note: this allows only the non-aliases, so excludes DEFAULT
+    return parse_enum("dither", value, DitherType)
 
 
 def parse_source(value: str) -> list[tuple[str, int]] | str:

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2024, National Research Foundation (SARAO)
+# Copyright (c) 2020-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -211,7 +211,9 @@ class TestEngine:
         magnitude 1 when the eq gain is 1. The array is 1D, indexed by
         channel.
         """
-        pfb = generate_pfb_weights(output.spectra_samples // output.subsampling, output.taps, output.w_cutoff)
+        pfb = generate_pfb_weights(
+            output.spectra_samples // output.subsampling, output.taps, output.w_cutoff, output.window_function
+        )
         gain = np.repeat(np.sum(pfb), output.channels)
         if isinstance(output, NarrowbandOutput):
             ddc = generate_ddc_weights(output.ddc_taps, output.subsampling, output.weight_pass)

--- a/test/fgpu/test_main.py
+++ b/test/fgpu/test_main.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2023-2024, National Research Foundation (SARAO)
+# Copyright (c) 2023-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -28,7 +28,7 @@ from katgpucbf.fgpu.main import (
     parse_args,
     parse_narrowband,
 )
-from katgpucbf.fgpu.output import NarrowbandOutput, WidebandOutput
+from katgpucbf.fgpu.output import NarrowbandOutput, WidebandOutput, WindowFunction
 from katgpucbf.utils import DitherType
 
 
@@ -50,6 +50,7 @@ class TestParseNarrowband:
             taps=DEFAULT_TAPS,
             ddc_taps=DEFAULT_DDC_TAPS_RATIO * 8,
             w_cutoff=DEFAULT_W_CUTOFF,
+            window_function=WindowFunction.DEFAULT,
             jones_per_batch=DEFAULT_JONES_PER_BATCH,
         )
 
@@ -57,7 +58,8 @@ class TestParseNarrowband:
         """Test with all valid arguments."""
         assert parse_narrowband(
             "name=foo,channels=1024,centre_frequency=400e6,decimation=8,taps=8,w_cutoff=0.5,"
-            "dst=239.1.2.3+1:7148,dither=none,ddc_taps=128,weight_pass=0.3,jones_per_batch=262144"
+            "dst=239.1.2.3+1:7148,dither=none,ddc_taps=128,weight_pass=0.3,jones_per_batch=262144,"
+            "window_function=rect"
         ) == NarrowbandOutput(
             name="foo",
             channels=1024,
@@ -65,6 +67,7 @@ class TestParseNarrowband:
             decimation=8,
             taps=8,
             w_cutoff=0.5,
+            window_function=WindowFunction.RECT,
             dst=[Endpoint("239.1.2.3", 7148), Endpoint("239.1.2.4", 7148)],
             dither=DitherType.NONE,
             ddc_taps=128,
@@ -110,7 +113,7 @@ class TestParseArgs:
             (
                 "--narrowband=name=nb0,dst=239.1.0.0+1,channels=32768,"
                 "centre_frequency=400e6,decimation=8,taps=4,w_cutoff=0.8,"
-                "ddc_taps=64,weight_pass=0.3,jones_per_batch=524288"
+                "window_function=hann,ddc_taps=64,weight_pass=0.3,jones_per_batch=524288"
             ),
             "--narrowband=name=nb1,dst=239.2.0.0+0:7149,channels=8192,centre_frequency=300e6,decimation=16",
             "239.0.1.0+15:7148",
@@ -124,6 +127,7 @@ class TestParseArgs:
                 channels=1024,
                 taps=64,
                 w_cutoff=0.9,
+                window_function=WindowFunction.DEFAULT,
                 jones_per_batch=262144,
             ),
             NarrowbandOutput(
@@ -135,6 +139,7 @@ class TestParseArgs:
                 decimation=8,
                 taps=4,
                 w_cutoff=0.8,
+                window_function=WindowFunction.HANN,
                 ddc_taps=64,
                 weight_pass=0.3,
                 jones_per_batch=524288,
@@ -148,6 +153,7 @@ class TestParseArgs:
                 decimation=16,
                 taps=DEFAULT_TAPS,
                 w_cutoff=DEFAULT_W_CUTOFF,
+                window_function=WindowFunction.DEFAULT,
                 ddc_taps=DEFAULT_DDC_TAPS_RATIO * 16,
                 weight_pass=DEFAULT_WEIGHT_PASS,
                 jones_per_batch=DEFAULT_JONES_PER_BATCH,


### PR DESCRIPTION
It can be set to `hann` (the default and what was previously implemented) or `rect` to use a boxcar.

Relates to NGC-1004.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match