### PR TITLE
Disable mirror_sensors when creating subarray products

### DIFF
--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -396,8 +396,8 @@ async def _cbf_config_and_description(
     # shutdown_delay is set to zero to speed up the test. We don't care
     # that Prometheus might not get to scrape the final metric updates.
     config: dict = {
-        "version": "4.5",
-        "config": {"shutdown_delay": 0.0},
+        "version": "4.6",
+        "config": {"shutdown_delay": 0.0, "mirror_sensors": False},
         "inputs": {},
         "outputs": {},
     }

--- a/scratch/sim_correlator.py
+++ b/scratch/sim_correlator.py
@@ -212,8 +212,8 @@ def generate_sdp(args: argparse.Namespace, outputs: dict) -> None:
 def generate_config(args: argparse.Namespace) -> dict:
     """Produce the configuration dict from the parsed command-line arguments."""
     config: dict = {
-        "version": "4.5",
-        "config": {},
+        "version": "4.6",
+        "config": {"mirror_sensors": False},
         "inputs": {},
         "outputs": {},
     }


### PR DESCRIPTION
<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] Deploy the master controller change on lab and site systems
- [x] If qualification tests are changed: attach a sample qualification report: https://jenkins.cbf.kat.ac.za/job/qualification_katgpucbf_lab/56/
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1660.
