### PR TITLE
Reduce karoo qualification run time

### DIFF
--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -44,7 +44,7 @@ from .recv import DEFAULT_TIMEOUT, BaselineCorrelationProductsReceiver, TiedArra
 from .reporter import Reporter, custom_report_log
 
 logger = logging.getLogger(__name__)
-FULL_ANTENNAS = [4, 8, 20, 32, 40, 64, 80]
+FULL_ANTENNAS = [1, 4, 8, 20, 32, 40, 64, 80]
 MAX_PASS_FRACTION = 0.7  # Maximum fraction of total narrowband bandwidth to use as pass_bandwidth
 pdf_report_data_key = pytest.StashKey[dict]()
 _CAPTURE_TYPES = {"gpucbf.baseline_correlation_products", "gpucbf.tied_array_channelised_voltage"}
@@ -167,11 +167,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
         metafunc.parametrize("n_antennas", values)
     if "band" in metafunc.fixturenames:
         metafunc.parametrize("band", metafunc.config.getini("bands"))
-    if (
-        "n_channels" in metafunc.fixturenames
-        or "narrowband_decimation" in metafunc.fixturenames
-        or "vlbi_decimation" in metafunc.fixturenames
-    ):
+    if "n_channels" in metafunc.fixturenames or "narrowband_decimation" in metafunc.fixturenames:
         # NOTE: Each config tuple is in the format (n_channels, decimation, vlbi_mode).
         # The VLBI mode configs are constructed separately as it does not use the same
         # decimation factors as 'normal' narrowband.

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -44,7 +44,7 @@ from .recv import DEFAULT_TIMEOUT, BaselineCorrelationProductsReceiver, TiedArra
 from .reporter import Reporter, custom_report_log
 
 logger = logging.getLogger(__name__)
-FULL_ANTENNAS = [1, 4, 8, 16, 20, 32, 40, 64, 80]
+FULL_ANTENNAS = [4, 8, 20, 32, 40, 64, 80]
 MAX_PASS_FRACTION = 0.7  # Maximum fraction of total narrowband bandwidth to use as pass_bandwidth
 pdf_report_data_key = pytest.StashKey[dict]()
 _CAPTURE_TYPES = {"gpucbf.baseline_correlation_products", "gpucbf.tied_array_channelised_voltage"}

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -44,7 +44,7 @@ from .recv import DEFAULT_TIMEOUT, BaselineCorrelationProductsReceiver, TiedArra
 from .reporter import Reporter, custom_report_log
 
 logger = logging.getLogger(__name__)
-FULL_ANTENNAS = [1, 4, 8, 10, 16, 20, 32, 40, 55, 64, 65, 80]
+FULL_ANTENNAS = [1, 4, 8, 16, 20, 32, 40, 64, 80]
 MAX_PASS_FRACTION = 0.7  # Maximum fraction of total narrowband bandwidth to use as pass_bandwidth
 pdf_report_data_key = pytest.StashKey[dict]()
 _CAPTURE_TYPES = {"gpucbf.baseline_correlation_products", "gpucbf.tied_array_channelised_voltage"}

--- a/qualification/pytest-jenkins-karoo.ini
+++ b/qualification/pytest-jenkins-karoo.ini
@@ -22,4 +22,5 @@ max_antennas = 80
 wideband_channels = 1024 4096 8192 32768
 narrowband_channels = 32768
 narrowband_decimation = 8 16
+vlbi_decimation = 8
 bands = u l s0

--- a/qualification/pytest-jenkins-lab.ini
+++ b/qualification/pytest-jenkins-lab.ini
@@ -22,4 +22,5 @@ max_antennas = 16
 wideband_channels = 1024 4096 8192 32768
 narrowband_channels = 32768
 narrowband_decimation = 8 16
+vlbi_decimation = 8
 bands = u l s0


### PR DESCRIPTION
This PR trims the `FULL_ANTENNAS` parameter list in qualification/conftest.py and introduces a new 
pytest.ini config option for limiting the decimation values used for VLBI-specific tests.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report: https://jenkins.cbf.kat.ac.za/job/qualification_katgpucbf_karoo/177/
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1671.
