### PR TITLE
Update fgpu to accommodate CUDA 12.9 cuFFT change

### DIFF
--- a/src/katgpucbf/fgpu/compute.py
+++ b/src/katgpucbf/fgpu/compute.py
@@ -243,7 +243,6 @@ class Compute(accel.OperationSequence):
             "phase": ["postproc:phase"],
             "gains": ["postproc:gains"],
         }
-
         aliases = {}
         if template.ddc is None:
             compounds["in"] = ["pfb_fir:in"]


### PR DESCRIPTION
This was discovered during work for NGC-1682 in supporting the latest Blackwell NVIDIA GPUs (RTX 5070).
- https://docs.nvidia.com/cuda/archive/12.9.0/cuda-toolkit-release-notes/index.html#cufft-release-12-9

This is the result of a CUDA library version update and **not** a [pycuda](https://pypi.org/project/pycuda/) update.

This must be merged alongside https://github.com/ska-sa/katsdpsigproc/pull/115

I have tested on the latest CUDA (12.9) and on an older CUDA (12.5) and both work without major complaint.
- Specifically running `test/fgpu/test_engine.py` on different machines accordingly.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Contributes to: NGC-1682.
