### PR TITLE
copy-mk: get information from katportal

### DIFF
--- a/scratch/copy-mk.py
+++ b/scratch/copy-mk.py
@@ -23,41 +23,34 @@ instead of a simulated one, it gets the parameters from a live MK correlator.
 """
 
 import argparse
-import ast
 import asyncio
 import json
 import sys
 from collections.abc import Sequence
-from dataclasses import dataclass
+from typing import Any
 
 import aiokatcp
+from katportalclient import KATPortalClient
 from katsdptelstate.endpoint import endpoint_parser
 
 import katgpucbf.configure_tools
-from katgpucbf.meerkat import BANDS
-
-
-@dataclass
-class Subordinate:
-    name: str
-    control_port: int
-    monitor_port: int
-    digitiser_address: str
-    n_antennas: int
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser()
-    parser.add_argument("cmc_host", help="Hostname / IP address of the CMC.")
-    parser.add_argument("--cmc-port", type=int, default=7147, help="KATCP port of the CMC. [%(default)s]")
-    parser.add_argument("--subordinate", type=str, required=True, help="Which subordinate to copy.")
+    parser.add_argument(
+        "--portal",
+        default="http://portal.mkat.karoo.kat.ac.za/api/client/1",
+        help="URL for katportal (including subarray number) [%(default)s]",
+    )
     parser.add_argument(
         "--controller",
         type=endpoint_parser(5001),
         default="cbf-mc.cbf.mkat.karoo.kat.ac.za",
         help="Endpoint of the CBF master controller",
     )
+    parser.add_argument("--name", help="Name of the subarray product")
     parser.add_argument("--dry-run", action="store_true", help="Print config only")
     katgpucbf.configure_tools.add_arguments(parser)
     args = parser.parse_args(argv)
@@ -65,73 +58,37 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 
 async def async_main(args) -> int:
-    cmc_client = await aiokatcp.Client.connect(args.cmc_host, args.cmc_port)
+    portal_client = KATPortalClient(args.portal, None)
+    # Get name of the CBF proxy e.g. "cbf_1"
+    prefix = await portal_client.sensor_subarray_lookup("cbf", "")
 
-    try:
-        _, informs = await cmc_client.request("subordinate-list")
-    except (aiokatcp.FailReply, ConnectionError) as exc:
-        print(f"Error: {exc}", file=sys.stderr)
-        return 1
+    async def cbf_sensor_value(name: str) -> Any:
+        sample = await portal_client.sensor_value(f"{prefix}_{name}")
+        return sample.value
 
-    if len(informs) == 0:
-        print(f"No subarrays currently running on {args.cmc_host}")
-        return 1
+    input_labels = (await cbf_sensor_value("input_labels")).split(",")
+    # Get the multicast groups. This is an annoying sensor because it's not
+    # valid Python or JSON: it's a comma-separated list surrounded by brackets,
+    # but the strings are not quoted.
+    mcast_groups_str = await cbf_sensor_value("wide_antenna_channelised_voltage_source")
+    mcast_groups = [group.strip() for group in mcast_groups_str[1:-1].split(",")]
+    for n, group in enumerate(mcast_groups[1:], start=1):
+        if group == mcast_groups[0]:
+            # MK is not using a full power-of-2 size array. There are dummies from here onwards.
+            print(f"Dummy antenna found starting at input {n}")
+            input_labels = input_labels[:n]
+            mcast_groups = mcast_groups[:n]
+            break
 
-    subordinates = {}
-    for inform in informs:
-        name = inform.arguments[0].decode()
-        control_port, monitor_port = inform.arguments[1].decode().split(",")
-        control_port = int(control_port)
-        monitor_port = int(monitor_port)
-        mcast_groups = []
-        for grp in inform.arguments[2:]:
-            mcast_groups.append(grp.decode())
-        n_antennas = len(mcast_groups) // 2
-        for n, grp in enumerate(mcast_groups[1:]):
-            if grp == mcast_groups[0]:
-                # MK is not using a full power-of-2 size array. There are dummies from here onwards.
-                print(f"Dummy antenna found starting at {(n + 1) // 2}")
-                n_antennas = (n + 1) // 2
-                break
-        digitiser_address = mcast_groups[0].split("+")[0]
-
-        subordinates[name] = Subordinate(name, control_port, monitor_port, digitiser_address, n_antennas)
-
-    try:
-        target = subordinates[args.subordinate]
-    except KeyError:
-        print(
-            f"{args.subordinate} is not among the subordinates currently running. "
-            f"Options are: {list(subordinates.keys())}",
-            file=sys.stderr,
-        )
-        return 1
-
-    # connect to the corr2_servlet itself to see the sync time, n_chans and bandwidth
-    corr2_client = await aiokatcp.Client.connect(args.cmc_host, target.control_port)
-    sync_time = await corr2_client.sensor_value("sync-time", float)
-    channels = await corr2_client.sensor_value("antenna-channelised-voltage-n-chans", int)
-    adc_sample_rate = await corr2_client.sensor_value("adc-sample-rate", float)
-    int_time = await corr2_client.sensor_value("baseline-correlation-products-int-time", float)
-    # This returns a string representation of a list of tuples, with each item
-    # in the format (input-label, input-index, LRU host, index-on-host).
-    input_labelling_str = await corr2_client.sensor_value("input-labelling", str)
-    input_labelling: list[tuple[str, int, str, int]] = ast.literal_eval(input_labelling_str)
-    input_labels = [label[0] for label in input_labelling]
-    # Trim off the dummy labels
-    input_labels = input_labels[: 2 * target.n_antennas]
-
-    # This won't distinguish between the different kinds of S-band. It'll be wrong. I'm not quite
-    # sure at this point how to match up the centre_frequency values in katgpucbf.meerkat.BANDS with
-    # what MK actually reports, even in the L and UHF cases, so for the purposes of getting
-    # something producing a result, I am leaving it as-is for the time being.
-    band = next((k for k, v in BANDS.items() if v.adc_sample_rate == adc_sample_rate), None)
-    if not band:
-        print(
-            f"Unable to determine which band. Sample rate reported as {adc_sample_rate}",
-            file=sys.stderr,
-        )
-        return 1
+    sync_time: float = await cbf_sensor_value("wide_sync_time")
+    channels: int = await cbf_sensor_value("wide_antenna_channelised_voltage_n_chans")
+    adc_sample_rate: float = await cbf_sensor_value("wide_adc_sample_rate")
+    int_time: float = await cbf_sensor_value("wide_baseline_correlation_products_int_time")
+    band: str = await cbf_sensor_value("band")
+    centre_frequency: float = await cbf_sensor_value("delay_centre_frequency")
+    if args.name is None:
+        subarray_product_id: str = await cbf_sensor_value("subarray_product_id")
+        args.name = f"{subarray_product_id}_wide"
 
     config: dict = {
         "version": "4.5",
@@ -142,7 +99,7 @@ async def async_main(args) -> int:
                 "sync_time": sync_time,
                 "band": band,
                 "adc_sample_rate": adc_sample_rate,
-                "centre_frequency": BANDS[band].centre_frequency,  # TODO get from CAM
+                "centre_frequency": centre_frequency,
                 "antenna": label[:-1],
                 "url": f"spead://{addr}",
             }
@@ -170,7 +127,7 @@ async def async_main(args) -> int:
     else:
         client = await aiokatcp.Client.connect(args.controller.host, args.controller.port)
         try:
-            reply, _ = await client.request("product-configure", target.name.replace(".", "_"), json.dumps(config))
+            reply, _ = await client.request("product-configure", args.name, json.dumps(config))
             pc_host = aiokatcp.decode(str, reply[1])
             pc_port = aiokatcp.decode(int, reply[2])
             print(f"Product controller is at {pc_host}:{pc_port}")

--- a/scratch/copy-mk.py
+++ b/scratch/copy-mk.py
@@ -31,8 +31,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 import aiokatcp
-import katportalclient
-from katportalclient import KATPortalClient
+from katportalclient import KATPortalClient, SensorNotFoundError
 from katsdptelstate.endpoint import endpoint_parser
 
 import katgpucbf.configure_tools
@@ -52,7 +51,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default="cbf-mc.cbf.mkat.karoo.kat.ac.za",
         help="Endpoint of the CBF master controller",
     )
-    parser.add_argument("--name", help="Name of the subarray product")
+    parser.add_argument("--name", help="Name of the subarray product to create")
     parser.add_argument("--dry-run", action="store_true", help="Print config only")
     katgpucbf.configure_tools.add_arguments(parser)
     args = parser.parse_args(argv)
@@ -75,8 +74,7 @@ async def multi_sensor_values(client: KATPortalClient, names: Sequence[str]) -> 
     out = {}
     for name in names:
         if name not in samples:
-            print(samples)
-            raise katportalclient.SensorNotFoundError(f"Value for sensor {name} not found")
+            raise SensorNotFoundError(f"Value for sensor {name} not found")
         out[name] = samples[name].value
     return out
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,9 @@ qualification =
     pytest-custom_exit_code
     pytest-reportlog
 
+copy-mk =
+    katportalclient
+
 [options.packages.find]
 where = src
 


### PR DESCRIPTION
Replace directly querying the CMC with getting sensors from CAM. This gives us access to extra information such as the band, centre frequency and sensor descriptions.

This adds a new dependency (katportalclient). I added it as an extra to setup.cfg, but given that this is a niche script I haven't added it for generating requirements-dev.txt.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Relates to NGC-1588.
