### PR TITLE
Fix some qualification reports failing to build

### DIFF
--- a/qualification/report/preamble.tex
+++ b/qualification/report/preamble.tex
@@ -8,8 +8,8 @@
 % http://www.bollchen.de/blog/2011/04/good-looking-line-breaks-with-the-listings-package/
 \lstset{prebreak=\raisebox{0ex}[0ex][0ex]{\ensuremath{\hookleftarrow}}}
 \lstset{postbreak=\raisebox{0ex}[0ex][0ex]{\ensuremath{\hookrightarrow\space}}}
-% Make degree sign and plus-minus sign in listings (e.g. from a backtrace) work.
-\lstset{inputencoding=utf8,literate={°}{{\textdegree}}1{±}{{\ensuremath{\pm}}}1}
+% Make some Unicode symbols in listings (e.g. from a backtrace) work.
+\lstset{inputencoding=utf8,literate={°}{{\textdegree}}1{±}{{\ensuremath{\pm}}}1{π}{{\ensuremath{\pi}}}1}
 
 % For plotting to work nicely.
 \usepackage{pgfplots}


### PR DESCRIPTION
If a stack backtrace for a failed test contains a π, it would fail because we need to tell the listings package explicitly how to cope with each non-ASCII symbol.
