### PR TITLE
qualification/Jenkinsfile improvements

### DIFF
--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -33,6 +33,8 @@
  * - katsdpcontroller_image: image path for katsdpcontroller (for product controller)
  * - branch: branch of katgpucbf from which to obtain test code
  * - ini: relative path (from repo root) to pytest configuration file
+ * - extra_args: extra user-provided command-line arguments
+ * - environment: name for the test environment (for use in email notification)
  *
  * For more information on the qualification framework, see
  * katgpucbf/doc/qualification.rst
@@ -101,7 +103,8 @@ pipeline {
            --suppress-tests-failed-exit-code \
            --image-override katgpucbf:${katgpucbf_image} \
            --image-override katsdpcontroller:${katsdpcontroller_image} \
-           --junitxml=result.xml
+           --junitxml=result.xml \
+           ${extra_args}
          '''
        }
      }
@@ -171,7 +174,7 @@ pipeline {
         <br>
         <i>Note: This is an Automated email notification.</i>""",
         recipientProviders: [developers(), requestor()],
-        subject: 'Qualification Tests - katgpucbf - $BUILD_STATUS!',
+        subject: "${params.environment} Qualification Tests - katgpucbf - \$BUILD_STATUS!",
         to: '$DEFAULT_RECIPIENTS'
       )
       sh "qualification/cleanup.py -- ${ini}"


### PR DESCRIPTION
Use the environment name to form the email subject (to distinguish lab from karoo).

Use extra_args to allow the user to specify extra command-line arguments for pytest.

Relates to NGC-1593.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report: see email notifications
- [x]  (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match