### PR TITLE
Add tx.next-timestamp sensors for XBEngine

### DIFF
--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -57,8 +57,8 @@ from ..utils import (
     TimeConverter,
     add_time_sync_sensors,
     gaussian_dtype,
-    rate_limited_sensor,
-    steady_state_timestamp_sensor,
+    make_rate_limited_sensor,
+    make_steady_state_timestamp_sensor,
 )
 from . import DIG_RMS_DBFS_HIGH, DIG_RMS_DBFS_LOW, DIG_RMS_DBFS_WINDOW, INPUT_CHUNK_PADDING, recv, send
 from .accum import Accum
@@ -579,7 +579,7 @@ class Pipeline:
                 )
             )
             sensors.add(
-                rate_limited_sensor(
+                make_rate_limited_sensor(
                     int,
                     f"{self.output.name}.input{pol}.feng-clip-cnt",
                     "Number of output samples that are saturated",
@@ -1363,7 +1363,7 @@ class Engine(aiokatcp.DeviceServer):
         """Define the sensors for an engine (excluding pipeline-specific sensors)."""
         for pol in range(N_POLS):
             sensors.add(
-                rate_limited_sensor(
+                make_rate_limited_sensor(
                     int,
                     f"input{pol}.dig-clip-cnt",
                     "Number of digitiser samples that are saturated",
@@ -1383,7 +1383,7 @@ class Engine(aiokatcp.DeviceServer):
 
         for sensor in recv.make_sensors(recv_sensor_timeout).values():
             sensors.add(sensor)
-        sensors.add(steady_state_timestamp_sensor())
+        sensors.add(make_steady_state_timestamp_sensor())
         sensors.add(DeviceStatusSensor(sensors))
 
         time_sync_task = add_time_sync_sensors(sensors)

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -39,7 +39,6 @@ from .. import (
     BYTE_BITS,
     DESCRIPTOR_TASK_NAME,
     GPU_PROC_TASK_NAME,
-    MIN_SENSOR_UPDATE_PERIOD,
     N_POLS,
     RECV_TASK_NAME,
     SEND_TASK_NAME,
@@ -58,6 +57,7 @@ from ..utils import (
     TimeConverter,
     add_time_sync_sensors,
     gaussian_dtype,
+    rate_limited_sensor,
     steady_state_timestamp_sensor,
 )
 from . import DIG_RMS_DBFS_HIGH, DIG_RMS_DBFS_LOW, DIG_RMS_DBFS_WINDOW, INPUT_CHUNK_PADDING, recv, send
@@ -579,14 +579,12 @@ class Pipeline:
                 )
             )
             sensors.add(
-                aiokatcp.Sensor(
+                rate_limited_sensor(
                     int,
                     f"{self.output.name}.input{pol}.feng-clip-cnt",
                     "Number of output samples that are saturated",
                     default=0,
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,
-                    auto_strategy=aiokatcp.SensorSampler.Strategy.EVENT_RATE,
-                    auto_strategy_parameters=(MIN_SENSOR_UPDATE_PERIOD, math.inf),
                 )
             )
 
@@ -1365,14 +1363,12 @@ class Engine(aiokatcp.DeviceServer):
         """Define the sensors for an engine (excluding pipeline-specific sensors)."""
         for pol in range(N_POLS):
             sensors.add(
-                aiokatcp.Sensor(
+                rate_limited_sensor(
                     int,
                     f"input{pol}.dig-clip-cnt",
                     "Number of digitiser samples that are saturated",
                     default=0,
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,
-                    auto_strategy=aiokatcp.SensorSampler.Strategy.EVENT_RATE,
-                    auto_strategy_parameters=(MIN_SENSOR_UPDATE_PERIOD, math.inf),
                 )
             )
             sensors.add(

--- a/src/katgpucbf/fgpu/recv.py
+++ b/src/katgpucbf/fgpu/recv.py
@@ -35,7 +35,7 @@ from .. import BYTE_BITS, N_POLS
 from .. import recv as base_recv
 from ..recv import BaseLayout, Chunk, StatsCollector
 from ..spead import DIGITISER_ID_ID, DIGITISER_STATUS_ID, DIGITISER_STATUS_SATURATION_COUNT_SHIFT, TIMESTAMP_ID
-from ..utils import DeviceStatusSensor, TimeConverter, TimeoutSensorStatusObserver, rate_limited_sensor
+from ..utils import DeviceStatusSensor, TimeConverter, TimeoutSensorStatusObserver, make_rate_limited_sensor
 from . import METRIC_NAMESPACE
 
 #: Number of partial chunks to allow at a time. Using 1 would reject any out-of-order
@@ -231,14 +231,14 @@ def make_sensors(sensor_timeout: float) -> aiokatcp.SensorSet:
     sensors = aiokatcp.SensorSet()
     for pol in range(N_POLS):
         timestamp_sensors: list[aiokatcp.Sensor] = [
-            rate_limited_sensor(
+            make_rate_limited_sensor(
                 int,
                 f"input{pol}.rx.timestamp",
                 "The timestamp (in samples) of the last chunk of data received from the digitiser",
                 default=-1,
                 initial_status=aiokatcp.Sensor.Status.ERROR,
             ),
-            rate_limited_sensor(
+            make_rate_limited_sensor(
                 aiokatcp.core.Timestamp,
                 f"input{pol}.rx.unixtime",
                 "The timestamp (in UNIX time) of the last chunk of data received from the digitiser",
@@ -251,7 +251,7 @@ def make_sensors(sensor_timeout: float) -> aiokatcp.SensorSet:
             sensors.add(sensor)
 
         missing_sensors: list[aiokatcp.Sensor] = [
-            rate_limited_sensor(
+            make_rate_limited_sensor(
                 aiokatcp.core.Timestamp,
                 f"input{pol}.rx.missing-unixtime",
                 "The timestamp (in UNIX time) when missing data was last detected",

--- a/src/katgpucbf/fgpu/recv.py
+++ b/src/katgpucbf/fgpu/recv.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2024, National Research Foundation (SARAO)
+# Copyright (c) 2020-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -18,7 +18,6 @@
 
 import functools
 import logging
-import math
 from collections.abc import AsyncGenerator, Sequence
 from dataclasses import dataclass
 from enum import IntEnum
@@ -32,11 +31,11 @@ from prometheus_client import Counter
 from spead2.numba import intp_to_voidptr
 from spead2.recv.numba import chunk_place_data
 
-from .. import BYTE_BITS, MIN_SENSOR_UPDATE_PERIOD, N_POLS
+from .. import BYTE_BITS, N_POLS
 from .. import recv as base_recv
 from ..recv import BaseLayout, Chunk, StatsCollector
 from ..spead import DIGITISER_ID_ID, DIGITISER_STATUS_ID, DIGITISER_STATUS_SATURATION_COUNT_SHIFT, TIMESTAMP_ID
-from ..utils import DeviceStatusSensor, TimeConverter, TimeoutSensorStatusObserver
+from ..utils import DeviceStatusSensor, TimeConverter, TimeoutSensorStatusObserver, rate_limited_sensor
 from . import METRIC_NAMESPACE
 
 #: Number of partial chunks to allow at a time. Using 1 would reject any out-of-order
@@ -232,23 +231,19 @@ def make_sensors(sensor_timeout: float) -> aiokatcp.SensorSet:
     sensors = aiokatcp.SensorSet()
     for pol in range(N_POLS):
         timestamp_sensors: list[aiokatcp.Sensor] = [
-            aiokatcp.Sensor(
+            rate_limited_sensor(
                 int,
                 f"input{pol}.rx.timestamp",
                 "The timestamp (in samples) of the last chunk of data received from the digitiser",
                 default=-1,
                 initial_status=aiokatcp.Sensor.Status.ERROR,
-                auto_strategy=aiokatcp.SensorSampler.Strategy.EVENT_RATE,
-                auto_strategy_parameters=(MIN_SENSOR_UPDATE_PERIOD, math.inf),
             ),
-            aiokatcp.Sensor(
+            rate_limited_sensor(
                 aiokatcp.core.Timestamp,
                 f"input{pol}.rx.unixtime",
                 "The timestamp (in UNIX time) of the last chunk of data received from the digitiser",
                 default=aiokatcp.core.Timestamp(-1.0),
                 initial_status=aiokatcp.Sensor.Status.ERROR,
-                auto_strategy=aiokatcp.SensorSampler.Strategy.EVENT_RATE,
-                auto_strategy_parameters=(MIN_SENSOR_UPDATE_PERIOD, math.inf),
             ),
         ]
         for sensor in timestamp_sensors:
@@ -256,14 +251,12 @@ def make_sensors(sensor_timeout: float) -> aiokatcp.SensorSet:
             sensors.add(sensor)
 
         missing_sensors: list[aiokatcp.Sensor] = [
-            aiokatcp.Sensor(
+            rate_limited_sensor(
                 aiokatcp.core.Timestamp,
                 f"input{pol}.rx.missing-unixtime",
                 "The timestamp (in UNIX time) when missing data was last detected",
                 default=aiokatcp.core.Timestamp(-1.0),
                 initial_status=aiokatcp.Sensor.Status.NOMINAL,
-                auto_strategy=aiokatcp.SensorSampler.Strategy.EVENT_RATE,
-                auto_strategy_parameters=(MIN_SENSOR_UPDATE_PERIOD, math.inf),
             )
         ]
         for sensor in missing_sensors:

--- a/src/katgpucbf/utils.py
+++ b/src/katgpucbf/utils.py
@@ -172,7 +172,7 @@ def comma_split(
 
 # We have to use *args/**kwargs because the default for status_func is a
 # private function in aiokatcp and hence cannot be named.
-def rate_limited_sensor(
+def make_rate_limited_sensor(
     sensor_type: type[_T],
     name: str,
     description: str = "",
@@ -384,7 +384,7 @@ def add_time_sync_sensors(sensors: aiokatcp.SensorSet) -> asyncio.Task:
     return asyncio.create_task(run(), name=TIME_SYNC_TASK_NAME)
 
 
-def steady_state_timestamp_sensor() -> aiokatcp.Sensor[int]:
+def make_steady_state_timestamp_sensor() -> aiokatcp.Sensor[int]:
     """Create ``steady-state-timestamp`` sensor."""
     return aiokatcp.Sensor(
         int,

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -480,6 +480,18 @@ class BPipeline(Pipeline[BOutput, BOutQueueItem]):
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,
                 )
             )
+            sensors.add(
+                rate_limited_sensor(
+                    int,
+                    f"{output.name}.tx.next-timestamp",
+                    "Timestamp (in samples) that has not yet been sent. This "
+                    "is strictly greater than any timestamp of the previous "
+                    "capture and less than or equal to any timestamp of the "
+                    "following capture.",
+                    default=0,
+                    initial_status=aiokatcp.Sensor.Status.NOMINAL,
+                )
+            )
 
     async def _get_in_item(self) -> InQueueItem | None:
         """Get the next :class:`InQueueItem`.

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -61,8 +61,8 @@ from ..utils import (
     DeviceStatusSensor,
     TimeConverter,
     add_time_sync_sensors,
-    rate_limited_sensor,
-    steady_state_timestamp_sensor,
+    make_rate_limited_sensor,
+    make_steady_state_timestamp_sensor,
 )
 from . import DEFAULT_BPIPELINE_NAME, DEFAULT_N_IN_ITEMS, DEFAULT_N_OUT_ITEMS, DEFAULT_XPIPELINE_NAME, recv
 from .beamform import Beam, BeamformTemplate
@@ -462,7 +462,7 @@ class BPipeline(Pipeline[BOutput, BOutQueueItem]):
                 )
             )
             sensors.add(
-                rate_limited_sensor(
+                make_rate_limited_sensor(
                     str,
                     f"{output.name}.weight",
                     "The summing weights applied to all the inputs of this beam",
@@ -472,7 +472,7 @@ class BPipeline(Pipeline[BOutput, BOutQueueItem]):
                 )
             )
             sensors.add(
-                rate_limited_sensor(
+                make_rate_limited_sensor(
                     int,
                     f"{output.name}.beng-clip-cnt",
                     "Number of complex samples that saturated.",
@@ -481,7 +481,7 @@ class BPipeline(Pipeline[BOutput, BOutQueueItem]):
                 )
             )
             sensors.add(
-                rate_limited_sensor(
+                make_rate_limited_sensor(
                     int,
                     f"{output.name}.tx.next-timestamp",
                     "Timestamp (in samples) that has not yet been sent. This "
@@ -1292,7 +1292,7 @@ class XBEngine(DeviceServer):
         # Dynamic sensors
         for sensor in recv.make_sensors(recv_sensor_timeout).values():
             sensors.add(sensor)
-        sensors.add(steady_state_timestamp_sensor())
+        sensors.add(make_steady_state_timestamp_sensor())
         sensors.add(DeviceStatusSensor(sensors))
 
         time_sync_task = add_time_sync_sensors(sensors)

--- a/src/katgpucbf/xbgpu/recv.py
+++ b/src/katgpucbf/xbgpu/recv.py
@@ -37,7 +37,7 @@ from ..recv import BaseLayout, Chunk, StatsCollector
 from ..recv import make_stream as make_base_stream
 from ..recv import user_data_type
 from ..spead import FENG_ID_ID, TIMESTAMP_ID
-from ..utils import DeviceStatusSensor, TimeConverter, TimeoutSensorStatusObserver, rate_limited_sensor
+from ..utils import DeviceStatusSensor, TimeConverter, TimeoutSensorStatusObserver, make_rate_limited_sensor
 from . import METRIC_NAMESPACE
 
 logger = logging.getLogger(__name__)
@@ -219,14 +219,14 @@ def make_sensors(sensor_timeout: float) -> SensorSet:
     """
     sensors = SensorSet()
     timestamp_sensors: list[Sensor] = [
-        rate_limited_sensor(
+        make_rate_limited_sensor(
             int,
             "rx.timestamp",
             "The timestamp (in samples) of the last chunk of data received from an F-engine",
             default=-1,
             initial_status=Sensor.Status.ERROR,
         ),
-        rate_limited_sensor(
+        make_rate_limited_sensor(
             Timestamp,
             "rx.unixtime",
             "The timestamp (in UNIX time) of the last chunk of data received from an F-engine",
@@ -239,7 +239,7 @@ def make_sensors(sensor_timeout: float) -> SensorSet:
         sensors.add(sensor)
 
     missing_sensors: list[Sensor] = [
-        rate_limited_sensor(
+        make_rate_limited_sensor(
             Timestamp,
             "rx.missing-unixtime",
             "The timestamp (in UNIX time) when missing data was last detected",

--- a/test/xbgpu/test_bsend.py
+++ b/test/xbgpu/test_bsend.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2023-2024, National Research Foundation (SARAO)
+# Copyright (c) 2023-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -242,6 +242,8 @@ class TestBSend:
         outputs, time_converter, sensors
             Fixtures.
         """
+        for output in outputs:
+            assert sensors[f"{output.name}.tx.next-timestamp"].value == 0
         # The test still needs to have some idea of "which engine" this is in a
         # sequence of B-engines. The value is chosen arbitrarily, but to ensure
         # it satisfies all values of `n_engines`, which can be as small as 4.
@@ -298,3 +300,6 @@ class TestBSend:
             heap_timestamp_step,
             first_heap,
         )
+
+        for output in outputs:
+            assert sensors[f"{output.name}.tx.next-timestamp"].value == SEND_HEAPS_PER_SUBSTREAM * heap_timestamp_step

--- a/test/xbgpu/test_bsend.py
+++ b/test/xbgpu/test_bsend.py
@@ -62,6 +62,7 @@ def sensors(outputs: Sequence[BOutput]) -> SensorSet:
     sensors = SensorSet()
     for output in outputs:
         sensors.add(Sensor(int, f"{output.name}.beng-clip-cnt", "Number of output samples that are saturated."))
+        sensors.add(Sensor(int, f"{output.name}.tx.next-timestamp", "Timestamp that has not yet been sent"))
     return sensors
 
 

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -440,6 +440,9 @@ def verify_corrprod_sensors(
         # Verify sensor updates while we're here
         xsync_sensor_name = f"{xpipeline.output.name}.rx.synchronised"
         assert actual_sensor_updates[xsync_sensor_name] == expected_sensor_updates
+        assert (
+            xpipeline.engine.sensors[f"{xpipeline.output.name}.tx.next-timestamp"].value == batch_end * timestamp_step
+        )
 
     return skipped_accs_total
 


### PR DESCRIPTION
These sensors are a past-the-end timestamp for the transmit stream. Care is taken to update them in the same event loop iteration that send-enabled is checked, which means that doing:
```
?capture-stop stream
?sensor-value stream.tx.next-timestamp
?capture-start stream
```
will give a timestamp that can be used to distinguish the data from the two capture sessions (it will be greater than any timestamp from the former and less than or equal to any timestamp from the latter). This will be useful in fixing NGC-1542, which appears to be caused by use of data from a previous capture session.

There will be a matching PR coming for katsdpcontroller to rename the sensors suitably.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

