### PR TITLE
Initial scaffolding for V-Engine

### DIFF
--- a/doc/katgpucbf.main.rst
+++ b/doc/katgpucbf.main.rst
@@ -1,0 +1,7 @@
+katgpucbf.main module
+=====================
+
+.. automodule:: katgpucbf.main
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/katgpucbf.rst
+++ b/doc/katgpucbf.rst
@@ -10,6 +10,7 @@ Subpackages
    katgpucbf.dsim
    katgpucbf.fgpu
    katgpucbf.fsim
+   katgpucbf.vgpu
    katgpucbf.xbgpu
 
 Submodules

--- a/doc/katgpucbf.rst
+++ b/doc/katgpucbf.rst
@@ -20,6 +20,7 @@ Submodules
 
    katgpucbf.configure_tools
    katgpucbf.curand_helpers
+   katgpucbf.main
    katgpucbf.mapped_array
    katgpucbf.meerkat
    katgpucbf.monitor

--- a/doc/katgpucbf.vgpu.engine.rst
+++ b/doc/katgpucbf.vgpu.engine.rst
@@ -1,0 +1,7 @@
+katgpucbf.vgpu.engine module
+============================
+
+.. automodule:: katgpucbf.vgpu.engine
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/katgpucbf.vgpu.main.rst
+++ b/doc/katgpucbf.vgpu.main.rst
@@ -1,0 +1,7 @@
+katgpucbf.vgpu.main module
+==========================
+
+.. automodule:: katgpucbf.vgpu.main
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/katgpucbf.vgpu.rst
+++ b/doc/katgpucbf.vgpu.rst
@@ -1,0 +1,19 @@
+katgpucbf.vgpu package
+======================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   katgpucbf.vgpu.engine
+   katgpucbf.vgpu.main
+
+Module contents
+---------------
+
+.. automodule:: katgpucbf.vgpu
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ copy-mk = [
 [project.scripts]
 fgpu = "katgpucbf.fgpu.main:main"
 xbgpu = "katgpucbf.xbgpu.main:main"
+vgpu = "katgpucbf.vgpu.main:main"
 dsim = "katgpucbf.dsim.main:main"
 fsim = "katgpucbf.fsim.main:main"
 

--- a/src/katgpucbf/dsim/main.py
+++ b/src/katgpucbf/dsim/main.py
@@ -33,8 +33,8 @@ import numpy as np
 import pyparsing as pp
 from katsdptelstate.endpoint import endpoint_list_parser
 
-from .. import BYTE_BITS, DEFAULT_KATCP_HOST, DEFAULT_KATCP_PORT, DEFAULT_TTL, SPEAD_DESCRIPTOR_INTERVAL_S
-from ..main import engine_main
+from .. import BYTE_BITS, DEFAULT_TTL, SPEAD_DESCRIPTOR_INTERVAL_S
+from ..main import add_common_arguments, engine_main
 from ..send import DescriptorSender
 from ..utils import TimeConverter
 from . import descriptors, send, signal
@@ -73,23 +73,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         "--max-period", type=int, help="Maximum supported period for pre-computed signals [same as --period]"
     )
     parser.add_argument("--dither-seed", type=int, help="Fixed seed for reproducible dithering [random]")
-    parser.add_argument(
-        "--katcp-host",
-        type=str,
-        default=DEFAULT_KATCP_HOST,
-        help="Hostname or IP on which to listen for KATCP C&M connections [all interfaces]",
-    )
-    parser.add_argument(
-        "--katcp-port",
-        type=int,
-        default=DEFAULT_KATCP_PORT,
-        help="Network port on which to listen for KATCP C&M connections [%(default)s]",
-    )
-    parser.add_argument(
-        "--prometheus-port",
-        type=int,
-        help="Network port on which to serve Prometheus metrics [none]",
-    )
+    add_common_arguments(parser)
     parser.add_argument(
         "dest",
         nargs="+",

--- a/src/katgpucbf/dsim/main.py
+++ b/src/katgpucbf/dsim/main.py
@@ -33,8 +33,8 @@ import numpy as np
 import pyparsing as pp
 from katsdptelstate.endpoint import endpoint_list_parser
 
-from .. import BYTE_BITS, DEFAULT_TTL, SPEAD_DESCRIPTOR_INTERVAL_S
-from ..main import add_common_arguments, engine_main
+from .. import BYTE_BITS, SPEAD_DESCRIPTOR_INTERVAL_S
+from ..main import add_common_arguments, add_send_arguments, engine_main
 from ..send import DescriptorSender
 from ..utils import TimeConverter
 from . import descriptors, send, signal
@@ -56,13 +56,10 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         "The specification must produce either a single signal, or one per output stream. [%(default)s]",
     )
     parser.add_argument("--sync-time", type=float, help="Sync time in UNIX epoch seconds (must be in the past)")
-    parser.add_argument("--interface", default="lo", help="Network interface on which to send packets [%(default)s]")
     parser.add_argument("--heap-samples", type=int, default=4096, help="Number of samples per heap [%(default)s]")
     parser.add_argument("--sample-bits", type=int, default=10, help="Number of bits per sample [%(default)s]")
     parser.add_argument("--first-id", type=int, default=0, help="Digitiser ID for first stream [%(default)s]")
-    parser.add_argument("--ttl", type=int, default=DEFAULT_TTL, help="IP TTL for multicast [%(default)s]")
-    parser.add_argument("--ibv", action="store_true", help="Use ibverbs for acceleration")
-    parser.add_argument("--affinity", type=int, default=-1, help="Core affinity for the sending thread [not bound]")
+    add_send_arguments(parser, prefix="")
     parser.add_argument(
         "--main-affinity", type=int, default=-1, help="Core affinity for the main Python thread [not bound]"
     )
@@ -176,6 +173,7 @@ async def start_engine(
         ttl=args.ttl,
         interface_address=interface_address,
         ibv=args.ibv,
+        comp_vector=args.comp_vector,
     )
     descriptor_stream.set_cnt_sequence(1, 2)
 
@@ -210,6 +208,7 @@ async def start_engine(
         interface_address=interface_address,
         ibv=args.ibv,
         affinity=args.affinity,
+        comp_vector=args.comp_vector,
     )
     # Set spead stream to have heap id in even numbers for dsim data.
     stream.set_cnt_sequence(2, 2)

--- a/src/katgpucbf/dsim/send.py
+++ b/src/katgpucbf/dsim/send.py
@@ -164,6 +164,7 @@ def make_stream_base(
     interface_address: str,
     ibv: bool = False,
     affinity: int = -1,
+    comp_vector: int = 0,
     memory_regions: list | None = None,
 ) -> "spead2.send.asyncio.AsyncStream":
     """Create a spead2 stream for sending.
@@ -178,6 +179,7 @@ def make_stream_base(
             endpoints=endpoints_list,
             interface_address=interface_address,
             ttl=ttl,
+            comp_vector=comp_vector,
         )
         if memory_regions is not None:
             ibv_config.memory_regions = memory_regions
@@ -203,6 +205,7 @@ def make_stream(
     interface_address: str,
     ibv: bool,
     affinity: int,
+    comp_vector: int,
 ) -> "spead2.send.asyncio.AsyncStream":
     """Create a spead2 stream for sending.
 
@@ -228,6 +231,8 @@ def make_stream(
         If true, use ibverbs for acceleration
     affinity
         If non-negative, bind the sending thread to this CPU core
+    comp_vector
+        Completion vector for ibverbs
     """
     preamble = 72  # SPEAD header, 4 standard item pointers, 4 application-specific item pointers
     heap_size = heap_samples * sample_bits // BYTE_BITS
@@ -244,6 +249,7 @@ def make_stream(
         interface_address=interface_address,
         ibv=ibv,
         affinity=affinity,
+        comp_vector=comp_vector,
         memory_regions=[heap_set.data["payload"].data for heap_set in heap_sets],
     )
 

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 ################################################################################
 
-"""Engine class, which combines all the processing steps for a single digitiser data stream."""
+"""FEngine class, which combines all the processing steps for a single digitiser data stream."""
 
 import asyncio
 import copy
@@ -521,7 +521,7 @@ class Pipeline:
         such as dig-rms-dbfs.
     """
 
-    def __init__(self, output: Output, engine: "Engine", context: AbstractContext, dig_stats: bool) -> None:
+    def __init__(self, output: Output, engine: "FEngine", context: AbstractContext, dig_stats: bool) -> None:
         assert isinstance(output, WidebandOutput) or not dig_stats, "wideband output required for digitiser stats"
         # Tuning knobs not exposed via arguments
         n_send = 4
@@ -1179,12 +1179,12 @@ class Pipeline:
         sensor.value = "[" + ", ".join(format_complex(gain) for gain in gains.tolist()) + "]"
 
 
-class Engine(aiokatcp.DeviceServer):
+class FEngine(aiokatcp.DeviceServer):
     """Top-level class running the whole thing.
 
     .. todo::
 
-      The :class:`Engine` needs to have more sensors and requests added to it,
+      The :class:`FEngine` needs to have more sensors and requests added to it,
       according to whatever the design is going to be. SKARAB didn't have katcp
       capability, that was all in corr2, so we need to figure out how to best
       control these engines. This docstring should also be updated to reflect
@@ -1197,7 +1197,7 @@ class Engine(aiokatcp.DeviceServer):
     katcp_port
         Network port on which to listen for KATCP C&M connections.
     context
-        The accelerator (CUDA) context to use for running the Engine.
+        The accelerator (CUDA) context to use for running the FEngine.
     vkgdr_handle
         Handle to vkgdr for the same device as `context`.
     srcs

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -45,7 +45,6 @@ from .. import (
     RECV_TASK_NAME,
     SEND_TASK_NAME,
     SPEAD_DESCRIPTOR_INTERVAL_S,
-    __version__,
 )
 from .. import recv as base_recv
 from ..mapped_array import MappedArray
@@ -55,12 +54,10 @@ from ..recv import RECV_SENSOR_TIMEOUT_CHUNKS, RECV_SENSOR_TIMEOUT_MIN
 from ..ringbuffer import ChunkRingbuffer
 from ..send import DescriptorSender
 from ..utils import (
-    DeviceStatusSensor,
+    Engine,
     TimeConverter,
-    add_time_sync_sensors,
     gaussian_dtype,
     make_rate_limited_sensor,
-    make_steady_state_timestamp_sensor,
 )
 from . import DIG_RMS_DBFS_HIGH, DIG_RMS_DBFS_LOW, DIG_RMS_DBFS_WINDOW, INPUT_CHUNK_PADDING, recv, send
 from .accum import Accum
@@ -1116,7 +1113,7 @@ class Pipeline:
                 self._chunk_send_and_cleanup(self._send_streams, n_batches, chunk),
                 name="Chunk Send and Cleanup Task",
             )
-            self.engine.add_service_task(task)
+            self.engine.add_service_task(task, wait_on_stop=True)
 
         if task:
             try:
@@ -1169,7 +1166,7 @@ class Pipeline:
         # self._out_item. If a less conservative answer is needed, one would
         # need to track a separate timestamp in the class that is updated
         # as gains are copied to the OutQueueItem.
-        self.engine._update_steady_state_timestamp(self._out_item.end_timestamp)
+        self.engine.update_steady_state_timestamp(self._out_item.end_timestamp)
         if np.all(gains == gains[0]):
             # All the values are the same, so it can be reported as a single value
             gains = gains[:1]
@@ -1179,16 +1176,8 @@ class Pipeline:
         sensor.value = "[" + ", ".join(format_complex(gain) for gain in gains.tolist()) + "]"
 
 
-class FEngine(aiokatcp.DeviceServer):
+class FEngine(Engine):
     """Top-level class running the whole thing.
-
-    .. todo::
-
-      The :class:`FEngine` needs to have more sensors and requests added to it,
-      according to whatever the design is going to be. SKARAB didn't have katcp
-      capability, that was all in corr2, so we need to figure out how to best
-      control these engines. This docstring should also be updated to reflect
-      its new nature as an inheritor of :class:`aiokatcp.DeviceServer`.
 
     Parameters
     ----------
@@ -1274,7 +1263,6 @@ class FEngine(aiokatcp.DeviceServer):
     # TODO: VERSION means interface version, rather than software version. It
     # will need to wait on a proper ICD for a release.
     VERSION = "katgpucbf-fgpu-icd-0.1"
-    BUILD_STATE = __version__
 
     def __init__(
         self,
@@ -1315,7 +1303,6 @@ class FEngine(aiokatcp.DeviceServer):
         monitor: Monitor,
     ) -> None:
         super().__init__(katcp_host, katcp_port)
-        self._cancel_tasks: list[asyncio.Task] = []  # Tasks that need to be cancelled on shutdown
         self._populate_sensors(
             self.sensors, max(RECV_SENSOR_TIMEOUT_MIN, RECV_SENSOR_TIMEOUT_CHUNKS * chunk_samples / adc_sample_rate)
         )
@@ -1446,12 +1433,6 @@ class FEngine(aiokatcp.DeviceServer):
 
         for sensor in recv.make_sensors(recv_sensor_timeout).values():
             sensors.add(sensor)
-        sensors.add(make_steady_state_timestamp_sensor())
-        sensors.add(DeviceStatusSensor(sensors))
-
-        time_sync_task = add_time_sync_sensors(sensors)
-        self.add_service_task(time_sync_task)
-        self._cancel_tasks.append(time_sync_task)
 
     def make_send_streams(
         self, output: Output, n_data_heaps: int, chunks: Sequence[send.Chunk]
@@ -1478,11 +1459,6 @@ class FEngine(aiokatcp.DeviceServer):
             chunks=chunks,
         )
 
-    def _update_steady_state_timestamp(self, timestamp: int) -> None:
-        """Update the ``steady-state-timestamp`` sensor to at least a given value."""
-        sensor = self.sensors["steady-state-timestamp"]
-        sensor.value = max(sensor.value, timestamp)
-
     def free_in_item(self, item: InQueueItem) -> None:
         """Return an InQueueItem to the free queue if its refcount hits zero."""
         item.refcount -= 1
@@ -1497,7 +1473,7 @@ class FEngine(aiokatcp.DeviceServer):
                     self._push_recv_chunks([chunk], item.events),
                     name="Receive Chunk Recycle Task",
                 )
-                self.add_service_task(task)
+                self.add_service_task(task, wait_on_stop=True)
             self._in_free_queue.put_nowait(item)
 
     @staticmethod
@@ -1765,7 +1741,7 @@ class FEngine(aiokatcp.DeviceServer):
 
         for delay_model, new_linear_model in zip(pipeline.delay_models, new_linear_models, strict=True):
             delay_model.base.add(new_linear_model)
-        self._update_steady_state_timestamp(pipeline.delay_update_timestamp())
+        self.update_steady_state_timestamp(pipeline.delay_update_timestamp())
 
     async def start(self, descriptor_interval_s: float = SPEAD_DESCRIPTOR_INTERVAL_S) -> None:
         """Start the engine.
@@ -1795,8 +1771,7 @@ class FEngine(aiokatcp.DeviceServer):
             descriptor_task = asyncio.create_task(
                 descriptor_sender.run(), name=f"{pipeline.output.name}.{DESCRIPTOR_TASK_NAME}"
             )
-            self.add_service_task(descriptor_task)
-            self._cancel_tasks.append(descriptor_task)
+            self.add_service_task(descriptor_task, wait_on_stop=False)
 
         recv_comp_vector_iter = iter(self._recv_comp_vector)
         if self._recv_interface is None:
@@ -1822,20 +1797,20 @@ class FEngine(aiokatcp.DeviceServer):
             self._run_receive(self._recv_group, self.recv_layout),
             name=RECV_TASK_NAME,
         )
-        self.add_service_task(recv_task)
+        self.add_service_task(recv_task, wait_on_stop=True)
 
         for pipeline in self._pipelines:
             proc_task = asyncio.create_task(
                 pipeline.run_processing(),
                 name=f"{pipeline.output.name}.{GPU_PROC_TASK_NAME}",
             )
-            self.add_service_task(proc_task)
+            self.add_service_task(proc_task, wait_on_stop=True)
 
             send_task = asyncio.create_task(
                 pipeline.run_transmit(),
                 name=f"{pipeline.output.name}.{SEND_TASK_NAME}",
             )
-            self.add_service_task(send_task)
+            self.add_service_task(send_task, wait_on_stop=True)
 
         await super().start()
 
@@ -1846,14 +1821,6 @@ class FEngine(aiokatcp.DeviceServer):
         Also handle any Exceptions thrown unexpectedly in any of the
         processing loops.
         """
-        for task in self._cancel_tasks:
-            task.cancel()
         self._recv_group.stop()
-        # If any of the tasks are already done then we had an exception, and
-        # waiting for the rest may hang as the shutdown path won't proceed
-        # neatly.
-        if not any(task.done() for task in self.service_tasks):
-            for task in self.service_tasks:
-                if task not in self._cancel_tasks:
-                    await task
+        await super().on_stop()  # Waits for service tasks to complete
         self._pipelines.clear()  # Breaks circular references

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -41,11 +41,19 @@ from .. import (
     DEFAULT_TTL,
     DIG_SAMPLE_BITS,
 )
-from ..main import add_common_arguments, add_recv_arguments, engine_main
+from ..main import (
+    add_common_arguments,
+    add_recv_arguments,
+    comma_split,
+    engine_main,
+    parse_dither,
+    parse_enum,
+    parse_source,
+)
 from ..mapped_array import make_vkgdr
 from ..monitor import FileMonitor, Monitor, NullMonitor
 from ..spead import DEFAULT_PORT
-from ..utils import DitherType, comma_split, parse_dither, parse_enum, parse_source
+from ..utils import DitherType
 from . import DIG_SAMPLE_BITS_VALID
 from .engine import FEngine
 from .output import NarrowbandOutput, NarrowbandOutputDiscard, NarrowbandOutputNoDiscard, WidebandOutput, WindowFunction

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -32,20 +32,16 @@ from typing import TypedDict
 import katsdpsigproc.accel as accel
 import vkgdr
 from katsdpservices import get_interface_address
-from katsdpservices.aiomonitor import add_aiomonitor_arguments
 from katsdpsigproc.abc import AbstractContext
 from katsdptelstate.endpoint import Endpoint, endpoint_list_parser
 
 from .. import (
     DEFAULT_JONES_PER_BATCH,
-    DEFAULT_KATCP_HOST,
-    DEFAULT_KATCP_PORT,
     DEFAULT_PACKET_PAYLOAD_BYTES,
     DEFAULT_TTL,
     DIG_SAMPLE_BITS,
-    __version__,
 )
-from ..main import engine_main
+from ..main import add_common_arguments, engine_main
 from ..mapped_array import make_vkgdr
 from ..monitor import FileMonitor, Monitor, NullMonitor
 from ..spead import DEFAULT_PORT
@@ -260,24 +256,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
             "window_function [hann], dither [uniform]"
         ),
     )
-    parser.add_argument(
-        "--katcp-host",
-        type=str,
-        default=DEFAULT_KATCP_HOST,
-        help="Hostname or IP on which to listen for KATCP C&M connections [all interfaces]",
-    )
-    parser.add_argument(
-        "--katcp-port",
-        type=int,
-        default=DEFAULT_KATCP_PORT,
-        help="Network port on which to listen for KATCP C&M connections [%(default)s]",
-    )
-    parser.add_argument(
-        "--prometheus-port",
-        type=int,
-        help="Network port on which to serve Prometheus metrics [none]",
-    )
-    add_aiomonitor_arguments(parser)
+    add_common_arguments(parser)
     parser.add_argument(
         "--recv-interface",
         type=comma_split(get_interface_address),
@@ -433,7 +412,6 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         "--use-peerdirect", action="store_true", help="Send chunks directly from GPU memory (requires supported GPU)"
     )
     parser.add_argument("--monitor-log", help="File to write performance-monitoring data to")
-    parser.add_argument("--version", action="version", version=__version__)
     parser.add_argument("src", type=parse_source, help="Source endpoints (or pcap file)")
     args = parser.parse_args(arglist)
 

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -31,20 +31,18 @@ from typing import TypedDict
 
 import katsdpsigproc.accel as accel
 import vkgdr
-from katsdpservices import get_interface_address
 from katsdpsigproc.abc import AbstractContext
 from katsdptelstate.endpoint import Endpoint, endpoint_list_parser
 
 from .. import (
     DEFAULT_JONES_PER_BATCH,
     DEFAULT_PACKET_PAYLOAD_BYTES,
-    DEFAULT_TTL,
     DIG_SAMPLE_BITS,
 )
 from ..main import (
     add_common_arguments,
     add_recv_arguments,
-    comma_split,
+    add_send_arguments,
     engine_main,
     parse_dither,
     parse_enum,
@@ -269,11 +267,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--recv-packet-samples", type=int, default=4096, help="Number of samples per digitiser packet [%(default)s]"
     )
-    parser.add_argument(
-        "--send-interface", type=comma_split(get_interface_address), required=True, help="Name of output network device"
-    )
-    parser.add_argument("--send-ttl", type=int, default=DEFAULT_TTL, help="TTL for outgoing packets [%(default)s]")
-    parser.add_argument("--send-ibv", action="store_true", help="Use ibverbs for output [no]")
+    add_send_arguments(parser, multi=True)
     parser.add_argument(
         "--send-packet-payload",
         type=int,
@@ -281,20 +275,8 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         metavar="BYTES",
         help="Size for output packets (voltage payload only) [%(default)s]",
     )
-    parser.add_argument(
-        "--send-affinity",
-        type=int,
-        default=-1,
-        metavar="CORE,...",
-        help="Cores for output-handling threads [not bound]",
-    )
-    parser.add_argument(
-        "--send-comp-vector",
-        type=int,
-        default=0,
-        metavar="VECTOR",
-        help="Completion vector for transmission, or -1 for polling [0]",
-    )
+    # TODO: add this argument to xbgpu/dsim so it can be incorporated into
+    # add_send_arguments.
     parser.add_argument(
         "--send-buffer",
         type=int,

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -441,15 +441,16 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
 
 
 def make_engine(ctx: AbstractContext, vkgdr_handle: vkgdr.Vkgdr, args: argparse.Namespace) -> tuple[Engine, Monitor]:
-    """Make an :class:`Engine` object, given a GPU context.
+    """Make an :class:`~katgpucbf.fgpu.engine.Engine` object, given a GPU context.
 
     Parameters
     ----------
     ctx
-        The GPU context in which the :class:`.Engine` will operate.
+        The GPU context in which the :class:`~katgpucbf.fgpu.engine.Engine`
+        will operate.
     vkgdr_handle
-        The Vkgdr handle in which the :class:`.Engine` will operate. It
-        must use the same device as `ctx`.
+        The Vkgdr handle in which the :class:`~katgpucbf.fgpu.engine.Engine`
+        will operate. It must use the same device as `ctx`.
     args
         Parsed arguments returned from :func:`parse_args`.
     """

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -17,7 +17,7 @@
 """fgpu main script.
 
 This is what kicks everything off. Command-line arguments are parsed, and used
-to create an :class:`~katgpucbf.fgpu.engine.Engine` object, which then takes over the
+to create an :class:`~katgpucbf.fgpu.engine.FEngine` object, which then takes over the
 actual running of the processing.
 """
 
@@ -47,7 +47,7 @@ from ..monitor import FileMonitor, Monitor, NullMonitor
 from ..spead import DEFAULT_PORT
 from ..utils import DitherType, comma_split, parse_dither, parse_enum, parse_source
 from . import DIG_SAMPLE_BITS_VALID
-from .engine import Engine
+from .engine import FEngine
 from .output import NarrowbandOutput, NarrowbandOutputDiscard, NarrowbandOutputNoDiscard, WidebandOutput, WindowFunction
 
 logger = logging.getLogger(__name__)
@@ -440,16 +440,16 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     return args
 
 
-def make_engine(ctx: AbstractContext, vkgdr_handle: vkgdr.Vkgdr, args: argparse.Namespace) -> tuple[Engine, Monitor]:
-    """Make an :class:`~katgpucbf.fgpu.engine.Engine` object, given a GPU context.
+def make_engine(ctx: AbstractContext, vkgdr_handle: vkgdr.Vkgdr, args: argparse.Namespace) -> tuple[FEngine, Monitor]:
+    """Make an :class:`~katgpucbf.fgpu.engine.FEngine` object, given a GPU context.
 
     Parameters
     ----------
     ctx
-        The GPU context in which the :class:`~katgpucbf.fgpu.engine.Engine`
+        The GPU context in which the :class:`~katgpucbf.fgpu.engine.FEngine`
         will operate.
     vkgdr_handle
-        The Vkgdr handle in which the :class:`~katgpucbf.fgpu.engine.Engine`
+        The Vkgdr handle in which the :class:`~katgpucbf.fgpu.engine.FEngine`
         will operate. It must use the same device as `ctx`.
     args
         Parsed arguments returned from :func:`parse_args`.
@@ -462,7 +462,7 @@ def make_engine(ctx: AbstractContext, vkgdr_handle: vkgdr.Vkgdr, args: argparse.
 
     batch_jones_lcm = math.lcm(*(output.jones_per_batch for output in args.outputs))
     chunk_jones = accel.roundup(args.send_chunk_jones, batch_jones_lcm)
-    engine = Engine(
+    engine = FEngine(
         katcp_host=args.katcp_host,
         katcp_port=args.katcp_port,
         context=ctx,
@@ -507,7 +507,7 @@ async def start_engine(
     tg: asyncio.TaskGroup,
     exit_stack: contextlib.AsyncExitStack,
     locals_: MutableMapping[str, object],
-) -> Engine:
+) -> FEngine:
     """Start the F-Engine asynchronously.
 
     See Also

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -41,7 +41,7 @@ from .. import (
     DEFAULT_TTL,
     DIG_SAMPLE_BITS,
 )
-from ..main import add_common_arguments, engine_main
+from ..main import add_common_arguments, add_recv_arguments, engine_main
 from ..mapped_array import make_vkgdr
 from ..monitor import FileMonitor, Monitor, NullMonitor
 from ..spead import DEFAULT_PORT
@@ -257,35 +257,9 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         ),
     )
     add_common_arguments(parser)
-    parser.add_argument(
-        "--recv-interface",
-        type=comma_split(get_interface_address),
-        help="Name(s) of input network device(s)",
-    )
-    parser.add_argument("--recv-ibv", action="store_true", help="Use ibverbs for receiving [no]")
-    parser.add_argument(
-        "--recv-affinity",
-        type=comma_split(int),
-        metavar="CORE,...",
-        default=[-1],
-        help="Cores for input-handling threads (comma-separated) [not bound]",
-    )
-    parser.add_argument(
-        "--recv-comp-vector",
-        type=comma_split(int),
-        metavar="VECTOR,...",
-        default=[0],
-        help="Completion vectors for source streams, or -1 for polling [0]",
-    )
+    add_recv_arguments(parser, multi=True)
     parser.add_argument(
         "--recv-packet-samples", type=int, default=4096, help="Number of samples per digitiser packet [%(default)s]"
-    )
-    parser.add_argument(
-        "--recv-buffer",
-        type=int,
-        default=128 * 1024 * 1024,
-        metavar="BYTES",
-        help="Size of network receive buffer [128MiB]",
     )
     parser.add_argument(
         "--send-interface", type=comma_split(get_interface_address), required=True, help="Name of output network device"

--- a/src/katgpucbf/fsim/main.py
+++ b/src/katgpucbf/fsim/main.py
@@ -47,7 +47,7 @@ from .. import (
     spead,
 )
 from ..fgpu.send import PREAMBLE_SIZE, make_descriptor_heap, make_item_group
-from ..main import add_gc_stats
+from ..main import add_common_arguments, add_gc_stats
 from ..send import DescriptorSender
 from ..utils import TimeConverter, comma_split
 from . import METRIC_NAMESPACE
@@ -104,11 +104,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--main-affinity", type=int, default=-1, help="Core affinity for the main Python thread [not bound]"
     )
-    parser.add_argument(
-        "--prometheus-port",
-        type=int,
-        help="Network port on which to serve Prometheus metrics [none]",
-    )
+    add_common_arguments(parser, katcp=False, aiomonitor=False)
     parser.add_argument("--run-once", action="store_true", help="Transmit a single collection of heaps before exiting")
     parser.add_argument(
         "dest",

--- a/src/katgpucbf/fsim/main.py
+++ b/src/katgpucbf/fsim/main.py
@@ -47,8 +47,9 @@ from .. import (
     spead,
 )
 from ..fgpu.send import PREAMBLE_SIZE, make_descriptor_heap, make_item_group
+from ..main import add_gc_stats
 from ..send import DescriptorSender
-from ..utils import TimeConverter, add_gc_stats, comma_split
+from ..utils import TimeConverter, comma_split
 from . import METRIC_NAMESPACE
 
 DTYPE = np.dtype(np.int8)

--- a/src/katgpucbf/fsim/main.py
+++ b/src/katgpucbf/fsim/main.py
@@ -47,9 +47,9 @@ from .. import (
     spead,
 )
 from ..fgpu.send import PREAMBLE_SIZE, make_descriptor_heap, make_item_group
-from ..main import add_common_arguments, add_gc_stats
+from ..main import add_common_arguments, add_gc_stats, comma_split
 from ..send import DescriptorSender
-from ..utils import TimeConverter, comma_split
+from ..utils import TimeConverter
 from . import METRIC_NAMESPACE
 
 DTYPE = np.dtype(np.int8)

--- a/src/katgpucbf/main.py
+++ b/src/katgpucbf/main.py
@@ -19,8 +19,11 @@
 import argparse
 import asyncio
 import contextlib
+import enum
 import gc
+import ipaddress
 import logging
+import os
 import signal
 import time
 from collections.abc import Awaitable, Callable, MutableMapping
@@ -32,11 +35,81 @@ import prometheus_async
 import prometheus_client
 from katsdpservices import get_interface_address
 from katsdpservices.aiomonitor import add_aiomonitor_arguments, start_aiomonitor
+from katsdptelstate.endpoint import endpoint_list_parser
 
-from . import DEFAULT_KATCP_HOST, DEFAULT_KATCP_PORT, __version__
-from .utils import comma_split
+from . import DEFAULT_KATCP_HOST, DEFAULT_KATCP_PORT, __version__, spead, utils
 
 logger = logging.getLogger(__name__)
+
+
+def parse_enum[E: enum.Enum](name: str, value: str, cls: type[E]) -> E:
+    """Parse a command-line argument into an enum type."""
+    table = {member.name.lower(): member for member in cls}
+    try:
+        return table[value]
+    except KeyError:
+        raise ValueError(f"Invalid {name} value {value} (valid values are {list(table.keys())})") from None
+
+
+def parse_dither(value: str) -> utils.DitherType:
+    """Parse a string into a dither type."""
+    # Note: this allows only the non-aliases, so excludes DEFAULT
+    return parse_enum("dither", value, utils.DitherType)
+
+
+def parse_source_ipv4(value: str) -> list[tuple[str, int]]:
+    """Parse a string into a list of IPv4 endpoints."""
+    endpoints = endpoint_list_parser(spead.DEFAULT_PORT)(value)
+    for endpoint in endpoints:
+        ipaddress.IPv4Address(endpoint.host)  # Raises if invalid syntax
+    return [(ep.host, ep.port) for ep in endpoints]
+
+
+def parse_source(value: str) -> list[tuple[str, int]] | str:
+    """Parse a string into a list of IP endpoints or a filename."""
+    try:
+        return parse_source_ipv4(value)
+    except ValueError:
+        if os.path.exists(value):
+            return value
+        raise ValueError(f"{value} is not an endpoint list or a filename") from None
+
+
+def comma_split[T](
+    base_type: Callable[[str], T], count: int | None = None, allow_single=False
+) -> Callable[[str], list[T]]:
+    """Return a function to split a comma-delimited str into a list of type T.
+
+    This function is used to parse lists of CPU core numbers, which come from
+    the command-line as comma-separated strings, but are obviously more useful
+    as a list of ints. It's generic enough that it could process lists of other
+    types as well though if necessary.
+
+    Parameters
+    ----------
+    base_type
+        The base type of thing you expect in the list, e.g. `int`, `float`.
+    count
+        How many of them you expect to be in the list. `None` means the list
+        could be any length.
+    allow_single
+        If true (defaults to false), allow a single value to be used when
+        `count` is greater than 1. In this case, it will be repeated `count`
+        times.
+    """
+
+    def func(value: str) -> list[T]:
+        parts = value.split(",")
+        if parts == [""]:
+            parts = []
+        n = len(parts)
+        if count is not None and n == 1 and allow_single:
+            parts = parts * count
+        elif count is not None and n != count:
+            raise ValueError(f"Expected {count} comma-separated fields, received {n}")
+        return [base_type(part) for part in parts]
+
+    return func
 
 
 def add_common_arguments(

--- a/src/katgpucbf/main.py
+++ b/src/katgpucbf/main.py
@@ -125,13 +125,13 @@ def add_common_arguments(
             "--katcp-host",
             type=str,
             default=DEFAULT_KATCP_HOST,
-            help="Hostname or IP on which to listen for KATCP C&M connections [all interfaces]",
+            help="Hostname or IP address on which to listen for KATCP C&M connections [all interfaces]",
         )
         parser.add_argument(
             "--katcp-port",
             type=int,
             default=DEFAULT_KATCP_PORT,
-            help="Network port on which to listen for KATCP C&M connections [%(default)s]",
+            help="TCP port on which to listen for KATCP C&M connections [%(default)s]",
         )
     if prometheus:
         parser.add_argument(

--- a/src/katgpucbf/main.py
+++ b/src/katgpucbf/main.py
@@ -29,9 +29,45 @@ import aiokatcp
 import katsdpservices
 import prometheus_async
 import prometheus_client
-from katsdpservices.aiomonitor import start_aiomonitor
+from katsdpservices.aiomonitor import add_aiomonitor_arguments, start_aiomonitor
+
+from . import DEFAULT_KATCP_HOST, DEFAULT_KATCP_PORT, __version__
 
 logger = logging.getLogger(__name__)
+
+
+def add_common_arguments(
+    parser: argparse.ArgumentParser,
+    *,
+    katcp: bool = True,
+    prometheus: bool = True,
+    aiomonitor: bool = True,
+    version: bool = True,
+) -> None:
+    """Add command-line arguments to the parser."""
+    if katcp:
+        parser.add_argument(
+            "--katcp-host",
+            type=str,
+            default=DEFAULT_KATCP_HOST,
+            help="Hostname or IP on which to listen for KATCP C&M connections [all interfaces]",
+        )
+        parser.add_argument(
+            "--katcp-port",
+            type=int,
+            default=DEFAULT_KATCP_PORT,
+            help="Network port on which to listen for KATCP C&M connections [%(default)s]",
+        )
+    if prometheus:
+        parser.add_argument(
+            "--prometheus-port",
+            type=int,
+            help="Network port on which to serve Prometheus metrics [none]",
+        )
+    if aiomonitor:
+        add_aiomonitor_arguments(parser)
+    if version:
+        parser.add_argument("--version", action="version", version=__version__)
 
 
 def add_signal_handlers(server: aiokatcp.DeviceServer) -> None:

--- a/src/katgpucbf/main.py
+++ b/src/katgpucbf/main.py
@@ -1,0 +1,145 @@
+################################################################################
+# Copyright (c) 2020-2025, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Utilities for writing the main programs of engines."""
+
+import argparse
+import asyncio
+import contextlib
+import gc
+import logging
+import signal
+import time
+from collections.abc import Awaitable, Callable, MutableMapping
+
+import aiokatcp
+import katsdpservices
+import prometheus_async
+import prometheus_client
+from katsdpservices.aiomonitor import start_aiomonitor
+
+logger = logging.getLogger(__name__)
+
+
+def add_signal_handlers(server: aiokatcp.DeviceServer) -> None:
+    """Arrange for clean shutdown on SIGINT (Ctrl-C) or SIGTERM."""
+    signums = [signal.SIGINT, signal.SIGTERM]
+
+    def handler():
+        # Remove the handlers so that if it fails to shut down, the next
+        # attempt will try harder.
+        logger.info("Received signal, shutting down")
+        for signum in signums:
+            loop.remove_signal_handler(signum)
+        server.halt()
+
+    loop = asyncio.get_running_loop()
+    for signum in signums:
+        loop.add_signal_handler(signum, handler)
+
+
+def add_gc_stats() -> None:
+    """Add Prometheus metrics for garbage collection timing.
+
+    It is only safe to call this once.
+    """
+    gc_time = prometheus_client.Histogram(
+        "python_gc_time_seconds",
+        "Time spent in garbage collection",
+        buckets=[0.0002, 0.0005, 0.001, 0.002, 0.005, 0.010, 0.020, 0.050, 0.100],
+        labelnames=["generation"],
+    )
+    # Make all the metrics exist, before any GC calls happen
+    for generation in range(3):
+        gc_time.labels(str(generation))
+    start_time = 0.0
+
+    def callback(phase: str, info: dict) -> None:
+        nonlocal start_time
+        if phase == "start":
+            start_time = time.monotonic()
+        else:
+            started = start_time  # Copy as early as possible, before any more GC can happen
+            elapsed = time.monotonic() - started
+            gc_time.labels(str(info["generation"])).observe(elapsed)
+
+    gc.callbacks.append(callback)
+
+
+async def _engine_main_async(
+    args: argparse.Namespace,
+    start_engine: Callable[
+        [argparse.Namespace, asyncio.TaskGroup, contextlib.AsyncExitStack, MutableMapping[str, object]],
+        Awaitable[aiokatcp.DeviceServer],
+    ],
+) -> None:
+    katsdpservices.setup_logging()
+    add_gc_stats()
+    locals_: dict[str, object] = {}
+    async with contextlib.AsyncExitStack() as exit_stack:
+        if getattr(args, "prometheus_port", None) is not None:
+            prometheus_server = await prometheus_async.aio.web.start_http_server(port=args.prometheus_port)
+            exit_stack.push_async_callback(prometheus_server.close)
+
+        if getattr(args, "aiomonitor", False):
+            exit_stack.enter_context(start_aiomonitor(asyncio.get_running_loop(), args, locals_))
+
+        tg = asyncio.TaskGroup()
+        await exit_stack.enter_async_context(tg)
+
+        engine = await start_engine(args, tg, exit_stack, locals_)
+        add_signal_handlers(engine)
+        # Avoid garbage collections needing to iterate over all the objects
+        # allocated so far. That makes garbage collection much faster, and we
+        # don't expect to free up much of what's currently allocated.
+        gc.freeze()
+        exit_stack.callback(gc.unfreeze)
+        tg.create_task(engine.join())
+
+
+def engine_main(
+    args: argparse.Namespace,
+    start_engine: Callable[
+        [argparse.Namespace, asyncio.TaskGroup, contextlib.AsyncExitStack, MutableMapping],
+        Awaitable[aiokatcp.DeviceServer],
+    ],
+) -> None:
+    """Run an engine.
+
+    This takes care of:
+
+    - running an event loop;
+    - setting up logging;
+    - running a web server for Prometheus scraping if requested on the command line;
+    - running aiomonitor
+    - adding Prometheus statistics for the garbage collector (GC);
+    - freezing the GC after starting the engine and unfreezing it on shutdown;
+
+    Parameters
+    ----------
+    args
+        The command-line arguments.
+    start_engine
+        The function that sets up and starts the engine. It takes the following parameters:
+
+        - The command-line arguments (`args`)
+        - A task group that can be used to schedule on-going work that will be
+          waited on before shutting down.
+        - An asynchronous exit stack that can be used to enter contexts or
+          schedule cleanup work.
+        - A dictionary of variables to expose to aiomonitor.
+    """
+    asyncio.run(_engine_main_async(args, start_engine))

--- a/src/katgpucbf/main.py
+++ b/src/katgpucbf/main.py
@@ -225,8 +225,10 @@ def add_recv_arguments(parser: argparse.ArgumentParser, *, multi: bool = False) 
     )
 
 
-def add_send_arguments(parser: argparse.ArgumentParser, *, prefix: str = "send-", multi: bool = False) -> None:
-    """Add arguments for sending interface (supporting ibverbs).
+def add_send_arguments(
+    parser: argparse.ArgumentParser, *, prefix: str = "send-", multi: bool = False, ibverbs: bool = True
+) -> None:
+    """Add arguments for sending interface (optionally supporting ibverbs).
 
     Parameters
     ----------
@@ -236,6 +238,8 @@ def add_send_arguments(parser: argparse.ArgumentParser, *, prefix: str = "send-"
         Prefix to use on argument names.
     multi
         If true, multiple interfaces are supported.
+    ibverbs
+        If true, ibverbs-related options will be added.
     """
     parser.add_argument(
         f"--{prefix}affinity",
@@ -244,13 +248,14 @@ def add_send_arguments(parser: argparse.ArgumentParser, *, prefix: str = "send-"
         metavar="CORE",
         help="Core for output-handling thread [not bound]",
     )
-    parser.add_argument(
-        f"--{prefix}comp-vector",
-        type=int,
-        default=0,
-        metavar="VECTOR",
-        help="Completion vector for transmission, or -1 for polling [%(default)s]",
-    )
+    if ibverbs:
+        parser.add_argument(
+            f"--{prefix}comp-vector",
+            type=int,
+            default=0,
+            metavar="VECTOR",
+            help="Completion vector for transmission, or -1 for polling [%(default)s]",
+        )
     _multi_add_argument(
         multi,
         parser,
@@ -263,7 +268,8 @@ def add_send_arguments(parser: argparse.ArgumentParser, *, prefix: str = "send-"
     parser.add_argument(
         f"--{prefix}ttl", type=int, default=DEFAULT_TTL, metavar="TTL", help="TTL for outgoing packets [%(default)s]"
     )
-    parser.add_argument(f"--{prefix}ibv", action="store_true", help="Use ibverbs for output [no]")
+    if ibverbs:
+        parser.add_argument(f"--{prefix}ibv", action="store_true", help="Use ibverbs for output [no]")
 
 
 def add_signal_handlers(server: aiokatcp.DeviceServer) -> None:

--- a/src/katgpucbf/recv.py
+++ b/src/katgpucbf/recv.py
@@ -440,7 +440,8 @@ def add_reader(
 ) -> None:
     """Connect a stream to an underlying transport.
 
-    See the documentation for :class:`.Engine` for an explanation of the parameters.
+    See the documentation for :class:`~katgpucbf.fgpu.engine.Engine` for an
+    explanation of the parameters.
     """
     if isinstance(src, str):
         stream.add_udp_pcap_file_reader(src)

--- a/src/katgpucbf/recv.py
+++ b/src/katgpucbf/recv.py
@@ -440,7 +440,7 @@ def add_reader(
 ) -> None:
     """Connect a stream to an underlying transport.
 
-    See the documentation for :class:`~katgpucbf.fgpu.engine.Engine` for an
+    See the documentation for :class:`~.FEngine` for an
     explanation of the parameters.
     """
     if isinstance(src, str):

--- a/src/katgpucbf/utils.py
+++ b/src/katgpucbf/utils.py
@@ -329,8 +329,8 @@ class Engine(aiokatcp.DeviceServer):
 
     BUILD_STATE = __version__
 
-    def __init__(self, katcp_host: str, katcp_port: int) -> None:
-        super().__init__(katcp_host, katcp_port)
+    def __init__(self, host: str, port: int) -> None:
+        super().__init__(host, port)
         self._wait_tasks: list[asyncio.Task] = []  # Tasks that need to be waited for on shutdown
 
         self.sensors.add(make_steady_state_timestamp_sensor())

--- a/src/katgpucbf/utils.py
+++ b/src/katgpucbf/utils.py
@@ -18,19 +18,15 @@
 
 import asyncio
 import enum
-import gc
 import ipaddress
 import logging
 import math
-import signal
-import time
 import weakref
 from collections import Counter
 from collections.abc import Callable
 
 import aiokatcp
 import numpy as np
-import prometheus_client
 from katsdptelstate.endpoint import endpoint_list_parser
 
 from . import MIN_SENSOR_UPDATE_PERIOD, TIME_SYNC_TASK_NAME
@@ -56,51 +52,6 @@ class DitherType(enum.Enum):
     NONE = 0  # Don't change this value: we rely on it being falsey
     UNIFORM = 1
     DEFAULT = 1  # Alias used to determine default when none is specified
-
-
-def add_signal_handlers(server: aiokatcp.DeviceServer) -> None:
-    """Arrange for clean shutdown on SIGINT (Ctrl-C) or SIGTERM."""
-    signums = [signal.SIGINT, signal.SIGTERM]
-
-    def handler():
-        # Remove the handlers so that if it fails to shut down, the next
-        # attempt will try harder.
-        logger.info("Received signal, shutting down")
-        for signum in signums:
-            loop.remove_signal_handler(signum)
-        server.halt()
-
-    loop = asyncio.get_running_loop()
-    for signum in signums:
-        loop.add_signal_handler(signum, handler)
-
-
-def add_gc_stats() -> None:
-    """Add Prometheus metrics for garbage collection timing.
-
-    It is only safe to call this once.
-    """
-    gc_time = prometheus_client.Histogram(
-        "python_gc_time_seconds",
-        "Time spent in garbage collection",
-        buckets=[0.0002, 0.0005, 0.001, 0.002, 0.005, 0.010, 0.020, 0.050, 0.100],
-        labelnames=["generation"],
-    )
-    # Make all the metrics exist, before any GC calls happen
-    for generation in range(3):
-        gc_time.labels(str(generation))
-    start_time = 0.0
-
-    def callback(phase: str, info: dict) -> None:
-        nonlocal start_time
-        if phase == "start":
-            start_time = time.monotonic()
-        else:
-            started = start_time  # Copy as early as possible, before any more GC can happen
-            elapsed = time.monotonic() - started
-            gc_time.labels(str(info["generation"])).observe(elapsed)
-
-    gc.callbacks.append(callback)
 
 
 def parse_enum[E: enum.Enum](name: str, value: str, cls: type[E]) -> E:

--- a/src/katgpucbf/vgpu/__init__.py
+++ b/src/katgpucbf/vgpu/__init__.py
@@ -1,0 +1,21 @@
+# noqa: D104
+
+################################################################################
+# Copyright (c) 2025 National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from typing import Final
+
+METRIC_NAMESPACE: Final = "vgpu"

--- a/src/katgpucbf/vgpu/engine.py
+++ b/src/katgpucbf/vgpu/engine.py
@@ -16,15 +16,12 @@
 
 """Engine class, which does all the actual processing."""
 
-import aiokatcp
-
-from .. import __version__
+from ..utils import Engine
 
 
-class VEngine(aiokatcp.DeviceServer):
+class VEngine(Engine):
     """Top-level class running the whole thing."""
 
     # TODO: VERSION means interface version, rather than software version. It
     # will need to wait on a proper ICD for a release.
     VERSION = "katgpucbf-vgpu-icd-0.1"
-    BUILD_STATE = __version__

--- a/src/katgpucbf/vgpu/engine.py
+++ b/src/katgpucbf/vgpu/engine.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2025, National Research Foundation (SARAO)
+# Copyright (c) 2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -21,7 +21,7 @@ import aiokatcp
 from .. import __version__
 
 
-class Engine(aiokatcp.DeviceServer):
+class VEngine(aiokatcp.DeviceServer):
     """Top-level class running the whole thing."""
 
     # TODO: VERSION means interface version, rather than software version. It

--- a/src/katgpucbf/vgpu/engine.py
+++ b/src/katgpucbf/vgpu/engine.py
@@ -1,0 +1,30 @@
+################################################################################
+# Copyright (c) 2020-2025, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Engine class, which does all the actual processing."""
+
+import aiokatcp
+
+from .. import __version__
+
+
+class Engine(aiokatcp.DeviceServer):
+    """Top-level class running the whole thing."""
+
+    # TODO: VERSION means interface version, rather than software version. It
+    # will need to wait on a proper ICD for a release.
+    VERSION = "katgpucbf-vgpu-icd-0.1"
+    BUILD_STATE = __version__

--- a/src/katgpucbf/vgpu/main.py
+++ b/src/katgpucbf/vgpu/main.py
@@ -22,15 +22,22 @@ import contextlib
 from collections.abc import MutableMapping, Sequence
 
 import aiokatcp
+from katsdptelstate.endpoint import endpoint_list_parser
 
-from ..main import add_common_arguments, engine_main
+from ..main import add_common_arguments, add_recv_arguments, engine_main
+from ..spead import DEFAULT_PORT
 from .engine import VEngine
+
+VTP_DEFAULT_PORT = 52030
 
 
 def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     """Parse the command-line arguments."""
     parser = argparse.ArgumentParser(prog="vgpu")
     add_common_arguments(parser)
+    add_recv_arguments(parser)
+    parser.add_argument("src", type=endpoint_list_parser(DEFAULT_PORT), nargs=2, help="Source endpoints")
+    parser.add_argument("dst", type=endpoint_list_parser(VTP_DEFAULT_PORT), help="Destination endpoints")
 
     args = parser.parse_args(arglist)
     return args

--- a/src/katgpucbf/vgpu/main.py
+++ b/src/katgpucbf/vgpu/main.py
@@ -22,39 +22,15 @@ import contextlib
 from collections.abc import MutableMapping, Sequence
 
 import aiokatcp
-from katsdpservices.aiomonitor import add_aiomonitor_arguments
 
-from .. import (
-    DEFAULT_KATCP_HOST,
-    DEFAULT_KATCP_PORT,
-    __version__,
-)
-from ..main import engine_main
+from ..main import add_common_arguments, engine_main
 from .engine import Engine
 
 
 def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     """Parse the command-line arguments."""
     parser = argparse.ArgumentParser(prog="vgpu")
-    parser.add_argument(
-        "--katcp-host",
-        type=str,
-        default=DEFAULT_KATCP_HOST,
-        help="Hostname or IP on which to listen for KATCP C&M connections [all interfaces]",
-    )
-    parser.add_argument(
-        "--katcp-port",
-        type=int,
-        default=DEFAULT_KATCP_PORT,
-        help="Network port on which to listen for KATCP C&M connections [%(default)s]",
-    )
-    parser.add_argument(
-        "--prometheus-port",
-        type=int,
-        help="Network port on which to serve Prometheus metrics [none]",
-    )
-    add_aiomonitor_arguments(parser)
-    parser.add_argument("--version", action="version", version=__version__)
+    add_common_arguments(parser)
 
     args = parser.parse_args(arglist)
     return args

--- a/src/katgpucbf/vgpu/main.py
+++ b/src/katgpucbf/vgpu/main.py
@@ -24,7 +24,7 @@ from collections.abc import MutableMapping, Sequence
 import aiokatcp
 from katsdptelstate.endpoint import endpoint_list_parser
 
-from ..main import add_common_arguments, add_recv_arguments, engine_main
+from ..main import add_common_arguments, add_recv_arguments, add_send_arguments, engine_main
 from ..spead import DEFAULT_PORT
 from .engine import VEngine
 
@@ -36,6 +36,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog="vgpu")
     add_common_arguments(parser)
     add_recv_arguments(parser)
+    add_send_arguments(parser, ibverbs=False)
     parser.add_argument("src", type=endpoint_list_parser(DEFAULT_PORT), nargs=2, help="Source endpoints")
     parser.add_argument("dst", type=endpoint_list_parser(VTP_DEFAULT_PORT), help="Destination endpoints")
 

--- a/src/katgpucbf/vgpu/main.py
+++ b/src/katgpucbf/vgpu/main.py
@@ -37,7 +37,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
 
 
 def make_engine(args: argparse.Namespace) -> Engine:
-    """Create the :class:`~katgpucbf.vgpu.Engine`."""
+    """Create the :class:`~katgpucbf.vgpu.engine.Engine`."""
     return Engine(args.katcp_host, args.katcp_port)
 
 

--- a/src/katgpucbf/vgpu/main.py
+++ b/src/katgpucbf/vgpu/main.py
@@ -1,0 +1,92 @@
+################################################################################
+# Copyright (c) 2025 National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""vgpu main script."""
+
+import argparse
+import asyncio
+import contextlib
+from collections.abc import MutableMapping, Sequence
+
+import aiokatcp
+from katsdpservices.aiomonitor import add_aiomonitor_arguments
+
+from .. import (
+    DEFAULT_KATCP_HOST,
+    DEFAULT_KATCP_PORT,
+    __version__,
+)
+from ..main import engine_main
+from .engine import Engine
+
+
+def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse the command-line arguments."""
+    parser = argparse.ArgumentParser(prog="vgpu")
+    parser.add_argument(
+        "--katcp-host",
+        type=str,
+        default=DEFAULT_KATCP_HOST,
+        help="Hostname or IP on which to listen for KATCP C&M connections [all interfaces]",
+    )
+    parser.add_argument(
+        "--katcp-port",
+        type=int,
+        default=DEFAULT_KATCP_PORT,
+        help="Network port on which to listen for KATCP C&M connections [%(default)s]",
+    )
+    parser.add_argument(
+        "--prometheus-port",
+        type=int,
+        help="Network port on which to serve Prometheus metrics [none]",
+    )
+    add_aiomonitor_arguments(parser)
+    parser.add_argument("--version", action="version", version=__version__)
+
+    args = parser.parse_args(arglist)
+    return args
+
+
+def make_engine(args: argparse.Namespace) -> Engine:
+    """Create the :class:`~katgpucbf.vgpu.Engine`."""
+    return Engine(args.katcp_host, args.katcp_port)
+
+
+async def start_engine(
+    args: argparse.Namespace,
+    tg: asyncio.TaskGroup,
+    exit_stack: contextlib.AsyncExitStack,
+    locals_: MutableMapping[str, object],
+) -> aiokatcp.DeviceServer:
+    """Start the V-engine asynchronously.
+
+    See Also
+    --------
+    katgpucbf.main.engine_main
+    """
+    engine = make_engine(args)
+    locals_.update(locals())
+    await engine.start()
+    return engine
+
+
+def main():
+    """Run the V-engine."""
+    engine_main(parse_args(), start_engine)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/katgpucbf/vgpu/main.py
+++ b/src/katgpucbf/vgpu/main.py
@@ -24,7 +24,7 @@ from collections.abc import MutableMapping, Sequence
 import aiokatcp
 
 from ..main import add_common_arguments, engine_main
-from .engine import Engine
+from .engine import VEngine
 
 
 def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
@@ -36,9 +36,9 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     return args
 
 
-def make_engine(args: argparse.Namespace) -> Engine:
-    """Create the :class:`~katgpucbf.vgpu.engine.Engine`."""
-    return Engine(args.katcp_host, args.katcp_port)
+def make_engine(args: argparse.Namespace) -> VEngine:
+    """Create the :class:`.VEngine`."""
+    return VEngine(args.katcp_host, args.katcp_port)
 
 
 async def start_engine(

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -50,11 +50,11 @@ from .. import (
     DEFAULT_PACKET_PAYLOAD_BYTES,
     DEFAULT_TTL,
 )
-from ..main import add_common_arguments, engine_main
+from ..main import add_common_arguments, add_recv_arguments, engine_main
 from ..mapped_array import make_vkgdr
 from ..monitor import FileMonitor, Monitor, NullMonitor
 from ..spead import DEFAULT_PORT
-from ..utils import DitherType, parse_dither, parse_source
+from ..utils import DitherType, parse_dither, parse_source_ipv4
 from .correlation import device_filter
 from .output import BOutput, XOutput
 
@@ -287,29 +287,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         required=True,
         help="UNIX time at which digitisers were synced.",
     )
-    parser.add_argument(
-        "--recv-affinity", type=int, default=-1, help="Core to which the receiver thread will be bound [not bound]."
-    )
-    parser.add_argument(
-        "--recv-comp-vector",
-        type=int,
-        default=0,
-        help="Completion vector for source streams, or -1 for polling [%(default)s].",
-    )
-    parser.add_argument(
-        "--recv-interface",
-        type=get_interface_address,
-        required=True,
-        help="Name of the interface receiving data from the F-Engines, e.g. eth0.",
-    )
-    parser.add_argument("--recv-ibv", action="store_true", help="Use ibverbs for input [no].")
-    parser.add_argument(
-        "--recv-buffer",
-        type=int,
-        default=128 * 1024 * 1024,
-        metavar="BYTES",
-        help="Size of network receive buffer [128MiB]",
-    )
+    add_recv_arguments(parser, multi=False)
     parser.add_argument(
         "--send-affinity", type=int, default=-1, help="Core to which the sender thread will be bound [not bound]."
     )
@@ -339,7 +317,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         help="Start with correlator output transmission enabled, without having to issue a katcp command.",
     )
     parser.add_argument("--monitor-log", type=str, help="File to write performance-monitoring data to")
-    parser.add_argument("src", type=parse_source, help="Multicast address data is received from.")
+    parser.add_argument("src", type=parse_source_ipv4, help="Multicast address data is received from.")
 
     args = parser.parse_args(arglist)
     if args.jones_per_batch % args.channels != 0:

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -338,6 +338,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Start with correlator output transmission enabled, without having to issue a katcp command.",
     )
+    parser.add_argument("--monitor-log", type=str, help="File to write performance-monitoring data to")
     parser.add_argument("src", type=parse_source, help="Multicast address data is received from.")
 
     args = parser.parse_args(arglist)

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -39,7 +39,6 @@ from typing import TypedDict
 
 import katsdpsigproc.accel
 import vkgdr
-from katsdpservices import get_interface_address
 from katsdpsigproc.abc import AbstractContext
 from katsdptelstate.endpoint import Endpoint, endpoint_parser
 
@@ -48,9 +47,15 @@ from katgpucbf.xbgpu.engine import XBEngine
 from .. import (
     DEFAULT_JONES_PER_BATCH,
     DEFAULT_PACKET_PAYLOAD_BYTES,
-    DEFAULT_TTL,
 )
-from ..main import add_common_arguments, add_recv_arguments, engine_main, parse_dither, parse_source_ipv4
+from ..main import (
+    add_common_arguments,
+    add_recv_arguments,
+    add_send_arguments,
+    engine_main,
+    parse_dither,
+    parse_source_ipv4,
+)
 from ..mapped_array import make_vkgdr
 from ..monitor import FileMonitor, Monitor, NullMonitor
 from ..spead import DEFAULT_PORT
@@ -288,29 +293,13 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         help="UNIX time at which digitisers were synced.",
     )
     add_recv_arguments(parser, multi=False)
-    parser.add_argument(
-        "--send-affinity", type=int, default=-1, help="Core to which the sender thread will be bound [not bound]."
-    )
-    parser.add_argument(
-        "--send-comp-vector",
-        type=int,
-        default=1,
-        help="Completion vector for transmission, or -1 for polling [%(default)s].",
-    )
-    parser.add_argument(
-        "--send-interface",
-        type=get_interface_address,
-        required=True,
-        help="Name of the interface that this engine will transmit data on, e.g. eth1.",
-    )
+    add_send_arguments(parser, multi=False)
     parser.add_argument(
         "--send-packet-payload",
         type=int,
         default=DEFAULT_PACKET_PAYLOAD_BYTES,
         help="Size in bytes for output packets (payload only) [%(default)s]",
     )
-    parser.add_argument("--send-ttl", type=int, default=DEFAULT_TTL, help="TTL for outgoing packets [%(default)s]")
-    parser.add_argument("--send-ibv", action="store_true", help="Use ibverbs for output [no].")
     parser.add_argument(
         "--send-enabled",
         action="store_true",

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -40,7 +40,6 @@ from typing import TypedDict
 import katsdpsigproc.accel
 import vkgdr
 from katsdpservices import get_interface_address
-from katsdpservices.aiomonitor import add_aiomonitor_arguments
 from katsdpsigproc.abc import AbstractContext
 from katsdptelstate.endpoint import Endpoint, endpoint_parser
 
@@ -48,13 +47,10 @@ from katgpucbf.xbgpu.engine import XBEngine
 
 from .. import (
     DEFAULT_JONES_PER_BATCH,
-    DEFAULT_KATCP_HOST,
-    DEFAULT_KATCP_PORT,
     DEFAULT_PACKET_PAYLOAD_BYTES,
     DEFAULT_TTL,
-    __version__,
 )
-from ..main import engine_main
+from ..main import add_common_arguments, engine_main
 from ..mapped_array import make_vkgdr
 from ..monitor import FileMonitor, Monitor, NullMonitor
 from ..spead import DEFAULT_PORT
@@ -207,24 +203,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         help="Add a baseline-correlation-products output (may be repeated). The required keys are: "
         "name, dst, heap_accumulation_threshold.",
     )
-    parser.add_argument(
-        "--katcp-host",
-        type=str,
-        default=DEFAULT_KATCP_HOST,
-        help="Hostname or IP address on which to listen for KATCP C&M connections [all interfaces]",
-    )
-    parser.add_argument(
-        "--katcp-port",
-        type=int,
-        default=DEFAULT_KATCP_PORT,
-        help="TCP port on which to listen for KATCP C&M connections [%(default)s]",
-    )
-    parser.add_argument(
-        "--prometheus-port",
-        type=int,
-        help="Network port on which to serve Prometheus metrics [none]",
-    )
-    add_aiomonitor_arguments(parser)
+    add_common_arguments(parser)
     parser.add_argument(
         "--adc-sample-rate",
         type=float,
@@ -359,8 +338,6 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Start with correlator output transmission enabled, without having to issue a katcp command.",
     )
-    parser.add_argument("--monitor-log", type=str, help="File to write performance-monitoring data to")
-    parser.add_argument("--version", action="version", version=__version__)
     parser.add_argument("src", type=parse_source, help="Multicast address data is received from.")
 
     args = parser.parse_args(arglist)

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -50,11 +50,11 @@ from .. import (
     DEFAULT_PACKET_PAYLOAD_BYTES,
     DEFAULT_TTL,
 )
-from ..main import add_common_arguments, add_recv_arguments, engine_main
+from ..main import add_common_arguments, add_recv_arguments, engine_main, parse_dither, parse_source_ipv4
 from ..mapped_array import make_vkgdr
 from ..monitor import FileMonitor, Monitor, NullMonitor
 from ..spead import DEFAULT_PORT
-from ..utils import DitherType, parse_dither, parse_source_ipv4
+from ..utils import DitherType
 from .correlation import device_filter
 from .output import BOutput, XOutput
 

--- a/test/dsim/conftest.py
+++ b/test/dsim/conftest.py
@@ -79,6 +79,7 @@ def send_stream(
             interface_address="",
             ibv=False,
             affinity=-1,
+            comp_vector=0,
         )
 
 

--- a/test/fgpu/conftest.py
+++ b/test/fgpu/conftest.py
@@ -27,7 +27,7 @@ from katsdpsigproc.abc import AbstractContext
 
 import katgpucbf.fgpu.engine
 import katgpucbf.fgpu.recv
-from katgpucbf.fgpu.engine import Engine
+from katgpucbf.fgpu.engine import FEngine
 from katgpucbf.fgpu.main import make_engine, parse_args
 
 
@@ -80,12 +80,12 @@ async def engine_server(
     recv_max_chunks_one,
     context: AbstractContext,
     vkgdr_handle: vkgdr.Vkgdr,
-) -> AsyncGenerator[Engine, None]:
-    """Create a dummy :class:`.fgpu.Engine` for unit testing.
+) -> AsyncGenerator[FEngine, None]:
+    """Create a dummy :class:`.FEngine` for unit testing.
 
     The arguments passed are based on the default arguments from
     :mod:`~katgpucbf.fgpu.main`, and are a set of simple parameters just to
-    get the :class:`~.fgpu.Engine` running so that the KATCP interface can be
+    get the :class:`.FEngine` running so that the KATCP interface can be
     tested.
 
     Extra command-line arguments can be added using a ``cmdline_args`` marker.
@@ -108,7 +108,7 @@ async def engine_server(
 
 
 @pytest.fixture
-async def engine_client(engine_server: Engine) -> AsyncGenerator[aiokatcp.Client, None]:
+async def engine_client(engine_server: FEngine) -> AsyncGenerator[aiokatcp.Client, None]:
     """Create a KATCP client for communicating with the dummy server."""
     host, port = engine_server.sockets[0].getsockname()[:2]
     async with asyncio.timeout(5):  # To fail the test quickly if unable to connect

--- a/test/fgpu/conftest.py
+++ b/test/fgpu/conftest.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020-2024, National Research Foundation (SARAO)
+# Copyright (c) 2020-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 ################################################################################
 
-"""Unit tests for Engine functions."""
+"""Unit tests for FEngine functions."""
 
 import logging
 import math
@@ -35,7 +35,7 @@ from numpy.typing import ArrayLike
 from katgpucbf import COMPLEX, DIG_SAMPLE_BITS, N_POLS
 from katgpucbf.fgpu import METRIC_NAMESPACE
 from katgpucbf.fgpu.delay import wrap_angle
-from katgpucbf.fgpu.engine import Engine, InQueueItem, Pipeline, generate_ddc_weights, generate_pfb_weights
+from katgpucbf.fgpu.engine import FEngine, InQueueItem, Pipeline, generate_ddc_weights, generate_pfb_weights
 from katgpucbf.fgpu.main import parse_narrowband, parse_wideband
 from katgpucbf.fgpu.output import NarrowbandOutput, NarrowbandOutputNoDiscard, Output
 from katgpucbf.utils import TimeConverter
@@ -146,8 +146,8 @@ def assert_angles_allclose(a, b, **kwargs) -> None:
     np.testing.assert_allclose(wrap_angle(a - b), 0.0, **kwargs)
 
 
-class TestEngine:
-    r"""Test :class:`.Engine`."""
+class TestFEngine:
+    r"""Test :class:`.FEngine`."""
 
     @pytest.fixture(params=["wideband", "narrowband_discard", "narrowband_no_discard"])
     def output_type(self, request: pytest.FixtureRequest) -> str:
@@ -322,7 +322,7 @@ class TestEngine:
             "239.10.10.0+15:7149",  # src
         ]
 
-    def test_engine_required_arguments(self, engine_server: Engine) -> None:
+    def test_engine_required_arguments(self, engine_server: FEngine) -> None:
         """Test proper setting of required arguments.
 
         .. note::
@@ -375,7 +375,7 @@ class TestEngine:
         self,
         mock_recv_stream: spead2.InprocQueue,
         mock_send_stream: list[spead2.InprocQueue],
-        engine: Engine,
+        engine: FEngine,
         output: Output,
         dig_data: np.ndarray,
         *,
@@ -519,7 +519,7 @@ class TestEngine:
         self,
         mock_recv_stream: spead2.InprocQueue,
         mock_send_stream: list[spead2.InprocQueue],
-        engine_server: Engine,
+        engine_server: FEngine,
         engine_client: aiokatcp.Client,
         output: Output,
         coherent_scale: np.ndarray,
@@ -625,7 +625,7 @@ class TestEngine:
         self,
         mock_recv_stream: spead2.InprocQueue,
         mock_send_stream: list[spead2.InprocQueue],
-        engine_server: Engine,
+        engine_server: FEngine,
         engine_client: aiokatcp.Client,
         output: Output,
         coherent_scale: np.ndarray,
@@ -701,7 +701,7 @@ class TestEngine:
         self,
         mock_recv_stream: spead2.InprocQueue,
         mock_send_stream: list[spead2.InprocQueue],
-        engine_server: Engine,
+        engine_server: FEngine,
         engine_client: aiokatcp.Client,
         output: Output,
         extra_delay_samples: float,
@@ -788,7 +788,7 @@ class TestEngine:
         self,
         mock_recv_stream: spead2.InprocQueue,
         mock_send_stream: list[spead2.InprocQueue],
-        engine_server: Engine,
+        engine_server: FEngine,
         engine_client: aiokatcp.Client,
         extra_delay_samples: float,
         extra_phase: float,
@@ -853,7 +853,7 @@ class TestEngine:
         self,
         mock_recv_stream: spead2.InprocQueue,
         mock_send_stream: list[spead2.InprocQueue],
-        engine_server: Engine,
+        engine_server: FEngine,
         engine_client: aiokatcp.Client,
         output: Output,
         channels: int,
@@ -951,7 +951,7 @@ class TestEngine:
         self,
         mock_recv_stream: spead2.InprocQueue,
         mock_send_stream: list[spead2.InprocQueue],
-        engine_server: Engine,
+        engine_server: FEngine,
         engine_client: aiokatcp.Client,
         output: Output,
         channels: int,
@@ -1096,7 +1096,7 @@ class TestEngine:
         self,
         mock_recv_stream: spead2.InprocQueue,
         mock_send_stream: list[spead2.InprocQueue],
-        engine_server: Engine,
+        engine_server: FEngine,
         engine_client: aiokatcp.Client,
         output: Output,
     ) -> None:
@@ -1133,7 +1133,7 @@ class TestEngine:
         self,
         mock_recv_stream: spead2.InprocQueue,
         mock_send_stream: list[spead2.InprocQueue],
-        engine_server: Engine,
+        engine_server: FEngine,
         engine_client: aiokatcp.Client,
         output: Output,
         input_voltage: int,
@@ -1168,7 +1168,7 @@ class TestEngine:
         self,
         mock_recv_stream: spead2.InprocQueue,
         mock_send_stream: list[spead2.InprocQueue],
-        engine_server: Engine,
+        engine_server: FEngine,
         engine_client: aiokatcp.Client,
         output: Output,
         default_gain: np.float32,
@@ -1235,7 +1235,7 @@ class TestEngine:
         self,
         mock_recv_stream: spead2.InprocQueue,
         mock_send_stream: list[spead2.InprocQueue],
-        engine_server: Engine,
+        engine_server: FEngine,
         engine_client: aiokatcp.Client,
         output: Output,
         monkeypatch,
@@ -1270,7 +1270,7 @@ class TestEngine:
         self,
         mock_recv_stream: spead2.InprocQueue,
         mock_send_stream: list[spead2.InprocQueue],
-        engine_server: Engine,
+        engine_server: FEngine,
         engine_client: aiokatcp.Client,
         output: Output,
         monkeypatch,
@@ -1307,7 +1307,7 @@ class TestEngine:
         self,
         mock_recv_stream: spead2.InprocQueue,
         mock_send_stream: list[spead2.InprocQueue],
-        engine_server: Engine,
+        engine_server: FEngine,
         engine_client: aiokatcp.Client,
         output: Output,
     ) -> None:

--- a/test/fgpu/test_katcp_interface.py
+++ b/test/fgpu/test_katcp_interface.py
@@ -25,7 +25,7 @@ import pytest
 
 from katgpucbf import N_POLS
 from katgpucbf.fgpu.delay import wrap_angle
-from katgpucbf.fgpu.engine import Engine
+from katgpucbf.fgpu.engine import FEngine
 
 pytestmark = [pytest.mark.cuda_only]
 
@@ -51,7 +51,7 @@ def assert_valid_complex_list(value: str) -> None:
 
 
 class TestKatcpRequests:
-    """Unit tests for the Engine's KATCP requests."""
+    """Unit tests for the FEngine's KATCP requests."""
 
     @pytest.fixture
     def engine_arglist(self) -> list[str]:
@@ -77,7 +77,7 @@ class TestKatcpRequests:
         assert sensor_value == "[0.125+0j]"
 
     @pytest.mark.parametrize("pol", range(N_POLS))
-    async def test_gain_set_scalar(self, engine_client: aiokatcp.Client, engine_server: Engine, pol: int) -> None:
+    async def test_gain_set_scalar(self, engine_client: aiokatcp.Client, engine_server: FEngine, pol: int) -> None:
         """Test that the eq gain is correctly set with a scalar value."""
         # TODO[nb]: need to update for multiple pipelines
         reply, _informs = await engine_client.request("gain", "wideband", pol, "0.2-3j")
@@ -97,7 +97,7 @@ class TestKatcpRequests:
         # Other pol must not have been affected
         np.testing.assert_equal(engine_server._pipelines[0].gains[:, 1 - pol], np.full(CHANNELS, GAIN, np.complex64))
 
-    async def test_gain_set_vector(self, engine_client: aiokatcp.Client, engine_server: Engine) -> None:
+    async def test_gain_set_vector(self, engine_client: aiokatcp.Client, engine_server: FEngine) -> None:
         """Test that the eq gain is correctly set with a vector of values."""
         # This test doesn't parametrize over pols. It's assumed that anything
         # causing the wrong pol to be set would be picked up by the scalar
@@ -144,7 +144,7 @@ class TestKatcpRequests:
         with pytest.raises(aiokatcp.FailReply):
             await engine_client.request("gain", "wideband", 0, "1", "2")
 
-    async def test_gain_all_set_scalar(self, engine_client: aiokatcp.Client, engine_server: Engine) -> None:
+    async def test_gain_all_set_scalar(self, engine_client: aiokatcp.Client, engine_server: FEngine) -> None:
         """Test that ``?gain-all`` works correctly with a vector of values."""
         # TODO[nb]: need to update for multiple pipelines
         reply, _informs = await engine_client.request("gain-all", "wideband", "0.2-3j")
@@ -157,7 +157,7 @@ class TestKatcpRequests:
                 engine_server._pipelines[0].gains[:, pol], np.full(CHANNELS, 0.2 - 3j, np.complex64)
             )
 
-    async def test_gain_all_set_vector(self, engine_client: aiokatcp.Client, engine_server: Engine) -> None:
+    async def test_gain_all_set_vector(self, engine_client: aiokatcp.Client, engine_server: FEngine) -> None:
         """Test that ``?gain-all`` works correctly with a scalar value."""
         # TODO[nb]: need to update for multiple pipelines
         gains = np.arange(CHANNELS, dtype=np.float32) * (2 + 3j)
@@ -169,7 +169,7 @@ class TestKatcpRequests:
             assert_valid_complex_list(sensor_value)
             np.testing.assert_equal(np.array(literal_eval(sensor_value)), gains)
 
-    async def test_gain_all_set_default(self, engine_client: aiokatcp.Client, engine_server: Engine) -> None:
+    async def test_gain_all_set_default(self, engine_client: aiokatcp.Client, engine_server: FEngine) -> None:
         """Test ``?gain-all default``."""
         await engine_client.request("gain-all", "wideband", "2+3j")
         await engine_client.request("gain-all", "wideband", "default")
@@ -189,7 +189,7 @@ class TestKatcpRequests:
 
     @pytest.mark.parametrize("correct_delay_strings", [("3.76e-9,0.12e-9:7.322,1.91", "2.67e-9,0.02e-9:5.678,1.81")])
     async def test_delay_model_update_correct(
-        self, engine_server: Engine, engine_client: aiokatcp.Client, correct_delay_strings: tuple[str, str]
+        self, engine_server: FEngine, engine_client: aiokatcp.Client, correct_delay_strings: tuple[str, str]
     ) -> None:
         """Test correctly-formed delay strings and validate the updates.
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,0 +1,75 @@
+################################################################################
+# Copyright (c) 2020-2025, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Tests for :mod:`katcbfgpu.main`."""
+
+import pytest
+
+from katgpucbf.main import comma_split, parse_dither
+from katgpucbf.utils import DitherType
+
+
+class TestCommaSplit:
+    """Test :func:`.comma_split`."""
+
+    def test_basic(self) -> None:
+        """Test normal usage, without optional features."""
+        assert comma_split(int)("3,5") == [3, 5]
+        assert comma_split(int)("3") == [3]
+        assert comma_split(int)("") == []
+
+    def test_bad_value(self) -> None:
+        """Test with a value that isn't valid for the element type."""
+        with pytest.raises(ValueError, match="invalid literal for int"):
+            assert comma_split(int)("3,hello")
+
+    def test_fixed_count(self) -> None:
+        """Test with a value for `count`."""
+        splitter = comma_split(int, 2)
+        assert splitter("3,5") == [3, 5]
+        with pytest.raises(ValueError, match="Expected 2 comma-separated fields, received 3"):
+            splitter("3,5,7")
+        with pytest.raises(ValueError, match="Expected 2 comma-separated fields, received 1"):
+            splitter("3")
+
+    def test_allow_single(self) -> None:
+        """Test with `allow_single`."""
+        splitter = comma_split(int, 2, allow_single=True)
+        assert splitter("3,5") == [3, 5]
+        assert splitter("3") == [3, 3]
+        with pytest.raises(ValueError, match="Expected 2 comma-separated fields, received 3"):
+            splitter("3,5,7")
+
+
+class TestParseDither:
+    """Test :func:`.parse_dither`."""
+
+    @pytest.mark.parametrize(
+        "input, output",
+        [("none", DitherType.NONE), ("uniform", DitherType.UNIFORM)],
+    )
+    def test_success(self, input: str, output: DitherType) -> None:
+        """Test with valid inputs."""
+        assert parse_dither(input) == output
+
+    @pytest.mark.parametrize("input", ["", "false", "UnIFoRM", "NONE", "default"])
+    def test_invalid(self, input: str) -> None:
+        """Test with invalid inputs."""
+        with pytest.raises(
+            ValueError,
+            match=rf"Invalid dither value {input} \(valid values are \['none', 'uniform'\]\)",
+        ):
+            parse_dither(input)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -29,11 +29,8 @@ from aiokatcp import DeviceStatus
 
 from katgpucbf.utils import (
     DeviceStatusSensor,
-    DitherType,
     TimeConverter,
     TimeoutSensorStatusObserver,
-    comma_split,
-    parse_dither,
 )
 
 
@@ -176,56 +173,3 @@ class TestTimeConverter:
         """Test :meth:`.TimeConverter.adc_to_unix`."""
         assert time_converter.adc_to_unix(0.0) == 1234567890.0
         assert time_converter.adc_to_unix(10485760.0) == 1234567890.0 + 10.0
-
-
-class TestCommaSplit:
-    """Test :func:`.comma_split`."""
-
-    def test_basic(self) -> None:
-        """Test normal usage, without optional features."""
-        assert comma_split(int)("3,5") == [3, 5]
-        assert comma_split(int)("3") == [3]
-        assert comma_split(int)("") == []
-
-    def test_bad_value(self) -> None:
-        """Test with a value that isn't valid for the element type."""
-        with pytest.raises(ValueError, match="invalid literal for int"):
-            assert comma_split(int)("3,hello")
-
-    def test_fixed_count(self) -> None:
-        """Test with a value for `count`."""
-        splitter = comma_split(int, 2)
-        assert splitter("3,5") == [3, 5]
-        with pytest.raises(ValueError, match="Expected 2 comma-separated fields, received 3"):
-            splitter("3,5,7")
-        with pytest.raises(ValueError, match="Expected 2 comma-separated fields, received 1"):
-            splitter("3")
-
-    def test_allow_single(self) -> None:
-        """Test with `allow_single`."""
-        splitter = comma_split(int, 2, allow_single=True)
-        assert splitter("3,5") == [3, 5]
-        assert splitter("3") == [3, 3]
-        with pytest.raises(ValueError, match="Expected 2 comma-separated fields, received 3"):
-            splitter("3,5,7")
-
-
-class TestParseDither:
-    """Test :func:`.parse_dither`."""
-
-    @pytest.mark.parametrize(
-        "input, output",
-        [("none", DitherType.NONE), ("uniform", DitherType.UNIFORM)],
-    )
-    def test_success(self, input: str, output: DitherType) -> None:
-        """Test with valid inputs."""
-        assert parse_dither(input) == output
-
-    @pytest.mark.parametrize("input", ["", "false", "UnIFoRM", "NONE", "default"])
-    def test_invalid(self, input: str) -> None:
-        """Test with invalid inputs."""
-        with pytest.raises(
-            ValueError,
-            match=rf"Invalid dither value {input} \(valid values are \['none', 'uniform'\]\)",
-        ):
-            parse_dither(input)


### PR DESCRIPTION
There are two major parts to this. The first is unifying a bunch of code between fgpu, xbgpu and (sometimes) dsim, so that it won't be copy-pasted yet again to create the V-engine. The second is adding a very minimal V-Engine which can start up and provides some sensors. It doesn't provide all the command-line options and sensors (as originally proposed in NGC-1691) as I wanted to get the first part out the door.

In the first part:
- Create a new katgpucbf.main module to hold functions called by the main modules of each engine. Some of katgpu.utils is moved here.
- Add a new Engine base class with common functionality for engines. This will add some extra sensors (device-status and time synchronisation sensors) to dsim which was missing them.
- Add `engine_main` to handle all the boilerplate for the main function (handling Prometheus and aiomonitor, managing the garbage collector). This will cause some behaviour changes in dsim, since it didn't previously support aiomonitor nor touch the garbage collector.
- Rename fgpu.engine.Engine to FEngine to more clearly disambiguate it from the Engine base class above, and for consistency with XBEngine.
- Add helper functions to add various sets of command-line arguments. This mostly causes changes in help text and the order of arguments, but there are some actual semantic changes:
  - xbgpu's `--send-comp-vector` default changes from 1 to 0, which matches the behaviour of fgpu.
  - dsim's `--interface` argument used to default to `lo`; it's now a requirements argument.
  - dsim gains `--version` and `--aiomonitor*` arguments.
  - dsim gains a `--comp-vector` argument, which was previously missing (see NGC-1753)

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`
- [x] If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [ ] If qualification tests are changed: attach a sample qualification report
- [x] If design has changed: ensure documentation is up to date
- [ ] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Relates to NGC-1691.
