### PR TITLE
Restrict pytest-check to 2.2.2

### DIFF
--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -294,7 +294,7 @@ pytest-asyncio==0.25.2
     # via
     #   -c qualification/../requirements-dev.txt
     #   katgpucbf (setup.cfg)
-pytest-check==2.4.1
+pytest-check==2.2.2
     # via katgpucbf (setup.cfg)
 pytest-custom-exit-code==0.3.0
     # via

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ qualification =
     pylatex
     pytest
     pytest-asyncio
-    pytest-check>=1.3
+    pytest-check>=1.3,<2.2.3  # Upper bound due to https://github.com/okken/pytest-check/issues/173
     pytest-custom_exit_code
     pytest-reportlog
 


### PR DESCRIPTION
Newer versions of pytest-check don't play nice with pytest-reportlog: https://github.com/okken/pytest-check/issues/173

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] (n/a) Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
