### PR TITLE
scratch benchmark tools: zero out accumulating buffers first

### DIFF
--- a/scratch/fgpu/benchmarks/compute_bench.py
+++ b/scratch/fgpu/benchmarks/compute_bench.py
@@ -157,7 +157,7 @@ def main():
 
         # Fill these with zeros just to ensure performance isn't affected
         # by stray NaNs and the like.
-        for name in ["fine_delay", "phase"]:
+        for name in ["fine_delay", "phase", "saturated", "dig_total_power"]:
             fn.buffer(name).zero(command_queue)
 
         def run_ddc():

--- a/scratch/fgpu/benchmarks/compute_bench.py
+++ b/scratch/fgpu/benchmarks/compute_bench.py
@@ -158,7 +158,8 @@ def main():
         # Fill these with zeros just to ensure performance isn't affected
         # by stray NaNs and the like.
         for name in ["fine_delay", "phase", "saturated", "dig_total_power"]:
-            fn.buffer(name).zero(command_queue)
+            if name in fn.slots:  # dig_total_power doesn't exist in narrowband modes
+                fn.buffer(name).zero(command_queue)
 
         def run_ddc():
             fn.ddc()

--- a/scratch/xbgpu/benchmarks/beamform_bench.py
+++ b/scratch/xbgpu/benchmarks/beamform_bench.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 ################################################################################
-# Copyright (c) 2024, National Research Foundation (SARAO)
+# Copyright (c) 2024-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -74,6 +74,7 @@ def main():
     fn.buffer("weights").set(command_queue, h_weights)
     fn.buffer("delays").zero(command_queue)
     fn.buffer("in").zero(command_queue)
+    fn.buffer("saturated").zero(command_queue)
 
     fn()  # Warmup pass
     command_queue.finish()


### PR DESCRIPTION
This is just to keep compute-sanitiser --tool=initcheck happy.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
