### PR TITLE
Qualification: save arrays when np.testing.assert_* fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
     texlive-base \
     texlive-latex-extra \
     texlive-latex-recommended \
-    texlive-science
+    texlive-science \
+    zstd
 
 # Install required packages for testing to be able to run
 COPY requirements-dev.txt .

--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -90,68 +90,80 @@ pipeline {
      * qualification test results.
      */
     stage('Run qualification tests') {
-       steps {
-         /* Run the actual pytest.
-          * Jenkins will not run subsequent steps if pytest returns a non-zero
-          * exit code. Passing --suppress-tests-failed-exit-code causes the
-          * exit code to be zero if there are failed tests, so that we can still
-          * get the report in that case. The junit step will detect the failed
-          * tests and mark the build as unstable.
-          */
-         sh '''
-           spead2_net_raw pytest -v -c ${ini} qualification \
-           --suppress-tests-failed-exit-code \
-           --image-override katgpucbf:${katgpucbf_image} \
-           --image-override katsdpcontroller:${katsdpcontroller_image} \
-           --junitxml=result.xml \
-           ${extra_args}
-         '''
-       }
-     }
+      steps {
+        /* Run the actual pytest.
+         * Jenkins will not run subsequent steps if pytest returns a non-zero
+         * exit code. Passing --suppress-tests-failed-exit-code causes the
+         * exit code to be zero if there are failed tests, so that we can still
+         * get the report in that case. The junit step will detect the failed
+         * tests and mark the build as unstable.
+         */
+        sh '''
+          spead2_net_raw pytest -v -c ${ini} qualification \
+          --suppress-tests-failed-exit-code \
+          --image-override katgpucbf:${katgpucbf_image} \
+          --image-override katsdpcontroller:${katsdpcontroller_image} \
+          --junitxml=result.xml \
+          ${extra_args}
+        '''
+      }
+    }
 
-     stage('Publish results') {
-       steps {
-         // skipPublishingChecks because it's a feature we don't use.
-         // See https://stackoverflow.com/questions/67162746/how-to-get-rid-of-noisy-warning-no-suitable-checks-publisher-found/68992826#68992826
-         junit testResults: 'result.xml', skipPublishingChecks: true
+    stage('Publish results') {
+      steps {
+        // skipPublishingChecks because it's a feature we don't use.
+        // See https://stackoverflow.com/questions/67162746/how-to-get-rid-of-noisy-warning-no-suitable-checks-publisher-found/68992826#68992826
+        junit testResults: 'result.xml', skipPublishingChecks: true
 
-         // Compress and publish json file so that at least we have that.
-         // 'includes' specifies which files from the current directory to archive;
-         // we only want the linked file itself
-         sh 'xz --keep --force -T 0 report.json'
-         publishHTML(target: [
-           keepAll: true,
-           reportName: 'Qualification Test Intermediate JSON',
-           reportDir: '',
-           reportFiles: 'report.json.xz',
-           includes: 'report.json.xz'
-         ])
+        // Compress and publish json file so that at least we have that.
+        // 'includes' specifies which files from the current directory to archive;
+        // we only want the linked file itself
+        sh 'xz --keep --force -T 0 report.json'
+        publishHTML(target: [
+          keepAll: true,
+          reportName: 'Qualification Test Intermediate JSON',
+          reportDir: '',
+          reportFiles: 'report.json.xz',
+          includes: 'report.json.xz'
+        ])
 
-         script {
-           // Generate and publish test report
-           COMMIT_ID = sh(script: 'qualification/report/generate_pdf.py report.json report.pdf -c', returnStdout: true)
-           currentBuild.displayName = "#${BUILD_NUMBER} (${COMMIT_ID})"
-         }
-         publishHTML(target: [
-           keepAll: true,
-           reportName: 'Qualification Test Report',
-           reportDir: '',
-           reportFiles: 'report.pdf',
-           includes: 'report.pdf'
-         ])
+        // Save any numpy arrays recorded by failing tests. We use zstd
+        // because --xz and --gzip can be extremely slow if there is a
+        // lot of data.
+        sh 'tar --zstd -cf arrays.tar.zstd -C qualification arrays/'
+        publishHTML(target: [
+          keepAll: true,
+          reportName: 'Qualification Test Raw Failed Arrays',
+          reportDir: '',
+          reportFiles: 'arrays.tar.zstd',
+          includes: 'arrays.tar.zstd'
+        ])
 
-         // If that worked, we can probably generate and publish a procedure as well
-         sh 'qualification/report/generate_pdf.py report.json procedure.pdf --generate-procedure-doc'
-         publishHTML(target: [
-           keepAll: true,
-           reportName: 'Qualification Test Procedure',
-           reportDir: '',
-           reportFiles: 'procedure.pdf',
-           includes: 'procedure.pdf'
-         ])
-       }
-     }
-   }
+        script {
+          // Generate and publish test report
+          COMMIT_ID = sh(script: 'qualification/report/generate_pdf.py report.json report.pdf -c', returnStdout: true)
+          currentBuild.displayName = "#${BUILD_NUMBER} (${COMMIT_ID})"
+        }
+        publishHTML(target: [
+          keepAll: true,
+          reportName: 'Qualification Test Report',
+          reportDir: '',
+          reportFiles: 'report.pdf',
+          includes: 'report.pdf'
+        ])
+
+        // If that worked, we can probably generate and publish a procedure as well
+        sh 'qualification/report/generate_pdf.py report.json procedure.pdf --generate-procedure-doc'
+        publishHTML(target: [
+          keepAll: true,
+          reportName: 'Qualification Test Procedure',
+          reportDir: '',
+          reportFiles: 'procedure.pdf',
+          includes: 'procedure.pdf'
+        ])
+      }
+    }
+  }
 
   /* This post stage is configured to always run at the end of this pipeline,
    * regardless of the completion status. In this stage an email is sent to

--- a/qualification/demo/demo.py
+++ b/qualification/demo/demo.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2022-2024, National Research Foundation (SARAO)
+# Copyright (c) 2022-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -94,3 +94,21 @@ def test_xfail(pdf_report: Reporter) -> None:
     pdf_report.detail("Check that 1 == 2")
     with check:
         assert 1 == 2
+
+
+def test_numpy_fail(pdf_report: Reporter) -> None:
+    """Test saving of numpy arrays on test failure."""
+    pdf_report.step("Start the test")
+    pdf_report.detail("Check that arrays are equal")
+    arr1 = np.array([1, 2, 3])
+    arr2 = np.array([4, 5, 6])
+    np.testing.assert_equal(arr1, arr2)
+
+
+def test_numpy_fail_approx(pdf_report: Reporter) -> None:
+    """Test saving of numpy arrays on test failure with pytest.approx."""
+    pdf_report.step("Start the test")
+    pdf_report.detail("Check that arrays are equal")
+    arr1 = np.array([1, 2, 3])
+    arr2 = np.array([4, 5, 6])
+    np.testing.assert_equal(arr1, pytest.approx(arr2))

--- a/qualification/pytest-jenkins-karoo.ini
+++ b/qualification/pytest-jenkins-karoo.ini
@@ -15,6 +15,8 @@ log_cli = true
 log_cli_level = info
 log_cli_format = %(asctime)s.%(msecs)03d  %(levelname)-8s %(name)s:%(filename)s:%(lineno)d %(message)s
 addopts = --report-log=report.json
+array_dir = arrays
+
 default_antennas = 32
 max_antennas = 80
 wideband_channels = 1024 4096 8192 32768

--- a/qualification/pytest-jenkins-lab.ini
+++ b/qualification/pytest-jenkins-lab.ini
@@ -15,6 +15,8 @@ log_cli = true
 log_cli_level = info
 log_cli_format = %(asctime)s.%(msecs)03d  %(levelname)-8s %(name)s:%(filename)s:%(lineno)d %(message)s
 addopts = --report-log=report.json
+array_dir = arrays
+
 default_antennas = 8
 max_antennas = 16
 wideband_channels = 1024 4096 8192 32768

--- a/qualification/reporter.py
+++ b/qualification/reporter.py
@@ -14,7 +14,13 @@
 # limitations under the License.
 ################################################################################
 
-"""Mechanism for logging Pytest's output to a PDF."""
+"""Mechanism for logging Pytest's output to a PDF.
+
+The immediate output is not actually a PDF. Instead, custom JSON-compatible
+data structures are stored in the log output. These are post-processed by
+:file:`report/generate_pdf.py` to produce a PDF.
+"""
+
 import base64
 import io
 import logging

--- a/qualification/tied_array_channelised_voltage/test_delay.py
+++ b/qualification/tied_array_channelised_voltage/test_delay.py
@@ -114,9 +114,9 @@ async def test_delay_small(
         # Need more precision to avoid overflows when subtracting
         data = data.astype(np.int16)
         max_error = np.max(np.abs(data[delay_beam] - data[ref_beam]))
-        with check:
-            assert max_error <= 3
         pdf_report.detail(f"Maximum difference is {max_error} ULP")
+        with check:
+            np.testing.assert_allclose(data[delay_beam], data[ref_beam], rtol=0, atol=3)
 
 
 @pytest.mark.requirements("CBF-REQ-0220")


### PR DESCRIPTION
<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report: see https://jenkins.cbf.mkat.karoo.kat.ac.za/job/qualification_katgpucbf_lab/31/ (including the download of failed arrays) - this is from a test branch which deliberately induces failures. https://jenkins.cbf.mkat.karoo.kat.ac.za/job/qualification_katgpucbf_lab/32/ is from this branch.
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Will help debug NGC-1600.
