### PR TITLE
Update vlbi_decimation list in karoo and lab

### DIFF
--- a/qualification/pytest-jenkins-karoo.ini
+++ b/qualification/pytest-jenkins-karoo.ini
@@ -22,5 +22,5 @@ max_antennas = 80
 wideband_channels = 1024 4096 8192 32768
 narrowband_channels = 32768
 narrowband_decimation = 8 16
-vlbi_decimation = 8
+vlbi_decimation = 4 8
 bands = u l s0

--- a/qualification/pytest-jenkins-lab.ini
+++ b/qualification/pytest-jenkins-lab.ini
@@ -22,5 +22,5 @@ max_antennas = 16
 wideband_channels = 1024 4096 8192 32768
 narrowband_channels = 32768
 narrowband_decimation = 8 16
-vlbi_decimation = 8
+vlbi_decimation = 4 8
 bands = u l s0


### PR DESCRIPTION
Specifically, to test 214MHz mode for VLBI. A qualification report isn't attached as we
want this to run tonight.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [ ] If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [x] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Contributes to: NGC-1698.
