### PR TITLE
Fix warning from Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,8 +168,8 @@ pipeline {
       }
       steps {
         script {
-          branch = env.BRANCH_NAME
-          tag = (branch == "main") ? "latest" : branch
+          String branch = env.BRANCH_NAME
+          String tag = (branch == "main") ? "latest" : branch
           // Supply credentials to Dockerhub so that we can reliably pull the base image
           docker.withRegistry("", "dockerhub") {
             dockerImage = docker.build(


### PR DESCRIPTION
It complains that the branch and tag variables are not scoped appropriately:
```
14:36:55  Did you forget the `def` keyword? WorkflowScript seems to be setting a field named branch (to a value of type String) which could lead to memory leaks or other issues.
14:36:55  Did you forget the `def` keyword? WorkflowScript seems to be setting a field named tag (to a value of type String) which could lead to memory leaks or other issues.
```

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x (n/a)] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
