### PR TITLE
Explicitly set a data_timeout for qualification tests

### DIFF
--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -395,9 +395,15 @@ async def _cbf_config_and_description(
 ) -> tuple[dict, dict]:
     # shutdown_delay is set to zero to speed up the test. We don't care
     # that Prometheus might not get to scrape the final metric updates.
+    # Using data_timeout ensures that any major issues with the network
+    # fail early rather than during a test.
     config: dict = {
         "version": "4.6",
-        "config": {"shutdown_delay": 0.0, "mirror_sensors": False},
+        "config": {
+            "shutdown_delay": 0.0,
+            "develop": {"data_timeout": 30.0},
+            "mirror_sensors": False,
+        },
         "inputs": {},
         "outputs": {},
     }


### PR DESCRIPTION
See NGC-1676 and https://github.com/ska-sa/katsdpcontroller/pull/805

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [ ] If qualification tests are changed: attach a sample qualification report: https://jenkins.cbf.kat.ac.za/job/qualification_katgpucbf_lab/60/console
- [x] If design has changed: ensure documentation is up to date: have updated product-configure schema to indicate that 0 is now the default
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match