### PR TITLE
Speed up dsim zeroing

### DIFF
--- a/doc/dsim.rst
+++ b/doc/dsim.rst
@@ -215,3 +215,8 @@ new signal is computed asynchronously into a spare second window. Once that's
 completed, the spare and active windows are swapped. The new spare window may
 still be referenced by in-flight heaps, so it is necessary to await
 transmission of those heaps before allowing the signal to be changed again.
+
+The qualification test framework resets state between tests by setting the
+dsim signal to all zeros. To speed this up, a third window is reserved for
+this purpose, which is pre-filled with zeros. Setting the signal to
+all-zeros thus needs only to switch windows, but not to compute new values.

--- a/src/katgpucbf/dsim/main.py
+++ b/src/katgpucbf/dsim/main.py
@@ -165,6 +165,7 @@ async def _async_main(tg: asyncio.TaskGroup) -> None:
         await prometheus_async.aio.web.start_http_server(port=args.prometheus_port)
 
     timestamps = np.zeros(args.max_period // args.heap_samples, dtype=">u8")
+    # One being currently sent, one spare, and one reserved for zeros
     heap_sets = [
         send.HeapSet.create(
             timestamps,
@@ -172,7 +173,7 @@ async def _async_main(tg: asyncio.TaskGroup) -> None:
             heap_size,
             range(args.first_id, args.first_id + len(args.dest)),
         )
-        for _ in range(2)
+        for _ in range(3)
     ]
 
     endpoints: list[tuple[str, int]] = []
@@ -230,7 +231,7 @@ async def _async_main(tg: asyncio.TaskGroup) -> None:
     server = DeviceServer(
         sender=sender,
         descriptor_sender=descriptor_sender,
-        spare=heap_sets[1],
+        heap_sets=heap_sets,
         adc_sample_rate=args.adc_sample_rate,
         dither_seed=args.dither_seed,
         sample_bits=args.sample_bits,

--- a/src/katgpucbf/dsim/main.py
+++ b/src/katgpucbf/dsim/main.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2021-2024, National Research Foundation (SARAO)
+# Copyright (c) 2021-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katgpucbf/dsim/send.py
+++ b/src/katgpucbf/dsim/send.py
@@ -45,7 +45,7 @@ class HeapSet:
     The heaps are split into two parts, each of which is preprocessed to
     allow efficient transmission.
 
-    This class should normally be constructed with :meth:`factory`.
+    This class should normally be constructed with :meth:`create`.
 
     Parameters
     ----------

--- a/src/katgpucbf/dsim/send.py
+++ b/src/katgpucbf/dsim/send.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2021-2024, National Research Foundation (SARAO)
+# Copyright (c) 2021-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katgpucbf/dsim/server.py
+++ b/src/katgpucbf/dsim/server.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2021-2024, National Research Foundation (SARAO)
+# Copyright (c) 2021-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katgpucbf/dsim/server.py
+++ b/src/katgpucbf/dsim/server.py
@@ -31,7 +31,7 @@ from ..send import DescriptorSender
 from ..spead import DIGITISER_STATUS_SATURATION_COUNT_SHIFT, DIGITISER_STATUS_SATURATION_FLAG_BIT
 from .send import HeapSet, Sender
 from .shared_array import SharedArray
-from .signal import Signal, SignalService, TerminalError, format_signals, parse_signals
+from .signal import Constant, Signal, SignalService, TerminalError, format_signals, parse_signals
 
 logger = logging.getLogger(__name__)
 
@@ -43,8 +43,9 @@ class DeviceServer(aiokatcp.DeviceServer):
     ----------
     sender
         Sender which is streaming data out. It is halted when the server is stopped.
-    spare
-        Heap set which is not currently being used, but is available to swap in
+    heap_sets
+        Heap sets which can be transmitted (must have length 3). The first element
+        must be currently set on `sender.`
     adc_sample_rate
         Sampling rate in Hz
     sample_bits
@@ -64,7 +65,7 @@ class DeviceServer(aiokatcp.DeviceServer):
         self,
         sender: Sender,
         descriptor_sender: DescriptorSender,
-        spare: HeapSet,
+        heap_sets: list[HeapSet],
         adc_sample_rate: float,
         sample_bits: int,
         dither_seed: int,
@@ -74,7 +75,8 @@ class DeviceServer(aiokatcp.DeviceServer):
         super().__init__(*args, **kwargs)
         self.sender = sender
         self.descriptor_sender = descriptor_sender
-        self.spare = spare
+        assert len(heap_sets) == 3
+        self.heap_sets = heap_sets
         self.adc_sample_rate = adc_sample_rate
         self.sample_bits = sample_bits
         # Scratch space for computing saturation counts. It is passed to
@@ -86,9 +88,10 @@ class DeviceServer(aiokatcp.DeviceServer):
             shared_saturated.buffer, dims=["pol", "time"], attrs={"shared_array": shared_saturated}
         )
         self._signals_lock = asyncio.Lock()  # Serialises request_signals
-        heap_sets = [sender.heap_set, spare]
+        # First two are for dynamic signals, while the 3rd is reserved for
+        # sending zeros.
         self._signal_service = SignalService(
-            [heap_set.data["payload"] for heap_set in heap_sets] + [self._saturated],
+            [heap_set.data["payload"] for heap_set in heap_sets[:2]] + [self._saturated],
             sample_bits,
             dither_seed,
         )
@@ -132,7 +135,7 @@ class DeviceServer(aiokatcp.DeviceServer):
                 "max-period",
                 "Maximum period that may be passed to ?signals",
                 initial_status=aiokatcp.Sensor.Status.NOMINAL,
-                default=spare.data["payload"].isel(pol=0).size * BYTE_BITS // sample_bits,
+                default=heap_sets[0].data["payload"].isel(pol=0).size * BYTE_BITS // sample_bits,
             )
         )
         self.sensors.add(
@@ -179,27 +182,36 @@ class DeviceServer(aiokatcp.DeviceServer):
         if period is None:
             period = self.sensors["max-period"].value
         async with self._signals_lock:
-            await self._signal_service.sample(
-                signals,
-                0,
-                period,
-                self.adc_sample_rate,
-                self.spare.data["payload"],
-                self._saturated,
-                self.sender.heap_samples,
-            )
-            # As per M1000-0001-053: bits [47:32] hold saturation count, while
-            # bit 1 holds a boolean flag.
-            # np.left_shift is << but xarray doesn't seem to implement the
-            # operator overload.
-            digitiser_status = np.left_shift(self._saturated, DIGITISER_STATUS_SATURATION_COUNT_SHIFT)
-            digitiser_status |= xr.where(
-                digitiser_status, np.uint64(1 << DIGITISER_STATUS_SATURATION_FLAG_BIT), np.uint64(0)
-            )
-            self.spare.data["digitiser_status"][:] = digitiser_status
-            spare = self.sender.heap_set
-            timestamp = await self.sender.set_heaps(self.spare)
-            self.spare = spare
+            if all(type(signal) is Constant and signal.value == 0.0 for signal in signals):
+                # We've been asked to generate just zeros. We have a heap set
+                # reserved for that.
+                target = self.heap_sets[2]
+            else:
+                # Find an unused heap set that is not the reserved-for-zeros one
+                if self.sender.heap_set is self.heap_sets[0]:
+                    target = self.heap_sets[1]
+                else:
+                    target = self.heap_sets[0]
+                await self._signal_service.sample(
+                    signals,
+                    0,
+                    period,
+                    self.adc_sample_rate,
+                    target.data["payload"],
+                    self._saturated,
+                    self.sender.heap_samples,
+                )
+                # As per M1000-0001-053: bits [47:32] hold saturation count, while
+                # bit 1 holds a boolean flag.
+                # np.left_shift is << but xarray doesn't seem to implement the
+                # operator overload.
+                digitiser_status = np.left_shift(self._saturated, DIGITISER_STATUS_SATURATION_COUNT_SHIFT)
+                digitiser_status |= xr.where(
+                    digitiser_status, np.uint64(1 << DIGITISER_STATUS_SATURATION_FLAG_BIT), np.uint64(0)
+                )
+                target.data["digitiser_status"][:] = digitiser_status
+
+            timestamp = await self.sender.set_heaps(target)
             self._signals_orig_sensor.value = signals_str
             self._signals_sensor.value = format_signals(signals)
             self._period_sensor.value = period
@@ -230,7 +242,7 @@ class DeviceServer(aiokatcp.DeviceServer):
             signals = parse_signals(signals_str)
         except (pp.ParseBaseException, TerminalError) as exc:
             raise aiokatcp.FailReply(str(exc)) from None
-        n_pol = self.spare.data.sizes["pol"]
+        n_pol = self.heap_sets[0].data.sizes["pol"]
         if len(signals) != n_pol:
             raise aiokatcp.FailReply(f"expected {n_pol} signals, received {len(signals)}")
         return await self.set_signals(signals, signals_str, period)

--- a/test/dsim/conftest.py
+++ b/test/dsim/conftest.py
@@ -90,15 +90,15 @@ def timestamps() -> np.ndarray:
 
 @pytest.fixture
 def heap_sets(timestamps: np.ndarray) -> Sequence[send.HeapSet]:
-    """Two instances of :class:`~katgpucbf.dsim.send.HeapSet` with random payload bytes."""
+    """Two instances of :class:`~katgpucbf.dsim.send.HeapSet` with random payload bytes and one with zeros."""
     heap_sets = [
         send.HeapSet.create(
             timestamps, [N_ENDPOINTS_PER_POL] * N_POLS, DIG_HEAP_SAMPLES * DIG_SAMPLE_BITS // BYTE_BITS, range(N_POLS)
         )
-        for _ in range(2)
+        for _ in range(3)
     ]
     rng = np.random.default_rng(1)
-    for heap_set in heap_sets:
+    for heap_set in heap_sets[:2]:
         heap_set.data["payload"][:] = rng.integers(0, 256, size=heap_set.data["payload"].shape, dtype=np.uint8)
     return heap_sets
 

--- a/test/dsim/test_server.py
+++ b/test/dsim/test_server.py
@@ -36,7 +36,7 @@ from .conftest import ADC_SAMPLE_RATE, SIGNAL_HEAPS
 
 @pytest.fixture
 async def katcp_server(
-    sender: Sender, heap_sets: Sequence[HeapSet], descriptor_sender: DescriptorSender
+    sender: Sender, heap_sets: list[HeapSet], descriptor_sender: DescriptorSender
 ) -> AsyncGenerator[DeviceServer, None]:
     """A :class:`~katgpucbf.dsim.server.DeviceServer`."""
     signals_str = "cw(0.2, 123); cw(0.3, 456);"
@@ -44,7 +44,7 @@ async def katcp_server(
     server = DeviceServer(
         sender=sender,
         descriptor_sender=descriptor_sender,
-        spare=heap_sets[1],
+        heap_sets=heap_sets,
         adc_sample_rate=ADC_SAMPLE_RATE,
         sample_bits=DIG_SAMPLE_BITS,
         dither_seed=dither_seed,

--- a/test/dsim/test_server.py
+++ b/test/dsim/test_server.py
@@ -121,6 +121,22 @@ async def test_signals(
     assert parse_signals(await katcp_client.sensor_value("signals", str)) == parse_signals(signals_str)
 
 
+async def test_signals_zero(
+    katcp_server: DeviceServer,
+    katcp_client: aiokatcp.Client,
+    sender: Sender,
+    heap_sets: Sequence[HeapSet],
+) -> None:
+    """Test the fast path for setting all signals to zero."""
+    signals_str = "0;0;"
+    await katcp_client.request("signals", signals_str)
+    assert sender.heap_set is heap_sets[2]
+    np.testing.assert_equal(sender.heap_set.data["payload"].data, 0)
+    np.testing.assert_equal(sender.heap_set.data["digitiser_status"].data, 0)
+    assert await katcp_client.sensor_value("signals-orig", str) == signals_str
+    assert parse_signals(await katcp_client.sensor_value("signals", str)) == parse_signals(signals_str)
+
+
 @pytest.mark.parametrize(
     "spec,match",
     [


### PR DESCRIPTION
Keep a pre-computed HeapSet with zeros, instead of constructing one freshly each time it is needed.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Contributes to NGC-1704.
