### PR TITLE
Grab input-labels from subarray for sim_correlator

### DIFF
--- a/scratch/copy-mk.py
+++ b/scratch/copy-mk.py
@@ -115,7 +115,7 @@ async def async_main(args) -> int:
     # This returns a string representation of a list of tuples, with each item
     # in the format (input-label, input-index, LRU host, index-on-host).
     input_labelling_str = await corr2_client.sensor_value("input-labelling", str)
-    input_labelling: list[tuple[str,]] = ast.literal_eval(input_labelling_str)
+    input_labelling: list[tuple[str, ...]] = ast.literal_eval(input_labelling_str)
     input_labels = [label[0] for label in input_labelling]
 
     # This won't distinguish between the different kinds of S-band. It'll be wrong. I'm not quite

--- a/scratch/copy-mk.py
+++ b/scratch/copy-mk.py
@@ -115,7 +115,7 @@ async def async_main(args) -> int:
     # This returns a string representation of a list of tuples, with each item
     # in the format (input-label, input-index, LRU host, index-on-host).
     input_labelling_str = await corr2_client.sensor_value("input-labelling", str)
-    input_labelling: list[tuple[str, ...]] = ast.literal_eval(input_labelling_str)
+    input_labelling: list[tuple[str, int, str, int]] = ast.literal_eval(input_labelling_str)
     input_labels = [label[0] for label in input_labelling]
 
     # This won't distinguish between the different kinds of S-band. It'll be wrong. I'm not quite

--- a/scratch/copy-mk.py
+++ b/scratch/copy-mk.py
@@ -111,6 +111,10 @@ async def async_main(args) -> int:
     sync_time = await corr2_client.sensor_value("sync-time", float)
     channels = await corr2_client.sensor_value("antenna-channelised-voltage-n-chans", int)
     sample_rate = await corr2_client.sensor_value("adc-sample-rate", float)
+    # This returns a string representation of a list of tuples, with each item
+    # in the format (input-label, input-index, LRU host, index-on-host).
+    input_labelling_str = await corr2_client.sensor_value("input-labelling", str)
+    input_labels_list = [labels_tuple.split(",")[0][1:-1] for labels_tuple in input_labelling_str[1:-1].split("(")[1:]]
 
     # This won't distinguish between the different kinds of S-band. It'll be wrong. I'm not quite
     # sure at this point how to match up the centre_frequency values in katgpucbf.meerkat.BANDS with
@@ -132,6 +136,7 @@ async def async_main(args) -> int:
         "sync-time": sync_time,
         "band": band,
         "develop": args.develop,
+        "input-labels": ",".join(input_labels_list),
     }
 
     out_cmd = [os.path.join(os.path.dirname(__file__), "sim_correlator.py")]

--- a/scratch/copy-mk.py
+++ b/scratch/copy-mk.py
@@ -23,6 +23,7 @@ instead of a simulated one, it gets the parameters from a live MK correlator.
 """
 
 import argparse
+import ast
 import asyncio
 import os
 import sys
@@ -114,7 +115,8 @@ async def async_main(args) -> int:
     # This returns a string representation of a list of tuples, with each item
     # in the format (input-label, input-index, LRU host, index-on-host).
     input_labelling_str = await corr2_client.sensor_value("input-labelling", str)
-    input_labels_list = [labels_tuple.split(",")[0][1:-1] for labels_tuple in input_labelling_str[1:-1].split("(")[1:]]
+    input_labelling: list[tuple[str,]] = ast.literal_eval(input_labelling_str)
+    input_labels = [label[0] for label in input_labelling]
 
     # This won't distinguish between the different kinds of S-band. It'll be wrong. I'm not quite
     # sure at this point how to match up the centre_frequency values in katgpucbf.meerkat.BANDS with
@@ -136,7 +138,8 @@ async def async_main(args) -> int:
         "sync-time": sync_time,
         "band": band,
         "develop": args.develop,
-        "input-labels": ",".join(input_labels_list),
+        # We don't want the dummy antennas for sim_correlator.py
+        "input-labels": ",".join(input_labels[: 2 * target.n_antennas]),
     }
 
     out_cmd = [os.path.join(os.path.dirname(__file__), "sim_correlator.py")]

--- a/scratch/sim_correlator.py
+++ b/scratch/sim_correlator.py
@@ -36,17 +36,18 @@ import aiokatcp
 from katgpucbf.meerkat import BANDS
 
 
+def parse_input_labels(value: str) -> list[str]:
+    return value.split(",")
+
+
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     """Parse the command-line arguments (which may be specified as a parameter)."""
-
-    def _parse_input_labels(value: str) -> list[str]:
-        return value.split(",")
 
     parser = argparse.ArgumentParser()
     parser.add_argument("controller", help="Hostname of the SDP master controller")
     parser.add_argument("--port", type=int, default=5001, help="TCP port of the SDP master controller [%(default)s]")
     parser.add_argument("--name", default="sim_correlator", help="Subarray product name [%(default)s]")
-    parser.add_argument("--input-labels", type=_parse_input_labels, help="Input labels for F-engine sources")
+    parser.add_argument("--input-labels", type=parse_input_labels, help="Input labels for F-engine sources")
     parser.add_argument("-a", "--antennas", type=int, required=True, help="Number of antennas")
     parser.add_argument("-d", "--digitisers", type=int, help="Number of digitisers [#antennas]")
     parser.add_argument("-c", "--channels", type=int, required=True, help="Number of channels")
@@ -102,7 +103,6 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     if args.digitiser_address is not None and args.sync_time is None:
         parser.error("--sync-time is required when specifying --digitiser-address")
     if args.input_labels is None:
-        print("No input labels received")
         args.input_labels = [f"m{800 + i}{pol}" for i in range(args.antennas) for pol in ["v", "h"]]
     return args
 


### PR DESCRIPTION
The parsing of the `input-labelling` sensor is a bit of a pain. Tried not to leave a mess while doing so.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Contributes to: NGC-1588.
