### PR TITLE
Tweak xbgpu benchmarks to use random input data 

### DIFF
--- a/scratch/xbgpu/benchmarks/beamform_bench.py
+++ b/scratch/xbgpu/benchmarks/beamform_bench.py
@@ -79,7 +79,7 @@ def main():
     h_data = buf.empty_like()
     assert h_data.dtype == np.int8
     rng = np.random.default_rng(seed=1)
-    h_data = rng.integers(-128, 127, size=h_data.shape, dtype=h_data.dtype)
+    h_data[:] = rng.integers(-128, 127, size=h_data.shape, dtype=h_data.dtype)
     fn.buffer("in").set(command_queue, h_data)
     fn.buffer("saturated").zero(command_queue)
 

--- a/scratch/xbgpu/benchmarks/beamform_bench.py
+++ b/scratch/xbgpu/benchmarks/beamform_bench.py
@@ -19,6 +19,7 @@
 import argparse
 
 import katsdpsigproc.accel
+import numpy as np
 
 from katgpucbf import DEFAULT_JONES_PER_BATCH
 from katgpucbf.utils import DitherType, parse_dither
@@ -73,7 +74,13 @@ def main():
     h_weights.fill(1)
     fn.buffer("weights").set(command_queue, h_weights)
     fn.buffer("delays").zero(command_queue)
-    fn.buffer("in").zero(command_queue)
+
+    buf = fn.buffer("in")
+    h_data = buf.empty_like()
+    assert h_data.dtype == np.int8
+    rng = np.random.default_rng(seed=1)
+    h_data = rng.integers(-128, 127, size=h_data.shape, dtype=h_data.dtype)
+    fn.buffer("in").set(command_queue, h_data)
     fn.buffer("saturated").zero(command_queue)
 
     fn()  # Warmup pass

--- a/scratch/xbgpu/benchmarks/correlate_bench.py
+++ b/scratch/xbgpu/benchmarks/correlate_bench.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 ################################################################################
-# Copyright (c) 2024, National Research Foundation (SARAO)
+# Copyright (c) 2024-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/scratch/xbgpu/benchmarks/correlate_bench.py
+++ b/scratch/xbgpu/benchmarks/correlate_bench.py
@@ -57,7 +57,7 @@ def main():
     h_data = buf.empty_like()
     assert h_data.dtype == np.int8
     rng = np.random.default_rng(seed=1)
-    h_data = rng.integers(-128, 127, size=h_data.shape, dtype=h_data.dtype)
+    h_data[:] = rng.integers(-128, 127, size=h_data.shape, dtype=h_data.dtype)
     fn.buffer("in_samples").set(command_queue, h_data)
     fn.zero_visibilities()
 


### PR DESCRIPTION
Taking inspiration from the fgpu's `compute_bench.py`.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Contributes to: NGC-1682.