### PR TITLE
Address some pydocstyle-type warnings in test code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ extend-ignore = ["D105", "D107"]  # docstrings for magic methods
 "test/**/*.py" = ["D"]
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
+property-decorators = ["pytest.fixture"]
 
 [tool.pytest.ini_options]
 testpaths = "test"

--- a/qualification/general/test_control.py
+++ b/qualification/general/test_control.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2022-2024, National Research Foundation (SARAO)
+# Copyright (c) 2022-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -215,7 +215,7 @@ def check_timestamps(
 
 # TODO: once requirements spec is finalised, note which requirements
 # this corresponds to.
-async def test_control(
+async def test_control(  # noqa: D103
     cbf: CBFRemoteControl,
     receive_baseline_correlation_products_manual_start: BaselineCorrelationProductsReceiver,
     receive_tied_array_channelised_voltage_manual_start: TiedArrayChannelisedVoltageReceiver,

--- a/test/dsim/test_signal.py
+++ b/test/dsim/test_signal.py
@@ -77,6 +77,7 @@ class TestMultiCW:
     """Tests for :class:`katgpucbf.dsim.signal.MultiCW`."""
 
     def test_even(self) -> None:
+        """Test with an even-length signal."""
         adc_sample_rate = 1e9
         sig = MultiCW(4, 0.5, 0.25, 100e6, 200e6)
         n = 10000
@@ -91,6 +92,7 @@ class TestMultiCW:
         np.testing.assert_allclose(out, expected, atol=1e-6)
 
     def test_odd(self) -> None:
+        """Test with an odd-length signal."""
         adc_sample_rate = 1e9
         sig = MultiCW(3, 0.5, 0.25, 200e6, 400e6)
         n = 25

--- a/test/fgpu/test_ddc.py
+++ b/test/fgpu/test_ddc.py
@@ -115,6 +115,7 @@ def test_bad_template_parameters(context: AbstractContext, taps: int, subsamplin
 
 
 def test_bad_tuning(context: AbstractContext) -> None:
+    """Test that :class:`DDCTemplate` raises ValueError when given bad tuning parameters."""
     with pytest.raises(ValueError, match="unroll must be a multiple of 16"):
         DDCTemplate(context, taps=255, subsampling=5, input_sample_bits=10, tuning={"wgs": 32, "unroll": 5})
 

--- a/test/fgpu/test_delay.py
+++ b/test/fgpu/test_delay.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2023, National Research Foundation (SARAO)
+# Copyright (c) 2020-2023, 2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -78,11 +78,13 @@ def multi(linear, mdelay_callback_list) -> MultiDelayModel:
 
 @pytest.fixture
 def aligned(linear: LinearDelayModel) -> AlignedDelayModel:
+    """An :class:`AlignedDelayModel` with even alignment."""
     return AlignedDelayModel(linear, 16)
 
 
 @pytest.fixture
 def aligned_odd(linear: LinearDelayModel) -> AlignedDelayModel:
+    """An :class:`AlignedDelayModel` with odd alignment."""
     return AlignedDelayModel(linear, 17)
 
 

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -72,11 +72,17 @@ NARROWBAND_ARGS = f"name=test_narrowband,dst=239.10.12.0+{DSTS - 1}:7149,taps={T
 
 @pytest.fixture
 def channels() -> int:
+    """Number of channels."""
     return CHANNELS
 
 
 @pytest.fixture
 def jones_per_batch(channels: int, request: pytest.FixtureRequest) -> int:
+    """Number of Jones vectors per batch.
+
+    This defaults to :const:`JONES_PER_BATCH`, but can be overridden by
+    ``pytest.mark.spectra_per_heap(spectra_per_heap)``.
+    """
     if marker := request.node.get_closest_marker("spectra_per_heap"):
         return marker.args[0] * channels
     else:

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -641,7 +641,6 @@ class TestEngine:
     @pytest.fixture
     def corrprod_args(self, heap_accumulation_threshold: tuple[int, int]) -> list[str]:
         """Arguments to pass to the command-line parser for multiple --corrprods."""
-
         return [
             f"name=bcp1,dst=239.10.11.0:7148,heap_accumulation_threshold={heap_accumulation_threshold[0]}",
             f"name=bcp2,dst=239.10.11.1:7148,heap_accumulation_threshold={heap_accumulation_threshold[1]}",
@@ -1011,6 +1010,7 @@ class TestEngine:
         corrprod_args: list[str],
         beam_args: list[str],
     ) -> list[str]:
+        """Command-line arguments for the engine."""
         args = [
             "--katcp-host=127.0.0.1",
             "--katcp-port=0",
@@ -1052,6 +1052,7 @@ class TestEngine:
 
     @pytest.fixture
     async def client(self, xbengine: XBEngine) -> AsyncGenerator[aiokatcp.Client, None]:
+        """Katcp client for controlling the engine."""
         host, port = xbengine.sockets[0].getsockname()[:2]
         async with asyncio.timeout(5):  # To fail the test quickly if unable to connect
             client = await aiokatcp.Client.connect(host, port)
@@ -1501,6 +1502,7 @@ class TestEngine:
 
     @DEFAULT_PARAMETERS
     async def test_bad_requests(self, client: aiokatcp.Client, n_ants: int) -> None:
+        """Test various requests with invalid parameters."""
         # Trying to use beamformer request on wrong stream type
         with pytest.raises(aiokatcp.FailReply, match=r"not a tied-array-channelised-voltage stream"):
             await client.request("beam-quant-gains", "bcp1", 1.0)


### PR DESCRIPTION
The warnings are not enabled in this PR, but this prepares for enabling them later.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] (n/a) Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Partial addresses NGC-1465.
