### PR TITLE
Fix stats collection for stream groups

### DIFF
--- a/src/katgpucbf/fgpu/recv.py
+++ b/src/katgpucbf/fgpu/recv.py
@@ -214,8 +214,7 @@ def make_stream_group(
         user_data=user_data,
         explicit_start=True,
     )
-    for stream in group:
-        stats_collector.add_stream(stream)
+    stats_collector.add_stream_group(group)
     return group
 
 


### PR DESCRIPTION
The way StatsCollector uses weak references was incompatible with ChunkStreamGroupMember: the latter is a thin Python wrapper that is created on the fly to wrap the real C++ class, and which immediately vanishes if the Python code doesn't hold a strong reference.

Fix it by using a proxy class that behaves like a weakref to a ChunkStreamGroupMember, but actually holds a weakref to the ChunkStreamRingGroup plus an index.

There is a unit test added as a basic sanity check, although it doesn't actually test this subtlety because can't easily be done with mocking. I've done a manual test (with a deliberately-broken dsim) to check that the fix is working.

Closes NGC-1468.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1468.
