### PR TITLE
Fix reporting of weights in test_delay_small

### DIFF
--- a/qualification/tied_array_channelised_voltage/test_delay.py
+++ b/qualification/tied_array_channelised_voltage/test_delay.py
@@ -82,7 +82,7 @@ async def test_delay_small(
     ref_weights = [0.0] * len(receiver.source_indices[ref_beam])
     ref_weights[ref_input_idx] = 1.0
     await client.request("beam-weights", receiver.stream_names[ref_beam], *ref_weights)
-    pdf_report.detail(f"Set weights on {receiver.stream_names[ref_beam]} to {delay_weights}")
+    pdf_report.detail(f"Set weights on {receiver.stream_names[ref_beam]} to {ref_weights}")
 
     # TODO: need the final version of the requirements to know what values to test
     max_delay = 0.5 / receiver.adc_sample_rate


### PR DESCRIPTION
I haven't actually run a qualification test with this, but it looks like an obvious enough fix.
<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [ ] If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
