### PR TITLE
Qualification: swap polarisations when building input_labels

### DIFF
--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -451,7 +451,7 @@ async def _cbf_config_and_description(
         "type": "gpucbf.antenna_channelised_voltage",
         "src_streams": [dig_names[i % len(dig_names)] for i in range(2 * n_antennas)],
         # m8xx is used to avoid possible confusion with real antennas
-        "input_labels": [f"m{800 + i}{pol}" for i in range(n_antennas) for pol in ["v", "h"]],
+        "input_labels": [f"m{800 + i}{pol}" for i in range(n_antennas) for pol in ["h", "v"]],
         "n_chans": n_channels,
     }
     if narrowband_decimation > 1:


### PR DESCRIPTION
This is needed to match a katsdpcontroller change to correct the dsim polarisation ordering in light of NGC-1016.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [ ] If qualification tests are changed: attach a sample qualification report: https://jenkins.cbf.kat.ac.za/job/qualification_katgpucbf_karoo/310/console
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match