### PR TITLE
More docstrings for tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ select = [
     "D",  # pydocstyle
     "N",  # pep8-naming
     "B",  # flake8-bugbear
+    "RUF100",  # Unnecessary noqa directives
 ]
 extend-ignore = ["D105", "D107"]  # docstrings for magic methods
 [tool.ruff.lint.extend-per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,6 @@ select = [
 extend-ignore = ["D105", "D107"]  # docstrings for magic methods
 [tool.ruff.lint.extend-per-file-ignores]
 "scratch/**/*.py" = ["D"]  # Don't fuss with docstrings in scratch/
-# Temporary, until the code can be cleaned up
-# (this is what pydocstyle used to do)
-"test_*.py" = ["D"]
-"test/**/*.py" = ["D"]
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
 property-decorators = ["pytest.fixture"]

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -206,7 +206,7 @@ def pytest_collection_modifyitems(session: pytest.Session, config: pytest.Config
 
 @pytest.fixture(scope="package")
 def n_dsims() -> int:
-    """Number of simulated digitisers."""  # noqa: D401
+    """Number of simulated digitisers."""
     return 1
 
 

--- a/test/dsim/conftest.py
+++ b/test/dsim/conftest.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2021-2022, 2024, National Research Foundation (SARAO)
+# Copyright (c) 2021-2022, 2024-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/dsim/conftest.py
+++ b/test/dsim/conftest.py
@@ -34,7 +34,7 @@ ADC_SAMPLE_RATE = 1712e6
 
 
 @pytest.fixture
-def inproc_queues() -> Sequence[spead2.InprocQueue]:  # noqa: D401
+def inproc_queues() -> Sequence[spead2.InprocQueue]:
     """An in-process queue for data per multicast destination."""
     return [spead2.InprocQueue() for _ in range(N_ENDPOINTS_PER_POL * N_POLS)]
 
@@ -89,7 +89,7 @@ def timestamps() -> np.ndarray:
 
 
 @pytest.fixture
-def heap_sets(timestamps: np.ndarray) -> Sequence[send.HeapSet]:  # noqa: D401
+def heap_sets(timestamps: np.ndarray) -> Sequence[send.HeapSet]:
     """Two instances of :class:`~katgpucbf.dsim.send.HeapSet` with random payload bytes."""
     heap_sets = [
         send.HeapSet.create(
@@ -104,15 +104,13 @@ def heap_sets(timestamps: np.ndarray) -> Sequence[send.HeapSet]:  # noqa: D401
 
 
 @pytest.fixture
-def sender(
-    send_stream: "spead2.send.asyncio.AsyncStream", heap_sets: Sequence[send.HeapSet]
-) -> send.Sender:  # noqa: D401
+def sender(send_stream: "spead2.send.asyncio.AsyncStream", heap_sets: Sequence[send.HeapSet]) -> send.Sender:
     """A :class:`~katgpucbf.dsim.Sender` using the first of :func:`heaps_sets`."""
     return send.Sender(send_stream, heap_sets[0], DIG_HEAP_SAMPLES)
 
 
 @pytest.fixture
-def descriptor_inproc_queues() -> Sequence[spead2.InprocQueue]:  # noqa: D401
+def descriptor_inproc_queues() -> Sequence[spead2.InprocQueue]:
     """An in-process queue for descriptors. Only one queue needed."""
     return [spead2.InprocQueue()]
 
@@ -153,7 +151,7 @@ def descriptor_send_stream(
 
 
 @pytest.fixture
-def descriptor_heap() -> spead2.send.Heap:  # noqa: D401
+def descriptor_heap() -> spead2.send.Heap:
     """One instances of :class:`~katgpucbf.dsim.descriptors.spead2.send.Heap`."""
     return descriptors.create_descriptors_heap()
 
@@ -161,7 +159,7 @@ def descriptor_heap() -> spead2.send.Heap:  # noqa: D401
 @pytest.fixture
 def descriptor_sender(
     descriptor_send_stream: "spead2.send.asyncio.AsyncStream", descriptor_heap: spead2.send.Heap
-) -> DescriptorSender:  # noqa: D401
+) -> DescriptorSender:
     """A :class:`~katgpucbf.dsim.descriptors.DescriptorSender`."""
     return DescriptorSender(
         descriptor_send_stream,

--- a/test/dsim/test_server.py
+++ b/test/dsim/test_server.py
@@ -37,7 +37,7 @@ from .conftest import ADC_SAMPLE_RATE, SIGNAL_HEAPS
 @pytest.fixture
 async def katcp_server(
     sender: Sender, heap_sets: Sequence[HeapSet], descriptor_sender: DescriptorSender
-) -> AsyncGenerator[DeviceServer, None]:  # noqa: D401
+) -> AsyncGenerator[DeviceServer, None]:
     """A :class:`~katgpucbf.dsim.server.DeviceServer`."""
     signals_str = "cw(0.2, 123); cw(0.3, 456);"
     dither_seed = 42
@@ -58,7 +58,7 @@ async def katcp_server(
 
 
 @pytest.fixture
-async def katcp_client(katcp_server: DeviceServer) -> AsyncGenerator[aiokatcp.Client, None]:  # noqa: D401
+async def katcp_client(katcp_server: DeviceServer) -> AsyncGenerator[aiokatcp.Client, None]:
     """A katcp client connection to :func:`katcp_server`."""
     host, port = katcp_server.sockets[0].getsockname()[:2]
     async with asyncio.timeout(5):  # To fail the test quickly if unable to connect

--- a/test/dsim/test_server.py
+++ b/test/dsim/test_server.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2021-2022, 2024, National Research Foundation (SARAO)
+# Copyright (c) 2021-2022, 2024-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/dsim/test_shared_array.py
+++ b/test/dsim/test_shared_array.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2021-2022, National Research Foundation (SARAO)
+# Copyright (c) 2021-2022, 2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/dsim/test_shared_array.py
+++ b/test/dsim/test_shared_array.py
@@ -33,7 +33,7 @@ _MPContext = (
 
 
 @pytest.fixture
-def array() -> Generator[SharedArray, None, None]:  # noqa: D401
+def array() -> Generator[SharedArray, None, None]:
     """A pre-created shared array."""
     array = SharedArray.create("test_shared_array", (10000,), np.int32)
     yield array
@@ -41,7 +41,7 @@ def array() -> Generator[SharedArray, None, None]:  # noqa: D401
 
 
 @pytest.fixture(params=["fork", "forkserver", "spawn"])
-def mp_context(request) -> multiprocessing.context.BaseContext:  # noqa: D401
+def mp_context(request) -> multiprocessing.context.BaseContext:
     """Multiprocessing context (launch method)."""
     return multiprocessing.get_context(request.param)
 

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -90,7 +90,7 @@ def jones_per_batch(channels: int, request: pytest.FixtureRequest) -> int:
 
 
 @pytest.fixture
-def dig_rms_dbfs_window_chunks() -> int:  # noqa: D401
+def dig_rms_dbfs_window_chunks() -> int:
     """Number of chunks per window for ``dig-rms-dbfs`` sensors."""
     return 2
 

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -147,10 +147,15 @@ def assert_angles_allclose(a, b, **kwargs) -> None:
 
 
 class TestEngine:
-    r"""Grouping of unit tests for :class:`.Engine`\'s various functionality."""
+    r"""Test :class:`.Engine`."""
 
     @pytest.fixture(params=["wideband", "narrowband_discard", "narrowband_no_discard"])
     def output_type(self, request: pytest.FixtureRequest) -> str:
+        """Which output to test.
+
+        In all cases there are wideband and narrowband streams, but only one
+        of them is tested for each parametrisation.
+        """
         return request.param
 
     @pytest.fixture
@@ -160,6 +165,7 @@ class TestEngine:
 
     @pytest.fixture(params=[4, 8, 16])
     def decimation(self, request: pytest.FixtureRequest) -> int:
+        """Narrowband decimation factor."""
         return request.param
 
     @pytest.fixture
@@ -199,8 +205,6 @@ class TestEngine:
         """
         return []
 
-    # This is marked autouse to ensure it will be run before the engine_server
-    # fixture.
     @pytest.fixture(autouse=True)
     def mock_dig_rms_dbfs_window_samples(
         self,
@@ -209,6 +213,16 @@ class TestEngine:
         dig_rms_dbfs_window_chunks: int,
         output: Output,
     ) -> None:
+        """Mock :meth:`.Pipeline._dig_rms_dbfs_window_samples`.
+
+        This overrides the calculation to use
+        :func:`dig_rms_dbfs_window_chunks`, and also populates
+        :meth:`dig_rms_dbfs_window_samples` with the computed value.
+
+        This is marked autouse to ensure it will be run before the
+        engine_server fixture.
+        """
+
         def _dig_rms_dbfs_window_samples(self: Pipeline) -> int:
             chunk_samples = self.spectra * self.output.spectra_samples
             window_samples = dig_rms_dbfs_window_chunks * chunk_samples
@@ -288,6 +302,7 @@ class TestEngine:
 
     @pytest.fixture
     def engine_arglist(self, wideband_args: str, narrowband_args: str, default_gain: np.float32) -> list[str]:
+        """Command-line arguments to pass to the engine."""
         return [
             "--katcp-host=127.0.0.1",
             "--katcp-port=0",

--- a/test/fgpu/test_katcp_interface.py
+++ b/test/fgpu/test_katcp_interface.py
@@ -55,6 +55,7 @@ class TestKatcpRequests:
 
     @pytest.fixture
     def engine_arglist(self) -> list[str]:
+        """Command-line arguments to pass to the engine."""
         return [
             "--katcp-host=127.0.0.1",
             "--katcp-port=0",

--- a/test/fgpu/test_pfb.py
+++ b/test/fgpu/test_pfb.py
@@ -113,6 +113,7 @@ def test_pfb_fir_real(
 
 @pytest.mark.parametrize("unzip_factor", [1, 2, 4])
 def test_pfb_fir_complex(context: AbstractContext, command_queue: AbstractCommandQueue, unzip_factor: int) -> None:
+    """Test PFB FIR with complex input."""
     samples = CHANNELS * (SPECTRA + TAPS - 1)
     shape = (N_POLS, samples)
     rng = np.random.default_rng(seed=1)

--- a/test/fgpu/test_pfb.py
+++ b/test/fgpu/test_pfb.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2021, 2023 National Research Foundation (SARAO)
+# Copyright (c) 2020-2021, 2023, 2025 National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/fgpu/test_recv.py
+++ b/test/fgpu/test_recv.py
@@ -294,9 +294,9 @@ class TestIterChunks:
         # This is an async fixture because make_sensors requires a running event loop
         return make_sensors(sensor_timeout=1e6)  # Large timeout so that it doesn't affect the test
 
-    async def test(
+    async def test(  # noqa: D102
         self, layout: Layout, sensors: aiokatcp.SensorSet, time_converter: TimeConverter
-    ) -> None:  # noqa: D102
+    ) -> None:
         streams = [Mock() for _ in range(N_POLS)]
         # Fake up stream stats
         config = spead2.recv.StreamConfig()

--- a/test/fgpu/test_send.py
+++ b/test/fgpu/test_send.py
@@ -48,17 +48,24 @@ NAME = "foo"
 
 @pytest.fixture(params=[4, 8])
 def sample_bits(request) -> int:
+    """Number of bits per output sample."""
     return request.param
 
 
 @pytest.fixture(params=[1, 2])
 def interfaces(request) -> Sequence[str]:
+    """Interface IP addresses for the test.
+
+    This is parametrised to check that both singleton and multiple interfaces
+    work.
+    """
     # request.param gives number of interfaces to use
     return ["10.0.0.1", "10.0.0.2"][: request.param]
 
 
 @pytest.fixture
 def time_converter() -> TimeConverter:
+    """Time converter with arbitrary fixed sync time."""
     return TimeConverter(1234567890.0, ADC_SAMPLE_RATE)
 
 
@@ -70,6 +77,7 @@ def queues(interfaces: Sequence[str]) -> dict[str, list[spead2.InprocQueue]]:
 
 @pytest.fixture
 def chunks(sample_bits) -> list[Chunk]:
+    """Chunks to populate the free queue with (initially all zero)."""
     dtype = gaussian_dtype(sample_bits)
     return [
         Chunk(

--- a/test/fgpu/test_send.py
+++ b/test/fgpu/test_send.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2023-2024, National Research Foundation (SARAO)
+# Copyright (c) 2023-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -211,6 +211,8 @@ class TestCommaSplit:
 
 
 class TestParseDither:
+    """Test :func:`.parse_dither`."""
+
     @pytest.mark.parametrize(
         "input, output",
         [("none", DitherType.NONE), ("uniform", DitherType.UNIFORM)],

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -159,7 +159,7 @@ class TestTimeConverter:
     """Tests for :class:`katgpucbf.utils.TimeConverter`."""
 
     @pytest.fixture
-    def time_converter(self) -> TimeConverter:  # noqa: D401
+    def time_converter(self) -> TimeConverter:
         """A time converter.
 
         It has power-of-two ADC sample count so that tests do not need to worry

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2024, National Research Foundation (SARAO)
+# Copyright (c) 2020-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/xbgpu/conftest.py
+++ b/test/xbgpu/conftest.py
@@ -21,7 +21,7 @@ import spead2
 
 
 @pytest.fixture
-def n_recv_streams() -> int:  # noqa: D401
+def n_recv_streams() -> int:
     """Number of source streams for an xbgpu instance."""
     return 1
 

--- a/test/xbgpu/conftest.py
+++ b/test/xbgpu/conftest.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2022-2024, National Research Foundation (SARAO)
+# Copyright (c) 2022-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/xbgpu/test_bsend.py
+++ b/test/xbgpu/test_bsend.py
@@ -44,6 +44,7 @@ SEND_HEAPS_PER_SUBSTREAM: Final[int] = N_CHUNKS * BATCHES_PER_CHUNK
 
 @pytest.fixture
 def time_converter() -> TimeConverter:
+    """Time converter with arbitrary fixed parameters."""
     return TimeConverter(123456789.0, 1234e6)
 
 


### PR DESCRIPTION
This completes making ruff happy with the docstrings in the tests. I've also enabled the RUF100 check, which will complain if we have a noqa that isn't needed.
<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1465.
