### PR TITLE
Remove a comment that got left behind

### DIFF
--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -346,7 +346,6 @@ async def _test_delay_phase_fixed(
     """
     receiver = receive_baseline_correlation_products
     pcc = cbf.product_controller_client
-    # Minimum, maximum, resolution step, and a small coarse delay
     n_dsims = len(cbf.dsim_names)
     assert N_POLS * n_dsims > len(delay_phases)  # > rather than >= because we need a reference
 


### PR DESCRIPTION
I think an array of test values was moved out to another function (with a copy of the comment), but the comment didn't get deleted.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match