### PR TITLE
Use PEP 695 syntax for generic functions and classes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: no-commit-to-branch # without arguments, master/main will be protected.
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort

--- a/qualification/tied_array_channelised_voltage/test_linearity.py
+++ b/qualification/tied_array_channelised_voltage/test_linearity.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2024, National Research Foundation (SARAO)
+# Copyright (c) 2024-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -18,7 +18,6 @@
 
 import itertools
 from collections.abc import Awaitable, Callable, Iterable, Iterator
-from typing import TypeVar
 
 import aiokatcp
 import numpy as np
@@ -29,11 +28,9 @@ from ..cbf import CBFRemoteControl
 from ..recv import TiedArrayChannelisedVoltageReceiver
 from ..reporter import Reporter
 
-_T = TypeVar("_T")
-
 
 # TODO (NGC-1266): use itertools.batched once Python 3.12 is required.
-def batched(iterable: Iterable[_T], n: int) -> Iterator[tuple[_T, ...]]:
+def batched[T](iterable: Iterable[T], n: int) -> Iterator[tuple[T, ...]]:
     """Divide an iterable into fixed-sized batches.
 
     This is a backport of :func:`itertools.batched` from Python 3.12. The

--- a/scratch/benchmarks/noisy_search.py
+++ b/scratch/benchmarks/noisy_search.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2023, National Research Foundation (SARAO)
+# Copyright (c) 2023, 2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -18,12 +18,9 @@
 
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
-from typing import TypeVar
 
 import numpy as np
 from numpy.typing import ArrayLike
-
-_T = TypeVar("_T", covariant=True)
 
 
 def _entropy(a: ArrayLike, axis: int | tuple[int, ...] | None = None) -> np.floating:
@@ -41,14 +38,14 @@ class NoisySearchResult:
     confidence: float  #: Probability that the interval [low, high) contains the new element
 
 
-async def noisy_search(
-    items: Sequence[_T],
+async def noisy_search[T](
+    items: Sequence[T],
     noise: ArrayLike,
     tolerance: float,
-    compare: Callable[[_T], Awaitable[bool]],
+    compare: Callable[[T], Awaitable[bool]],
     *,
     max_interval: int = 1,
-    max_comparisons: int | None = None
+    max_comparisons: int | None = None,
 ) -> NoisySearchResult:
     """
     Perform a binary search with a noisy comparison function.

--- a/src/katgpucbf/fgpu/delay.py
+++ b/src/katgpucbf/fgpu/delay.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2023, National Research Foundation (SARAO)
+# Copyright (c) 2020-2023, 2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -27,11 +27,8 @@ import warnings
 from abc import ABC, abstractmethod
 from collections import deque
 from collections.abc import Callable, Sequence
-from typing import Generic, TypeVar
 
 import numpy as np
-
-_DM = TypeVar("_DM", bound="AbstractDelayModel")
 
 
 def wrap_angle(angle):
@@ -277,13 +274,13 @@ class MultiDelayModel(AbstractDelayModel):
             self.callback_func(self._models)
 
 
-class AlignedDelayModel(AbstractDelayModel, Generic[_DM]):
+class AlignedDelayModel[DM: AbstractDelayModel](AbstractDelayModel):
     """Wrap another delay model and enforce an alignment on original timestamp.
 
     Note that this can cause residual delays to be larger than 1.
     """
 
-    def __init__(self, base: _DM, align: int) -> None:
+    def __init__(self, base: DM, align: int) -> None:
         self.base = base
         self.align = align
 

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -27,7 +27,7 @@ import gc
 import logging
 import math
 from collections.abc import Callable, Sequence
-from typing import TypedDict, TypeVar
+from typing import TypedDict
 
 import katsdpservices
 import katsdpsigproc.accel as accel
@@ -55,8 +55,6 @@ from . import DIG_SAMPLE_BITS_VALID
 from .engine import Engine
 from .output import NarrowbandOutput, NarrowbandOutputDiscard, NarrowbandOutputNoDiscard, WidebandOutput, WindowFunction
 
-_T = TypeVar("_T")
-_OD = TypeVar("_OD", bound="_OutputDict")
 logger = logging.getLogger(__name__)
 DEFAULT_TAPS = 16
 DEFAULT_W_CUTOFF = 1.0
@@ -105,7 +103,7 @@ class _NarrowbandOutputDict(_OutputDict, total=False):
     pass_bandwidth: float
 
 
-def _parse_stream(value: str, kws: _OD, field_callback: Callable[[_OD, str, str], None]) -> None:
+def _parse_stream[OD: _OutputDict](value: str, kws: OD, field_callback: Callable[[OD, str, str], None]) -> None:
     """Parse a wideband or narrowband stream description.
 
     This populates `kws` (which should initially be empty) from key=value pairs

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2024, National Research Foundation (SARAO)
+# Copyright (c) 2020-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -28,7 +28,6 @@ import math
 import time
 from abc import abstractmethod
 from collections.abc import Sequence
-from typing import Generic, TypeVar
 
 import aiokatcp
 import katsdpsigproc
@@ -76,8 +75,6 @@ from .xsend import make_stream as make_xstream
 from .xsend import skipped_accum_counter
 
 logger = logging.getLogger(__name__)
-_O = TypeVar("_O", bound=Output)
-_T = TypeVar("_T", bound=QueueItem)
 
 
 class InQueueItem(QueueItem):
@@ -210,7 +207,7 @@ class BOutQueueItem(QueueItem):
         self.present.fill(True)
 
 
-class Pipeline(Generic[_O, _T]):
+class Pipeline[O: Output, T: QueueItem]:
     r"""Base Pipeline class to build on.
 
     SPEAD heaps utilised by this pipeline are first received at the
@@ -255,7 +252,7 @@ class Pipeline(Generic[_O, _T]):
 
     send_stream: Send
 
-    def __init__(self, outputs: Sequence[_O], name: str, engine: "XBEngine", context: AbstractContext) -> None:
+    def __init__(self, outputs: Sequence[O], name: str, engine: "XBEngine", context: AbstractContext) -> None:
         self.outputs = outputs
         self.name = name
         self.engine = engine
@@ -280,8 +277,8 @@ class Pipeline(Generic[_O, _T]):
         self._in_queue: asyncio.Queue[InQueueItem | None] = engine.monitor.make_queue(
             f"{name}.in_queue", self.n_in_items
         )
-        self._out_queue: asyncio.Queue[_T | None] = engine.monitor.make_queue(f"{name}.out_queue", self.n_out_items)
-        self._out_free_queue: asyncio.Queue[_T] = engine.monitor.make_queue(f"{name}.out_free_queue", self.n_out_items)
+        self._out_queue: asyncio.Queue[T | None] = engine.monitor.make_queue(f"{name}.out_queue", self.n_out_items)
+        self._out_free_queue: asyncio.Queue[T] = engine.monitor.make_queue(f"{name}.out_free_queue", self.n_out_items)
 
     def add_in_item(self, item: InQueueItem) -> None:
         """Append a newly-received :class:`InQueueItem` to the :attr:`_in_queue`."""

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2024, National Research Foundation (SARAO)
+# Copyright (c) 2020-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -35,7 +35,7 @@ import gc
 import logging
 import os
 from collections.abc import Callable, Sequence
-from typing import TypedDict, TypeVar
+from typing import TypedDict
 
 import katsdpsigproc.accel
 import prometheus_async
@@ -62,7 +62,6 @@ from ..utils import DitherType, add_gc_stats, add_signal_handlers, parse_dither,
 from .correlation import device_filter
 from .output import BOutput, XOutput
 
-_OD = TypeVar("_OD", bound="_OutputDict")
 logger = logging.getLogger(__name__)
 
 
@@ -97,7 +96,7 @@ class _XOutputDict(_OutputDict, total=False):
     heap_accumulation_threshold: int
 
 
-def _parse_stream(value: str, kws: _OD, field_callback: Callable[[_OD, str, str], None]) -> None:
+def _parse_stream[OD: _OutputDict](value: str, kws: OD, field_callback: Callable[[OD, str, str], None]) -> None:
     """Parse a correlation-product or beam stream description.
 
     This populates `kws` (which should initially be empty) from key=value pairs


### PR DESCRIPTION
It's a little more readable and makes it clear where classes are generic.

Upgrade black since the previous version sometimes put line breaks in non-intuitive places with this syntax.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
