### PR TITLE
Bump katsdpsigproc to v1.9.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
             'aiomonitor==0.7.1',
             'asyncssh==2.19.0',
             'dask==2025.3.0',
-            'katsdpsigproc==1.8.1',
+            'katsdpsigproc==1.9.0',
             'katsdptelstate==0.14',
             'matplotlib==3.10.0',
             'numpy==2.0.2',

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -142,7 +142,7 @@ katsdpservices==1.4
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   katgpucbf (setup.cfg)
-katsdpsigproc==1.8.1
+katsdpsigproc==1.9.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -139,7 +139,7 @@ katsdpservices==1.4
     # via
     #   -c requirements.txt
     #   katgpucbf (setup.cfg)
-katsdpsigproc==1.8.1
+katsdpsigproc==1.9.0
     # via
     #   -c requirements.txt
     #   katgpucbf (setup.cfg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ katcp-codec==0.1.0
     # via aiokatcp
 katsdpservices==1.4
     # via katgpucbf (setup.cfg)
-katsdpsigproc==1.8.1
+katsdpsigproc==1.9.0
     # via katgpucbf (setup.cfg)
 katsdptelstate==0.14
     # via katgpucbf (setup.cfg)

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ install_requires =
     aiokatcp>=1.9.0
     dask
     katsdpservices[aiomonitor]
-    katsdpsigproc>=1.8.0
+    katsdpsigproc>=1.9.0
     katsdptelstate
     numba
     numpy


### PR DESCRIPTION
To make use of the CUDA 12.9 cuFFT workaround in #947.

I've also just realised this version bump should have been part of the previous PR. My apologies.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
