### PR TITLE
Adjust channel spacing for test_group_delay

### DIFF
--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -635,7 +635,10 @@ async def test_group_delay(
         )
     else:
         # Pick channels to test, keeping some distance from the edges.
-        channel_step = 8  # Gap to minimise leakage between tones
+        # The channel step is set to keep a fixed number of channels
+        # between tones in the same dsim, because that determines the
+        # spectral leakage between tones.
+        channel_step = math.ceil(256 / n_dsims)
         channels_slice = slice(
             pass_channels.start + channel_step // 2,
             pass_channels.stop - channel_step // 2,


### PR DESCRIPTION
Keep 256 channels per dsim, rather than 8 between channels in different dsims. It's the spacing within each dsim that determines spectral leakage, and tests in the lab (with fewer dsims) were failing.

Relates to NGC-1593.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report: [report-NGC-1593.pdf](https://github.com/user-attachments/files/19181140/report-NGC-1593.pdf)
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match