### PR TITLE
copy-mk improvements

### DIFF
--- a/scratch/copy-mk.py
+++ b/scratch/copy-mk.py
@@ -242,8 +242,12 @@ async def async_main(args) -> int:
             "src_streams": ["baseline-correlation-products"],
             "output_int_time": sensor_values[sdp_int_time_name],
             "excise": False,
-            "archive": False,  # This is just for testing, so do not archive
+            "archive": False,
             "continuum_factor": 1,
+        }
+        config["inputs"]["camdata"] = {
+            "type": "cam.http",
+            "url": args.portal,
         }
 
     katgpucbf.configure_tools.apply_arguments(config, args)


### PR DESCRIPTION
The main change is to add tracking of gains, and conversion to match the scale for MK. To do this, I made the katportalclient callback even simpler, just passing through the sensor name and value, with all the processing on it done in the main function.

A more minor change is to pass through a cam.http stream so that the SDP can query sensors from CAM.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Relates to NGC-1588.
