### PR TITLE
Bump aiohttp to latest

### DIFF
--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -9,12 +9,12 @@ aioconsole==0.8.1
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   aiomonitor
-aiohappyeyeballs==2.4.4
+aiohappyeyeballs==2.6.1
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   aiohttp
-aiohttp==3.11.11
+aiohttp==3.12.14
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
@@ -30,7 +30,7 @@ aiomonitor==0.7.1
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   katsdpservices
-aiosignal==1.3.2
+aiosignal==1.4.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
@@ -376,6 +376,7 @@ typing-extensions==4.12.2
     #   -c qualification/../requirements.txt
     #   aiokatcp
     #   aiomonitor
+    #   aiosignal
     #   katsdpsigproc
 tzdata==2024.2
     # via

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,11 +8,11 @@ aioconsole==0.8.1
     # via
     #   -c requirements.txt
     #   aiomonitor
-aiohappyeyeballs==2.4.4
+aiohappyeyeballs==2.6.1
     # via
     #   -c requirements.txt
     #   aiohttp
-aiohttp==3.11.11
+aiohttp==3.12.14
     # via
     #   -c requirements.txt
     #   aiomonitor
@@ -25,7 +25,7 @@ aiomonitor==0.7.1
     # via
     #   -c requirements.txt
     #   katsdpservices
-aiosignal==1.3.2
+aiosignal==1.4.0
     # via
     #   -c requirements.txt
     #   aiohttp
@@ -399,6 +399,7 @@ typing-extensions==4.12.2
     #   -c requirements.txt
     #   aiokatcp
     #   aiomonitor
+    #   aiosignal
     #   katsdpsigproc
     #   pytools
 tzdata==2024.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,9 @@
 #
 aioconsole==0.8.1
     # via aiomonitor
-aiohappyeyeballs==2.4.4
+aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.11.11
+aiohttp==3.12.14
     # via
     #   aiomonitor
     #   prometheus-async
@@ -16,7 +16,7 @@ aiokatcp==2.0.2
     # via katgpucbf (setup.cfg)
 aiomonitor==0.7.1
     # via katsdpservices
-aiosignal==1.3.2
+aiosignal==1.4.0
     # via aiohttp
 appdirs==1.4.4
     # via katsdpsigproc
@@ -166,6 +166,7 @@ typing-extensions==4.12.2
     # via
     #   aiokatcp
     #   aiomonitor
+    #   aiosignal
     #   katsdpsigproc
     #   pytools
 tzdata==2024.2

--- a/scratch/benchmarks/requirements.txt
+++ b/scratch/benchmarks/requirements.txt
@@ -4,19 +4,19 @@
 #
 #    pip-compile --output-file=scratch/benchmarks/requirements.txt --strip-extras scratch/benchmarks/requirements.in
 #
-aiohappyeyeballs==2.4.4
+aiohappyeyeballs==2.6.1
     # via
     #   -c scratch/benchmarks/../../qualification/requirements.txt
     #   -c scratch/benchmarks/../../requirements-dev.txt
     #   -c scratch/benchmarks/../../requirements.txt
     #   aiohttp
-aiohttp==3.11.11
+aiohttp==3.12.14
     # via
     #   -c scratch/benchmarks/../../qualification/requirements.txt
     #   -c scratch/benchmarks/../../requirements-dev.txt
     #   -c scratch/benchmarks/../../requirements.txt
     #   -r scratch/benchmarks/requirements.in
-aiosignal==1.3.2
+aiosignal==1.4.0
     # via
     #   -c scratch/benchmarks/../../qualification/requirements.txt
     #   -c scratch/benchmarks/../../requirements-dev.txt
@@ -130,6 +130,7 @@ typing-extensions==4.12.2
     #   -c scratch/benchmarks/../../qualification/requirements.txt
     #   -c scratch/benchmarks/../../requirements-dev.txt
     #   -c scratch/benchmarks/../../requirements.txt
+    #   aiosignal
     #   asyncssh
 tzdata==2024.2
     # via


### PR DESCRIPTION
This is to keep dependabot happy.

Some dependencies also had to be bumped to satisfy lower bounds.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `setup.cfg` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] (n/a) Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
