### PR TITLE
Specify strict= parameter to zip() calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ known_local_folder = ["noisy_search", "remote", "sighandler"]
 
 [tool.ruff]
 line-length = 120
+target-version = "py312"
 [tool.ruff.lint]
 select = [
     "E", "W",  # pycodestyle

--- a/qualification/antenna_channelised_voltage/__init__.py
+++ b/qualification/antenna_channelised_voltage/__init__.py
@@ -139,7 +139,8 @@ async def sample_tone_response(
                 signal = tasks[i][1] * N_POLS
                 tg.create_task(pcc.request("dsim-signals", receiver.cbf.dsim_names[i], signal))
         _, data = await receiver.next_complete_chunk()
-        for task, bl_idx in zip(tasks, corrs):
+        # strict=False because we might not have a task for every dsim
+        for task, bl_idx in zip(tasks, corrs, strict=False):
             # In the absence of noise this should be purely real, but
             # due to quantization noise it is complex. Take the absolute
             # value.

--- a/qualification/antenna_channelised_voltage/test_channel.py
+++ b/qualification/antenna_channelised_voltage/test_channel.py
@@ -48,7 +48,7 @@ def measure_sfdr(hdr_data_db: np.ndarray, base_channel: np.ndarray) -> list[floa
     """
     sfdr_measurements = []
 
-    for spectrum, channel in zip(hdr_data_db, base_channel):
+    for spectrum, channel in zip(hdr_data_db, base_channel, strict=True):
         peak_value = spectrum[channel]
         next_peak_value = max(np.max(spectrum[:channel]), np.max(spectrum[channel + 1 :]))
         peak_diff = peak_value - next_peak_value

--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -257,7 +257,7 @@ async def test_delay_sensors(
     pdf_report.step("Wait for load time and check sensors.")
     pdf_report.detail(f"Wait for an accumulation with timestamp >= {load_ts}.")
     await receiver.next_complete_chunk(min_timestamp=load_ts)
-    for expected, label in zip(delay_tuples, receiver.input_labels):
+    for expected, label in zip(delay_tuples, receiver.input_labels, strict=True):
         value = await delay_sensor_value(label)
         pdf_report.detail(f"Input {label} has delay sensor {value}, expected value {expected}.")
         with check:
@@ -720,7 +720,7 @@ async def test_group_delay(
             the Central Limit Theorem applies.
         """
         async with asyncio.TaskGroup() as tg:
-            for dsim_name, dsim_freqs in zip(cbf.dsim_names, cfreqs_by_dsim):
+            for dsim_name, dsim_freqs in zip(cbf.dsim_names, cfreqs_by_dsim, strict=True):
                 if dsim_freqs:
                     signal = " ".join(
                         f"multicw({len(dsim_freqs)}, {amplitude}, 0.0, {dsim_freqs[0] + rfreq}, {freq_step_dsim});"

--- a/qualification/antenna_channelised_voltage/test_gain.py
+++ b/qualification/antenna_channelised_voltage/test_gain.py
@@ -78,7 +78,7 @@ async def test_gains(
 
     loop = asyncio.get_running_loop()
     start_time = loop.time()
-    for input_gain, input_label in zip(gains_text, receiver.input_labels):
+    for input_gain, input_label in zip(gains_text, receiver.input_labels, strict=True):
         await cbf.product_controller_client.request(
             "gain",
             "antenna-channelised-voltage",

--- a/qualification/general/test_control.py
+++ b/qualification/general/test_control.py
@@ -108,7 +108,7 @@ async def control_acv_delays(rng: np.random.Generator, cbf: CBFRemoteControl, pd
     all_elapsed = []
     try:
         async for _ in periodically(rng, DELAY_INTERVAL):
-            coeff = [f"{d},{dr}:{p},{pr}" for d, dr, p, pr in zip(delay, delay_rate, phase, phase_rate)]
+            coeff = [f"{d},{dr}:{p},{pr}" for d, dr, p, pr in zip(delay, delay_rate, phase, phase_rate, strict=True)]
             elapsed = await measure(pcc.request("delays", name, target_time, *coeff))
             pdf_report.detail(f"Set delays for {name} in {elapsed:.3f} s.")
             with check:
@@ -147,7 +147,7 @@ async def control_tacv_delays(rng: np.random.Generator, cbf: CBFRemoteControl, p
         async for _ in periodically(rng, BEAM_DELAY_INTERVAL):
             delay = rng.uniform(-BEAM_MAX_DELAY, BEAM_MAX_DELAY, n_inputs)
             phase = rng.uniform(-np.pi, np.pi, n_inputs)
-            coeff = [f"{d}:{p}" for d, p in zip(delay, phase)]
+            coeff = [f"{d}:{p}" for d, p in zip(delay, phase, strict=True)]
             elapsed = await measure(pcc.request("beam-delays", name, *coeff))
             pdf_report.detail(f"Set delays for {name} in {elapsed:.3f} s.")
             with check:

--- a/qualification/recv.py
+++ b/qualification/recv.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2022-2024, National Research Foundation (SARAO)
+# Copyright (c) 2022-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -480,7 +480,7 @@ def _create_receive_stream_group(
 
     # Needed for placing the individual heaps within the chunk.
     items = [FREQUENCY_ID, TIMESTAMP_ID, BEAM_ANTS_ID, spead2.HEAP_LENGTH_ID]
-    for i, (endpoints, core) in enumerate(zip(multicast_endpoints, cores)):
+    for i, (endpoints, core) in enumerate(zip(multicast_endpoints, cores, strict=True)):
         user_data = np.array([i], np.int64)
         chunk_stream_config = spead2.recv.ChunkStreamConfig(
             items=items,

--- a/qualification/tied_array_channelised_voltage/test_delay.py
+++ b/qualification/tied_array_channelised_voltage/test_delay.py
@@ -247,7 +247,7 @@ async def test_delay_update_time(
     pdf_report.step("Measure delay setting time")
     start = time.monotonic()
     pdf_report.detail(f"Start time is {start:.6f}.")
-    for stream_name, stream_params in zip(receiver.stream_names, params):
+    for stream_name, stream_params in zip(receiver.stream_names, params, strict=True):
         await client.request("beam-delays", stream_name, *stream_params)
         pdf_report.detail(f"Set delays on {stream_name} to {stream_params}")
     stop = time.monotonic()

--- a/qualification/tied_array_channelised_voltage/test_gain.py
+++ b/qualification/tied_array_channelised_voltage/test_gain.py
@@ -60,7 +60,7 @@ async def test_gain(
         pdf_report.detail(f"Set weights for {stream_name} to {weights}.")
 
     pdf_report.step("Set gains to 1/2, 1 and 2.")
-    for gain, stream_name in zip(gains, stream_names):
+    for gain, stream_name in zip(gains, stream_names, strict=True):
         await pcc.request("beam-quant-gains", stream_name, gain)
         pdf_report.detail(f"Set gain for {stream_name} to {gain}.")
 
@@ -69,8 +69,8 @@ async def test_gain(
     pdf_report.detail(f"Received chunk with timestamp {timestamp}.")
 
     pdf_report.step("Check power level of each beam.")
-    data = data[:, pass_channels]
-    for gain, stream_name, stream_data in zip(gains, stream_names, data):
+    data = data[: len(gains), pass_channels]
+    for gain, stream_name, stream_data in zip(gains, stream_names, data, strict=True):
         power = np.sum(np.square(stream_data, dtype=np.float32)) / (stream_data.shape[0] * stream_data.shape[1])
         expected_power = np.square(amplitude * dig_max * gain)
         pdf_report.detail(f"{stream_name}: power measured as {power:.2f}, expected {expected_power:.2f}.")

--- a/qualification/tied_array_channelised_voltage/test_linearity.py
+++ b/qualification/tied_array_channelised_voltage/test_linearity.py
@@ -70,8 +70,8 @@ async def _test_linearity(
     assert scales[middle] == pytest.approx(1.0)
     powers = np.zeros_like(scales)
     for batch in batched(enumerate(scales), len(receiver.stream_names)):
-        # The last batch might be short (since the number of scales won't be
-        # multiple of the number of streams. When zipping with streams, we
+        # The last batch might be short (since the number of scales won't be a
+        # multiple of the number of streams). When zipping with streams, we
         # don't expect the iterables to be the same length, and some streams
         # will be unused.
         for (_, scale), beam_name in zip(batch, receiver.stream_names, strict=False):

--- a/qualification/tied_array_channelised_voltage/test_linearity.py
+++ b/qualification/tied_array_channelised_voltage/test_linearity.py
@@ -70,6 +70,10 @@ async def _test_linearity(
     assert scales[middle] == pytest.approx(1.0)
     powers = np.zeros_like(scales)
     for batch in batched(enumerate(scales), len(receiver.stream_names)):
+        # The last batch might be short (since the number of scales won't be
+        # multiple of the number of streams. When zipping with streams, we
+        # don't expect the iterables to be the same length, and some streams
+        # will be unused.
         for (_, scale), beam_name in zip(batch, receiver.stream_names, strict=False):
             await set_variable(client, beam_name, scale)
             pdf_report.detail(f"Set {variable} to {scale} on {beam_name}.")

--- a/qualification/tied_array_channelised_voltage/test_linearity.py
+++ b/qualification/tied_array_channelised_voltage/test_linearity.py
@@ -70,12 +70,12 @@ async def _test_linearity(
     assert scales[middle] == pytest.approx(1.0)
     powers = np.zeros_like(scales)
     for batch in batched(enumerate(scales), len(receiver.stream_names)):
-        for (_, scale), beam_name in zip(batch, receiver.stream_names):
+        for (_, scale), beam_name in zip(batch, receiver.stream_names, strict=False):
             await set_variable(client, beam_name, scale)
             pdf_report.detail(f"Set {variable} to {scale} on {beam_name}.")
         _, data = await receiver.next_complete_chunk()
         pdf_report.detail("Received chunk.")
-        for (i, _), d, beam_name in zip(batch, data, receiver.stream_names):
+        for (i, _), d, beam_name in zip(batch, data, receiver.stream_names, strict=False):
             powers[i] = np.sum(np.square(d.astype(np.float64)))
             pdf_report.detail(f"Power on {beam_name} is {powers[i]}.")
 

--- a/qualification/tied_array_channelised_voltage/test_weights.py
+++ b/qualification/tied_array_channelised_voltage/test_weights.py
@@ -63,7 +63,7 @@ async def test_weight_mapping(
 
     pdf_report.step("Set eq gains to select one channel per input.")
     async with asyncio.TaskGroup() as tg:
-        for input_label, channel in zip(receiver.input_labels, all_channels_under_test):
+        for input_label, channel in zip(receiver.input_labels, all_channels_under_test, strict=True):
             gains = [0.0] * receiver.n_chans
             gains[channel] = 1.0
             tg.create_task(pcc.request("gain", "antenna-channelised-voltage", input_label, *gains))

--- a/scratch/benchmarks/benchmark_fgpu.py
+++ b/scratch/benchmarks/benchmark_fgpu.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 ################################################################################
-# Copyright (c) 2023-2024, National Research Foundation (SARAO)
+# Copyright (c) 2023-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -258,7 +258,7 @@ async def heap_counts(session: aiohttp.client.ClientSession, server: Server, n: 
             tg.create_task(_heap_counts1(session, f"http://{server.hostname}:{7250 + i}/metrics")) for i in range(n)
         ]
     partials = [task.result() for task in tasks]
-    heaps, missing_heaps = zip(*partials)
+    heaps, missing_heaps = zip(*partials, strict=True)
     return sum(heaps), sum(missing_heaps)
 
 
@@ -347,7 +347,7 @@ async def calibrate(args: argparse.Namespace) -> None:
                         print(f"{result.message()}, rerunning", flush=True, file=sys.stderr)
                     else:
                         print(f"{result.message()}, {successes[j]}/{trial + 1} passed", flush=True, file=sys.stderr)
-    for success, adc_sample_rate in zip(successes, rates):
+    for success, adc_sample_rate in zip(successes, rates, strict=True):
         print(adc_sample_rate, success, args.calibrate_repeat)
 
 

--- a/scratch/copy-mk.py
+++ b/scratch/copy-mk.py
@@ -231,7 +231,7 @@ async def async_main(args) -> int:
                 "antenna": observers[f"{label[:-1]}_observer"],
                 "url": f"spead://{addr}",
             }
-            for label, addr in zip(input_labels, mcast_groups)
+            for label, addr in zip(input_labels, mcast_groups, strict=True)
         },
         "outputs": {
             "antenna-channelised-voltage": {

--- a/scratch/plot.py
+++ b/scratch/plot.py
@@ -1,5 +1,21 @@
 #!/usr/bin/env python3
 
+################################################################################
+# Copyright (c) 2022, 2025, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 import argparse
 import json
 
@@ -69,12 +85,12 @@ for data in events:
 fig, axes = plt.subplots(len(queues) + len(state_machines), 1, sharex=True)
 queue_axes = axes[: len(queues)]
 state_machine_axes = axes[len(queues) :]
-for ax, queue in zip(queue_axes, queues.values()):
+for ax, queue in zip(queue_axes, queues.values(), strict=True):
     ax.axhline(queue.maxsize, color="r", alpha=0.3)
     ax.plot(queue.x, queue.y, drawstyle="steps-post", label=queue.name)
     ax.set_xticks(np.arange(0, queue.x[-1], 4096 * 16384 / 1712000000))
     ax.legend(loc="upper left")
-for ax, state_machine in zip(state_machine_axes, state_machines.values()):
+for ax, state_machine in zip(state_machine_axes, state_machines.values(), strict=True):
     ax.plot(state_machine.x, state_machine.y, drawstyle="steps-post", label=state_machine.name)
     ax.set_xticks(np.arange(0, queue.x[-1], 4096 * 16384 / 1712000000))
     ax.legend(loc="upper left")

--- a/src/katgpucbf/dsim/signal.py
+++ b/src/katgpucbf/dsim/signal.py
@@ -309,19 +309,6 @@ class MultiCW(Signal):
     frequency_step: float
     _class_name: ClassVar[str] = "multicw"
 
-    @staticmethod
-    def _sample_chunk(
-        offset: np.ndarray, *, amplitudes: np.ndarray, chunk_size: int, frequencies: np.ndarray
-    ) -> np.ndarray:
-        # Do intermediate computations in double precision, to minimise error
-        # accumulation in the sum.
-        accum = np.zeros(chunk_size, np.float64)
-        for amplitude, frequency in zip(amplitudes, frequencies):
-            accum += _cw(
-                offset[0], amplitude=amplitude, frequency=frequency, n=chunk_size, dtype=np.dtype(np.complex128)
-            )
-        return accum.astype(np.float32)
-
     def sample(self, n: int, sample_rate: float) -> da.Array:  # noqa: D102
         # Build the frequency domain
         spectrum = np.zeros(n // 2 + 1, np.float32)

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -83,7 +83,7 @@ def _sample_models(
     # Each element of parts is a tuple of results from one delay model
     parts = [model.range(start, stop, step) for model in delay_models]
     # Transpose so that each element of groups is one result from all delay models
-    return tuple(np.stack(group) for group in zip(*parts))  # type: ignore
+    return tuple(np.stack(group) for group in zip(*parts, strict=True))  # type: ignore
 
 
 def generate_pfb_weights(step: int, taps: int, w_cutoff: float, window_function: WindowFunction) -> np.ndarray:
@@ -1007,7 +1007,7 @@ class Pipeline:
             The current :class:`OutQueueItem`
         """
         all_present = np.all(out_item.present)
-        for pol, (accum, trg) in enumerate(zip(dig_total_power_accums, dig_total_power)):
+        for pol, (accum, trg) in enumerate(zip(dig_total_power_accums, dig_total_power, strict=True)):
             power: int | None = int(trg)
             if not all_present:
                 power = None
@@ -1754,7 +1754,7 @@ class Engine(aiokatcp.DeviceServer):
                 )
             )
 
-        for delay_model, new_linear_model in zip(pipeline.delay_models, new_linear_models):
+        for delay_model, new_linear_model in zip(pipeline.delay_models, new_linear_models, strict=True):
             delay_model.base.add(new_linear_model)
         self._update_steady_state_timestamp(pipeline.delay_update_timestamp())
 

--- a/src/katgpucbf/fgpu/send.py
+++ b/src/katgpucbf/fgpu/send.py
@@ -256,7 +256,7 @@ class Chunk:
         """
         futures = []
         saturated = [0] * N_POLS
-        for present, batch in zip(self.present[:batches], self._batches[:batches]):
+        for present, batch in zip(self.present[:batches], self._batches[:batches], strict=True):
             if present:
                 futures.append(_multi_send(streams, batch.heaps))
                 futures[-1].add_done_callback(functools.partial(self._inc_counters, batch, output_name))

--- a/src/katgpucbf/xbgpu/bsend.py
+++ b/src/katgpucbf/xbgpu/bsend.py
@@ -295,7 +295,7 @@ class Chunk:
         """
         send_enabled = tuple(
             enabled and self.timestamp >= timestamp
-            for enabled, timestamp in zip(send_stream.send_enabled, send_stream.send_enabled_timestamp)
+            for enabled, timestamp in zip(send_stream.send_enabled, send_stream.send_enabled_timestamp, strict=True)
         )
         n_enabled = sum(send_enabled)
         end_timestamp_adc = self._timestamp + self._timestamp_step * len(self._batches)
@@ -308,7 +308,7 @@ class Chunk:
         rate = send_stream.bytes_per_second_per_beam * n_enabled
         send_futures: list[asyncio.Future] = []
         if n_enabled > 0:
-            for batch, antenna_presence in zip(self._batches, self._present_ants):
+            for batch, antenna_presence in zip(self._batches, self._present_ants, strict=True):
                 if antenna_presence == 0:
                     # No antennas were present in the received batch of heaps
                     # This check takes priority as we do not transmit batches
@@ -319,7 +319,7 @@ class Chunk:
                     batch.send_heaps = spead2.send.HeapReferenceList(
                         [
                             spead2.send.HeapReference(heap, substream_index=i, rate=rate)
-                            for i, (heap, enabled) in enumerate(zip(batch.heaps, send_enabled))
+                            for i, (heap, enabled) in enumerate(zip(batch.heaps, send_enabled, strict=True))
                             if enabled
                         ]
                     )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2024, National Research Foundation (SARAO)
+# Copyright (c) 2020-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -102,8 +102,8 @@ def pytest_generate_tests(metafunc) -> None:
         for indices in itertools.product(*(range(len(value_list)) for value_list in values)):
             candidate = _CombinationsCandidate(
                 indices=indices,
-                values=tuple(value_list[i] for value_list, i in zip(values, indices)),
-                by_name={name: value_list[i] for name, value_list, i in zip(names, values, indices)},
+                values=tuple(value_list[i] for value_list, i in zip(values, indices, strict=True)),
+                by_name={name: value_list[i] for name, value_list, i in zip(names, values, indices, strict=True)},
             )
             if filter(candidate.by_name):
                 candidates.append(candidate)
@@ -121,7 +121,7 @@ def pytest_generate_tests(metafunc) -> None:
                 best: _CombinationsCandidate | None = None
                 best_score = 0
                 for candidate in candidates:
-                    score = sum(c[idx] for c, idx in zip(cover, candidate.indices))
+                    score = sum(c[idx] for c, idx in zip(cover, candidate.indices, strict=True))
                     if best is None or score <= best_score:
                         best = candidate
                         best_score = score
@@ -129,7 +129,7 @@ def pytest_generate_tests(metafunc) -> None:
                     raise RuntimeError("Filter is too strict: not all values can be tested")
                 combos.append(best)
                 candidates.remove(best)
-                for c, idx in zip(cover, best.indices):
+                for c, idx in zip(cover, best.indices, strict=True):
                     c[idx] += 1
             # First combo will have last element of each list. Make that the
             # last test rather than the first.
@@ -165,7 +165,7 @@ def mock_send_stream(
         stream_queues = [spead2.InprocQueue() for _ in endpoints]
         queues.extend(
             queue
-            for queue, endpoint in zip(stream_queues, endpoints)
+            for queue, endpoint in zip(stream_queues, endpoints, strict=True)
             if IPv4Address(endpoint[0]) in mock_send_stream_network
         )
         return spead2.send.asyncio.InprocStream(thread_pool, stream_queues, config)

--- a/test/fgpu/test_katcp_interface.py
+++ b/test/fgpu/test_katcp_interface.py
@@ -218,7 +218,8 @@ class TestKatcpRequests:
             sensor_values_str = sensor_reading[1:-1].split(",")[1:]  # Drop the timestamp
             sensor_values = (float(field.strip()) for field in sensor_values_str)
 
-            for actual_value, expected_value in zip(sensor_values, parse_delay_string(correct_delay_strings[pol])):
+            expected_values = parse_delay_string(correct_delay_strings[pol])
+            for actual_value, expected_value in zip(sensor_values, expected_values, strict=True):
                 assert actual_value == pytest.approx(expected=expected_value)
 
     @pytest.mark.parametrize(

--- a/test/fgpu/test_recv.py
+++ b/test/fgpu/test_recv.py
@@ -220,7 +220,7 @@ class TestStream:
         if timestamps == "bad":
             bad_heaps = gen_heaps(layout, ~data, first_timestamp + 1234567)
             # Interleave the sequences
-            heaps = itertools.chain.from_iterable(zip(heaps, bad_heaps))
+            heaps = itertools.chain.from_iterable(zip(heaps, bad_heaps, strict=True))
 
         # Heap with no payload - representing any sort of metadata heap such as descriptors
         heap = spead2.send.Heap(FLAVOUR)

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -334,7 +334,7 @@ def verify_corrprod_data(
         Boolean array of shape (n_batches, n_ants) indicating which heaps were
         present.
     """
-    for corrprod_output, acc_index_list in zip(corrprod_outputs, acc_indices):
+    for corrprod_output, acc_index_list in zip(corrprod_outputs, acc_indices, strict=True):
         for j, acc_index in enumerate(acc_index_list):
             n_batches = corrprod_output.heap_accumulation_threshold
             batch_start_index = acc_index * n_batches
@@ -874,7 +874,7 @@ class TestEngine:
 
         acc_indices = [
             [acc_index for acc_index, count in counts.items() if count == corrprod_output.heap_accumulation_threshold]
-            for counts, corrprod_output in zip(acc_counts, corrprod_outputs)
+            for counts, corrprod_output in zip(acc_counts, corrprod_outputs, strict=True)
         ]
 
         for queue in mock_recv_streams:
@@ -891,7 +891,7 @@ class TestEngine:
                 ),
                 dtype=np.int32,
             )
-            for corrprod_output, acc_index_list in zip(corrprod_outputs, acc_indices)
+            for corrprod_output, acc_index_list in zip(corrprod_outputs, acc_indices, strict=True)
         }
 
         out_config = spead2.recv.StreamConfig(max_heaps=100)
@@ -939,7 +939,7 @@ class TestEngine:
         if beam_capture_stop_heap_indices is None:
             # Rather be explicit for each `beam_output` to simplify the logic below
             beam_capture_stop_heap_indices = [None] * len(beam_outputs)
-        for beam_output, capture_stop_heap_index in zip(beam_outputs, beam_capture_stop_heap_indices):
+        for beam_output, capture_stop_heap_index in zip(beam_outputs, beam_capture_stop_heap_indices, strict=True):
             # If necessary, adjust the corresponding beam stream to only receive
             # the required amount of data (up until the capture-stop point).
             n_batches = len(batch_indices) if capture_stop_heap_index is None else capture_stop_heap_index
@@ -962,7 +962,7 @@ class TestEngine:
             items = ig_recv.update(heap)
             assert len(items) == 0, "This heap contains item values not just the expected descriptors."
             n_batches_to_receive = beam_results[beam_output.name].shape[0]
-            for j, index in zip(range(n_batches_to_receive), batch_indices):
+            for j, index in zip(range(n_batches_to_receive), batch_indices, strict=False):
                 assert await self.get_data_heap(stream, ig_recv) == {"frequency", "timestamp", "beam_ants", "bf_raw"}
                 assert ig_recv["timestamp"].value == index * timestamp_step
                 assert ig_recv["frequency"].value == frequency

--- a/test/xbgpu/test_recv.py
+++ b/test/xbgpu/test_recv.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2024, National Research Foundation (SARAO)
+# Copyright (c) 2020-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -192,7 +192,7 @@ class TestStream:
         if timestamps == "bad":
             bad_heaps = gen_heaps(layout, ~data, first_timestamp + 1234567)
             # Interleave the sequences
-            heaps = itertools.chain.from_iterable(zip(heaps, bad_heaps))
+            heaps = itertools.chain.from_iterable(zip(heaps, bad_heaps, strict=True))
 
         with PromDiff(namespace=METRIC_NAMESPACE) as prom_diff:
             # Heap with no payload - representing any sort of metadata heap such as descriptors


### PR DESCRIPTION
Add target-version="py312" parameter to ruff configuration. This enables
it to give warnings that are not appropriate to older Python versions.
The primary is that it recommends specifying the 'strict' parameter to
zip() calls to indicate whether the inputs are expected to be the same
length. This is probably good documentation and a good sanity check so
I've done that.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report:
  - https://jenkins.cbf.mkat.karoo.kat.ac.za/job/qualification_katgpucbf/111 (had two failures, but since only one config is affected and the results are related to not receiving data, I'm assuming this is a network wobble rather than broken code)
  - https://jenkins.cbf.mkat.karoo.kat.ac.za/job/qualification_katgpucbf_lab/13 (still running)
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match