### PR TITLE
Remove quantisation of narrowband centre frequency

### DIFF
--- a/doc/fgpu.design.rst
+++ b/doc/fgpu.design.rst
@@ -695,10 +695,17 @@ the fractional part. Even passing :math:`f` in single precision can lead
 to large errors.
 
 To avoid these problems, fixed-point computations are used. Phase is
-represented as a fractional number of cycles, scaled by :math:`2^{32}` and
-stored in a 32-bit integer. When performing arithmetic on values encoded this
+represented as a fractional number of cycles, scaled by :math:`2^{64}` and
+stored in a 64-bit integer. When performing arithmetic on values encoded this
 way, the values may overflow and wrap. The high bits that are lost represent
 complete cycles, and so have no effect on phase.
+
+This is sufficient to avoid any rounding errors inside the kernel, where
+:math:`t` is limited to the number of samples processed by a single kernel
+invocation. However, over much longer timescales (days) even quantising the
+frequency to 64-bit fixed point could lead to a small phase drift. The Python
+code thus uses the :class:`~fractions.Fraction` class to perform exact
+arithmetic until after it has subtracted the whole cycles.
 
 Delays
 ^^^^^^

--- a/qualification/antenna_channelised_voltage/test_narrowband.py
+++ b/qualification/antenna_channelised_voltage/test_narrowband.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2024, National Research Foundation (SARAO)
+# Copyright (c) 2024-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -16,6 +16,7 @@
 
 """Test specific features of narrowband."""
 
+import numpy as np
 import pytest
 
 from katgpucbf.meerkat import BANDS
@@ -27,18 +28,14 @@ def test_narrowband_centre_frequency() -> None:
 
     Verification method
     -------------------
-    Verified by analysis. The F-engine converts the frequency of the DDC mixer
-    to a fixed-point representation with 32 fractional bits. The units are
-    cycles per output (decimated) sample. The resolution is thus
-    :math:`\frac{f}{2^{32} d}`
-    where :math:`f` is the ADC sample rate and :math:`d` is the decimation
-    factor. For Narrowband Fine L-band,
-    :math:`f = 1712 \text{MHz}` and :math:`d = 16`, giving
-    a resolution of 0.025 Hz.
-
-    The interfaces which set and report the centre frequency use IEEE-754
-    double precision, which has significantly more precision than this and
-    is not the limiting factor.
+    Verified by analysis. The F-engine converts the text representation
+    of the centre frequency to double-precision floating point. The
+    resolution is thus determined by float-point accuracy and depends on
+    the magnitude of the value. The magnitude is limited to 856 MHz
+    (since the value is specified at baseband) and at this magnitude,
+    1 ULP is approximately :math:`1.2\times 10^{-7}` Hz.
     """
     for band in ["u", "l"]:
-        assert BANDS[band].adc_sample_rate / 2**32 / 16 < 100.0
+        max_centre_frequency = BANDS[band].adc_sample_rate / 2
+        resolution = max_centre_frequency - np.nextafter(max_centre_frequency, 0.0)
+        assert resolution < 100.0

--- a/scratch/fgpu/benchmarks/compute_bench.py
+++ b/scratch/fgpu/benchmarks/compute_bench.py
@@ -17,6 +17,7 @@
 ################################################################################
 
 import argparse
+from fractions import Fraction
 
 import numpy as np
 from katsdpsigproc import accel
@@ -70,7 +71,7 @@ def main():  # noqa: C901
         if args.narrowband:
             narrowband_config = NarrowbandConfig(
                 decimation=args.narrowband_decimation,
-                mix_frequency=0.25,
+                mix_frequency=Fraction(1, 4),
                 weights=generate_ddc_weights(args.ddc_taps, args.narrowband_decimation, 0.005),
             )
             spectra_samples = 2 * args.channels * args.narrowband_decimation

--- a/scratch/fgpu/benchmarks/ddc_bench.py
+++ b/scratch/fgpu/benchmarks/ddc_bench.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 ################################################################################
-# Copyright (c) 2022-2023, National Research Foundation (SARAO)
+# Copyright (c) 2022-2023, 2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -17,6 +17,7 @@
 ################################################################################
 
 import argparse
+from fractions import Fraction
 
 import numpy as np
 from katsdpsigproc import accel
@@ -47,7 +48,7 @@ def main():
         fn = template.instantiate(command_queue, samples=args.samples, n_pols=args.pols)
         fn.ensure_all_bound()
         fn.buffer("in").zero(command_queue)
-        fn.configure(0.25, np.ones(args.taps, np.float32))
+        fn.configure(Fraction(0.25), np.ones(args.taps, np.float32))
         fn()  # Do a warmup pass
         start = command_queue.enqueue_marker()
         for _ in range(args.passes):

--- a/src/katgpucbf/fgpu/compute.py
+++ b/src/katgpucbf/fgpu/compute.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2024, National Research Foundation (SARAO)
+# Copyright (c) 2020-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -39,7 +39,7 @@ class NarrowbandConfig:
     #: Factor by which bandwidth is reduced
     decimation: int
     #: Mixer frequency, in cycles per ADC sample
-    mix_frequency: float
+    mix_frequency: Fraction
     #: Downconversion filter weights (float)
     weights: np.ndarray
 
@@ -274,9 +274,10 @@ class Compute(accel.OperationSequence):
         # Compute the fractional part of first_sample * mix_frequency.
         # Using Fraction avoids the serious rounding errors that would
         # occur using floating point.
-        phase = Fraction(self.ddc.mix_frequency) * first_sample
+        assert isinstance(self.ddc.mix_frequency, Fraction)
+        phase = self.ddc.mix_frequency * first_sample
         phase -= round(phase)
-        self.ddc.mix_phase = float(phase)
+        self.ddc.mix_phase = phase
         self.ddc()
 
     def _run_frontend_common(

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -23,6 +23,7 @@ import logging
 import math
 import numbers
 from collections.abc import Iterable, Iterator, Sequence
+from fractions import Fraction
 from functools import partial
 
 import aiokatcp
@@ -494,7 +495,7 @@ class Pipeline:
         if isinstance(output, NarrowbandOutput):
             narrowband_config = NarrowbandConfig(
                 decimation=output.decimation,
-                mix_frequency=-output.centre_frequency / engine.adc_sample_rate,
+                mix_frequency=-Fraction(output.centre_frequency) / Fraction(engine.adc_sample_rate),
                 weights=generate_ddc_weights(output.ddc_taps, output.subsampling, output.weight_pass),
             )
         else:

--- a/src/katgpucbf/fgpu/kernels/ddc.mako
+++ b/src/katgpucbf/fgpu/kernels/ddc.mako
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, National Research Foundation (SARAO)
+ * Copyright (c) 2023, 2025, National Research Foundation (SARAO)
  *
  * Licensed under the BSD 3-Clause License (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy
@@ -128,8 +128,8 @@ void ddc(
     unsigned int in_stride,  // stride between pols, unit: sample_word
     unsigned int out_size,
     unsigned int in_size_words,
-    unsigned int mix_scale,  // Mixer frequency in cycles per SUBSAMPLING samples, fixed point
-    unsigned int mix_bias    // Mixer phase in cycles at the first sample, fixed point
+    unsigned long mix_scale,  // Mixer frequency in cycles per SUBSAMPLING samples, fixed point
+    unsigned long mix_bias    // Mixer phase in cycles at the first sample, fixed point
 )
 {
     const int group_in_size = TAPS + (WGS * C - 1) * SUBSAMPLING;
@@ -201,15 +201,15 @@ void ddc(
         }
     }
 
-    unsigned int mix_cycles = get_global_id(0) * C * mix_scale + mix_bias;
+    unsigned long mix_cycles = get_global_id(0) * C * mix_scale + mix_bias;
 #pragma unroll
     for (int i = 0; i < C; i++)
     {
         cplx mix;
-        // Casting from unsigned int to int changes the range from [0, 2pi) to
-        // [-pi, pi). The magic number is 2^32, used to convert fixed-point
+        // Casting from unsigned long to long changes the range from [0, 2pi) to
+        // [-pi, pi). The magic number is 2^64, used to convert fixed-point
         // representation to real.
-        __sincosf(2 * (float) M_PI / 4294967296.0f * (int) mix_cycles, &mix.y, &mix.x);
+        __sincosf(2 * (float) M_PI / 18446744073709551616.0f * (long) mix_cycles, &mix.y, &mix.x);
         accum[i] = cmul(accum[i], mix);
         mix_cycles += mix_scale;
     }

--- a/test/fgpu/test_compute.py
+++ b/test/fgpu/test_compute.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2024, National Research Foundation (SARAO)
+# Copyright (c) 2020-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -15,6 +15,9 @@
 ################################################################################
 
 """Smoke test for Compute class."""
+
+from fractions import Fraction
+
 import pytest
 from katsdpsigproc.abc import AbstractCommandQueue, AbstractContext
 
@@ -49,7 +52,7 @@ def test_compute(context: AbstractContext, command_queue: AbstractCommandQueue, 
     else:
         narrowband = compute.NarrowbandConfig(
             decimation=decimation,
-            mix_frequency=0.2,
+            mix_frequency=Fraction(1, 5),
             weights=generate_ddc_weights(ddc_taps, decimation, 0.1),
         )
         spectra = nb_spectra


### PR DESCRIPTION
- On the host, use Fraction instead of double precision, to eliminate
  rounding errors except where we explicitly choose to convert.
- On the device, use 64-bit fixed-point instead of 32-bit. This seems to
  have no noticeable performance impact (in some tests it seems to be
  faster!)

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report: [report.pdf](https://github.com/user-attachments/files/18501302/report.pdf)
- [x] If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1557.
