### PR TITLE
Bump requests to 2.32.4

### DIFF
--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -327,7 +327,7 @@ redis==5.2.1
     #   katsdptelstate
 regex==2024.11.6
     # via dateparser
-requests==2.32.3
+requests==2.32.4
     # via
     #   -c qualification/../requirements-dev.txt
     #   httmock

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -322,7 +322,7 @@ redis==5.2.1
     # via
     #   -c requirements.txt
     #   katsdptelstate
-requests==2.32.3
+requests==2.32.4
     # via sphinx
 scipy==1.15.1
     # via


### PR DESCRIPTION
To keep dependabot happy. The actual CVE that is fixed (CVE-2024-35195) is a corner case that's unlikely to affect us.
