### PR TITLE
xbgpu: remove warning re data arriving too fast

### DIFF
--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -956,20 +956,6 @@ class XPipeline(Pipeline[XOutput, XOutQueueItem]):
                     item.timestamp - old_timestamp,
                     time_difference_between_heaps_s,
                 )
-
-                # NOTE: As the output packets are rate limited in
-                # such a way to match the dump rate, receiving data too quickly
-                # will result in data bottlenecking at the sender, the pipeline
-                # eventually stalling and the input buffer overflowing.
-                if time_difference_between_heaps_s * 1.05 < self.dump_interval_s:
-                    logger.warning(
-                        "Time between output heaps: %.2f which is less the expected %.2f. "
-                        "If this warning occurs too often, the pipeline will stall "
-                        "because the rate limited sender will not keep up with the input rate.",
-                        time_difference_between_heaps_s,
-                        self.dump_interval_s,
-                    )
-
                 old_time_s = new_time_s
                 old_timestamp = item.timestamp
 


### PR DESCRIPTION
These warnings were being spuriously issued in narrowband. I believe that's due to the chunks being fairly sizable in time and causing delivery to sender_loop to be uneven. At this stage I don't think the warning has ever really been useful.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
