### PR TITLE
Add dependencies for vgpu

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,7 @@ repos:
             'aiomonitor==0.7.1',
             'asyncssh==2.19.0',
             'dask==2025.3.0',
+            'katcbf-vlbi-resample==0.2',
             'katsdpsigproc==1.10.0',
             'katsdptelstate==0.14',
             'matplotlib==3.10.0',

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
           - --python-version=3.12
           - pyproject.toml
           - requirements.in
-        files: '^(requirements\.(in|txt)|setup\.cfg)$'
+        files: '^(requirements\.(in|txt)|pyproject\.toml)$'
       - id: pip-compile
         name: pip-compile requirements-dev.txt
         args:
@@ -73,7 +73,7 @@ repos:
           - --python-version=3.12
           - pyproject.toml
           - requirements-dev.in
-        files: '^(requirements(-dev)?\.(in|txt))$'
+        files: '^(requirements(-dev)?\.(in|txt)|pyproject\.toml)$'
       - id: pip-compile
         name: pip-compile qualification/requirements.txt
         args:
@@ -82,7 +82,7 @@ repos:
           - --python-version=3.12
           - pyproject.toml
           - qualification/requirements.in
-        files: '(.*requirements(-dev)?\.(in|txt))$'
+        files: '(.*requirements(-dev)?\.(in|txt)|pyproject\.toml)$'
       - id: pip-compile
         name: pip-compile scratch/benchmarks/requirements.txt
         args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 dependencies = [
     "aiokatcp>=1.9.0",
     "dask",
+    "katcbf-vlbi-resample>=0.2",
     "katsdpservices[aiomonitor]",
     "katsdpsigproc>=1.9.0",
     "katsdptelstate",

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -36,18 +36,39 @@ appdirs==1.4.4
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   katsdpsigproc
+astropy==7.1.0
+    # via
+    #   -c qualification/../requirements-dev.txt
+    #   -c qualification/../requirements.txt
+    #   baseband
+    #   katcbf-vlbi-resample
+astropy-iers-data==0.2025.9.29.0.35.48
+    # via
+    #   -c qualification/../requirements-dev.txt
+    #   -c qualification/../requirements.txt
+    #   astropy
 async-timeout==5.0.1
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   katgpucbf (pyproject.toml)
     #   aiokatcp
+atomicwrites==1.4.1
+    # via
+    #   -c qualification/../requirements-dev.txt
+    #   -c qualification/../requirements.txt
+    #   katcbf-vlbi-resample
 attrs==24.3.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   aiohttp
     #   aiomonitor
+baseband==4.3.0
+    # via
+    #   -c qualification/../requirements-dev.txt
+    #   -c qualification/../requirements.txt
+    #   katcbf-vlbi-resample
 certifi==2024.12.14
     # via
     #   -c qualification/../requirements-dev.txt
@@ -101,6 +122,11 @@ fsspec==2024.12.0
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   dask
+h5py==3.14.0
+    # via
+    #   -c qualification/../requirements-dev.txt
+    #   -c qualification/../requirements.txt
+    #   katcbf-vlbi-resample
 hiredis==3.1.0
     # via
     #   -c qualification/../requirements-dev.txt
@@ -128,6 +154,11 @@ jinja2==3.1.6
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   aiomonitor
+katcbf-vlbi-resample==0.2
+    # via
+    #   -c qualification/../requirements-dev.txt
+    #   -c qualification/../requirements.txt
+    #   katgpucbf (pyproject.toml)
 katcp-codec==0.2.0
     # via
     #   -c qualification/../requirements-dev.txt
@@ -148,6 +179,7 @@ katsdptelstate==0.14
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   katgpucbf (pyproject.toml)
+    #   katcbf-vlbi-resample
 kiwisolver==1.4.8
     # via matplotlib
 llvmlite==0.43.0
@@ -165,6 +197,11 @@ mako==1.3.8
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   katsdpsigproc
+markdown-it-py==4.0.0
+    # via
+    #   -c qualification/../requirements-dev.txt
+    #   -c qualification/../requirements.txt
+    #   rich
 markupsafe==3.0.2
     # via
     #   -c qualification/../requirements-dev.txt
@@ -175,6 +212,11 @@ matplotlib==3.10.0
     # via
     #   katgpucbf (pyproject.toml)
     #   prometheus-api-client
+mdurl==0.1.2
+    # via
+    #   -c qualification/../requirements-dev.txt
+    #   -c qualification/../requirements.txt
+    #   markdown-it-py
 msgpack==1.1.0
     # via
     #   -c qualification/../requirements-dev.txt
@@ -202,13 +244,17 @@ numpy==2.0.2
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   katgpucbf (pyproject.toml)
+    #   astropy
     #   contourpy
+    #   h5py
+    #   katcbf-vlbi-resample
     #   katsdpsigproc
     #   katsdptelstate
     #   matplotlib
     #   numba
     #   pandas
     #   prometheus-api-client
+    #   pyerfa
     #   scipy
     #   spead2
     #   xarray
@@ -218,7 +264,9 @@ packaging==24.2
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
+    #   astropy
     #   dask
+    #   katcbf-vlbi-resample
     #   matplotlib
     #   pytest
     #   xarray
@@ -236,6 +284,11 @@ partd==1.4.2
     #   dask
 pillow==11.1.0
     # via matplotlib
+platformdirs==4.3.6
+    # via
+    #   -c qualification/../requirements-dev.txt
+    #   -c qualification/../requirements.txt
+    #   katcbf-vlbi-resample
 pluggy==1.5.0
     # via
     #   -c qualification/../requirements-dev.txt
@@ -264,11 +317,21 @@ propcache==0.2.1
     #   -c qualification/../requirements.txt
     #   aiohttp
     #   yarl
+pyerfa==2.0.1.5
+    # via
+    #   -c qualification/../requirements-dev.txt
+    #   -c qualification/../requirements.txt
+    #   astropy
 pygelf==0.4.2
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   katsdpservices
+pygments==2.19.1
+    # via
+    #   -c qualification/../requirements-dev.txt
+    #   -c qualification/../requirements.txt
+    #   rich
 pylatex==1.4.2
     # via katgpucbf (pyproject.toml)
 pyparsing==3.2.1
@@ -305,6 +368,11 @@ python-dateutil==2.9.0.post0
     #   dateparser
     #   matplotlib
     #   pandas
+python-lzf==0.2.6
+    # via
+    #   -c qualification/../requirements-dev.txt
+    #   -c qualification/../requirements.txt
+    #   katsdptelstate
 pytz==2024.2
     # via
     #   -c qualification/../requirements-dev.txt
@@ -315,12 +383,19 @@ pyyaml==6.0.2
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
+    #   astropy
     #   dask
+rdbtools==0.1.15
+    # via
+    #   -c qualification/../requirements-dev.txt
+    #   -c qualification/../requirements.txt
+    #   katsdptelstate
 redis==5.2.1
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   katsdptelstate
+    #   rdbtools
 regex==2024.11.6
     # via dateparser
 requests==2.32.4
@@ -328,11 +403,17 @@ requests==2.32.4
     #   -c qualification/../requirements-dev.txt
     #   httmock
     #   prometheus-api-client
+rich==14.1.0
+    # via
+    #   -c qualification/../requirements-dev.txt
+    #   -c qualification/../requirements.txt
+    #   katcbf-vlbi-resample
 scipy==1.15.1
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   katgpucbf (pyproject.toml)
+    #   katcbf-vlbi-resample
     #   katsdpsigproc
 six==1.17.0
     # via
@@ -401,6 +482,7 @@ xarray==2025.1.1
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   katgpucbf (pyproject.toml)
+    #   katcbf-vlbi-resample
 yarl==1.18.3
     # via
     #   -c qualification/../requirements-dev.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -31,6 +31,15 @@ appdirs==1.4.4
     # via
     #   -c requirements.txt
     #   katsdpsigproc
+astropy==7.1.0
+    # via
+    #   -c requirements.txt
+    #   baseband
+    #   katcbf-vlbi-resample
+astropy-iers-data==0.2025.9.29.0.35.48
+    # via
+    #   -c requirements.txt
+    #   astropy
 asttokens==3.0.0
     # via stack-data
 async-solipsism==0.7
@@ -39,6 +48,10 @@ async-timeout==5.0.1
     # via
     #   -c requirements.txt
     #   aiokatcp
+atomicwrites==1.4.1
+    # via
+    #   -c requirements.txt
+    #   katcbf-vlbi-resample
 attrs==24.3.0
     # via
     #   -c requirements.txt
@@ -46,6 +59,10 @@ attrs==24.3.0
     #   aiomonitor
 babel==2.16.0
     # via sphinx
+baseband==4.3.0
+    # via
+    #   -c requirements.txt
+    #   katcbf-vlbi-resample
 certifi==2024.12.14
     # via requests
 cfgv==3.4.0
@@ -96,6 +113,10 @@ fsspec==2024.12.0
     # via
     #   -c requirements.txt
     #   dask
+h5py==3.14.0
+    # via
+    #   -c requirements.txt
+    #   katcbf-vlbi-resample
 hiredis==3.1.0
     # via
     #   -c requirements.txt
@@ -124,6 +145,10 @@ jinja2==3.1.6
     #   -c requirements.txt
     #   aiomonitor
     #   sphinx
+katcbf-vlbi-resample==0.2
+    # via
+    #   -c requirements.txt
+    #   katgpucbf (pyproject.toml)
 katcp-codec==0.2.0
     # via
     #   -c requirements.txt
@@ -140,6 +165,7 @@ katsdptelstate==0.14
     # via
     #   -c requirements.txt
     #   katgpucbf (pyproject.toml)
+    #   katcbf-vlbi-resample
 latexcodec==3.0.0
     # via pybtex
 llvmlite==0.43.0
@@ -155,6 +181,10 @@ mako==1.3.8
     #   -c requirements.txt
     #   katsdpsigproc
     #   pycuda
+markdown-it-py==4.0.0
+    # via
+    #   -c requirements.txt
+    #   rich
 markupsafe==3.0.2
     # via
     #   -c requirements.txt
@@ -162,6 +192,10 @@ markupsafe==3.0.2
     #   mako
 matplotlib-inline==0.1.7
     # via ipython
+mdurl==0.1.2
+    # via
+    #   -c requirements.txt
+    #   markdown-it-py
 msgpack==1.1.0
     # via
     #   -c requirements.txt
@@ -186,17 +220,23 @@ numpy==2.0.2
     # via
     #   -c requirements.txt
     #   katgpucbf (pyproject.toml)
+    #   astropy
+    #   h5py
+    #   katcbf-vlbi-resample
     #   katsdpsigproc
     #   katsdptelstate
     #   numba
     #   pandas
+    #   pyerfa
     #   scipy
     #   spead2
     #   xarray
 packaging==24.2
     # via
     #   -c requirements.txt
+    #   astropy
     #   dask
+    #   katcbf-vlbi-resample
     #   pytest
     #   sphinx
     #   xarray
@@ -216,6 +256,7 @@ pexpect==4.9.0
 platformdirs==4.3.6
     # via
     #   -c requirements.txt
+    #   katcbf-vlbi-resample
     #   pycuda
     #   pytools
     #   virtualenv
@@ -256,13 +297,19 @@ pycuda==2025.1.1
     # via
     #   -c requirements.txt
     #   katsdpsigproc
+pyerfa==2.0.1.5
+    # via
+    #   -c requirements.txt
+    #   astropy
 pygelf==0.4.2
     # via
     #   -c requirements.txt
     #   katsdpservices
 pygments==2.19.1
     # via
+    #   -c requirements.txt
     #   ipython
+    #   rich
     #   sphinx
 pyparsing==3.2.1
     # via
@@ -290,6 +337,10 @@ python-dateutil==2.9.0.post0
     # via
     #   -c requirements.txt
     #   pandas
+python-lzf==0.2.6
+    # via
+    #   -c requirements.txt
+    #   katsdptelstate
 pytools==2025.1.1
     # via
     #   -c requirements.txt
@@ -301,19 +352,30 @@ pytz==2024.2
 pyyaml==6.0.2
     # via
     #   -c requirements.txt
+    #   astropy
     #   dask
     #   pre-commit
     #   pybtex
+rdbtools==0.1.15
+    # via
+    #   -c requirements.txt
+    #   katsdptelstate
 redis==5.2.1
     # via
     #   -c requirements.txt
     #   katsdptelstate
+    #   rdbtools
 requests==2.32.4
     # via sphinx
+rich==14.1.0
+    # via
+    #   -c requirements.txt
+    #   katcbf-vlbi-resample
 scipy==1.15.1
     # via
     #   -c requirements.txt
     #   katgpucbf (pyproject.toml)
+    #   katcbf-vlbi-resample
     #   katsdpsigproc
 setuptools==80.9.0
     # via sphinxcontrib-bibtex
@@ -413,6 +475,7 @@ xarray==2025.1.1
     # via
     #   -c requirements.txt
     #   katgpucbf (pyproject.toml)
+    #   katcbf-vlbi-resample
 yarl==1.18.3
     # via
     #   -c requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -1,1 +1,2 @@
 psutil  # Gives more accurate dask.system.CPU_COUNT
+cupy-cuda12x  # Not listed in package metadata because CUDA version is unknown

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,12 +40,16 @@ click==8.1.8
     #   dask
 cloudpickle==3.1.1
     # via dask
+cupy-cuda12x==13.6.0
+    # via -r requirements.in
 dask==2025.3.0
     # via katgpucbf (pyproject.toml)
 decorator==5.1.1
     # via
     #   aiokatcp
     #   katsdpsigproc
+fastrlock==0.8.3
+    # via cupy-cuda12x
 frozenlist==1.5.0
     # via
     #   aiohttp
@@ -106,6 +110,7 @@ numpy==2.0.2
     # via
     #   katgpucbf (pyproject.toml)
     #   astropy
+    #   cupy-cuda12x
     #   h5py
     #   katcbf-vlbi-resample
     #   katsdpsigproc

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,12 +16,22 @@ aiosignal==1.4.0
     # via aiohttp
 appdirs==1.4.4
     # via katsdpsigproc
+astropy==7.1.0
+    # via
+    #   baseband
+    #   katcbf-vlbi-resample
+astropy-iers-data==0.2025.9.29.0.35.48
+    # via astropy
 async-timeout==5.0.1
     # via aiokatcp
+atomicwrites==1.4.1
+    # via katcbf-vlbi-resample
 attrs==24.3.0
     # via
     #   aiohttp
     #   aiomonitor
+baseband==4.3.0
+    # via katcbf-vlbi-resample
 cffi==1.17.1
     # via vkgdr
 click==8.1.8
@@ -42,6 +52,8 @@ frozenlist==1.5.0
     #   aiosignal
 fsspec==2024.12.0
     # via dask
+h5py==3.14.0
+    # via katcbf-vlbi-resample
 hiredis==3.1.0
     # via katsdptelstate
 idna==3.10
@@ -50,6 +62,8 @@ janus==2.0.0
     # via aiomonitor
 jinja2==3.1.6
     # via aiomonitor
+katcbf-vlbi-resample==0.2
+    # via katgpucbf (pyproject.toml)
 katcp-codec==0.2.0
     # via aiokatcp
 katsdpservices==1.4
@@ -57,7 +71,9 @@ katsdpservices==1.4
 katsdpsigproc==1.10.0
     # via katgpucbf (pyproject.toml)
 katsdptelstate==0.14
-    # via katgpucbf (pyproject.toml)
+    # via
+    #   katgpucbf (pyproject.toml)
+    #   katcbf-vlbi-resample
 llvmlite==0.43.0
     # via numba
 locket==1.0.0
@@ -66,10 +82,14 @@ mako==1.3.8
     # via
     #   katsdpsigproc
     #   pycuda
+markdown-it-py==4.0.0
+    # via rich
 markupsafe==3.0.2
     # via
     #   jinja2
     #   mako
+mdurl==0.1.2
+    # via markdown-it-py
 msgpack==1.1.0
     # via katsdptelstate
 multidict==6.1.0
@@ -85,16 +105,22 @@ numba==0.60.0
 numpy==2.0.2
     # via
     #   katgpucbf (pyproject.toml)
+    #   astropy
+    #   h5py
+    #   katcbf-vlbi-resample
     #   katsdpsigproc
     #   katsdptelstate
     #   numba
     #   pandas
+    #   pyerfa
     #   scipy
     #   spead2
     #   xarray
 packaging==24.2
     # via
+    #   astropy
     #   dask
+    #   katcbf-vlbi-resample
     #   xarray
 pandas==2.2.3
     # via
@@ -104,6 +130,7 @@ partd==1.4.2
     # via dask
 platformdirs==4.3.6
     # via
+    #   katcbf-vlbi-resample
     #   pycuda
     #   pytools
 prometheus-async==22.2.0
@@ -124,23 +151,38 @@ pycparser==2.22
     # via cffi
 pycuda==2025.1.1
     # via katsdpsigproc
+pyerfa==2.0.1.5
+    # via astropy
 pygelf==0.4.2
     # via katsdpservices
+pygments==2.19.1
+    # via rich
 pyparsing==3.2.1
     # via katgpucbf (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via pandas
+python-lzf==0.2.6
+    # via katsdptelstate
 pytools==2025.1.1
     # via pycuda
 pytz==2024.2
     # via pandas
 pyyaml==6.0.2
-    # via dask
-redis==5.2.1
+    # via
+    #   astropy
+    #   dask
+rdbtools==0.1.15
     # via katsdptelstate
+redis==5.2.1
+    # via
+    #   katsdptelstate
+    #   rdbtools
+rich==14.1.0
+    # via katcbf-vlbi-resample
 scipy==1.15.1
     # via
     #   katgpucbf (pyproject.toml)
+    #   katcbf-vlbi-resample
     #   katsdpsigproc
 six==1.17.0
     # via
@@ -175,6 +217,8 @@ wcwidth==0.2.13
 wrapt==1.17.2
     # via prometheus-async
 xarray==2025.1.1
-    # via katgpucbf (pyproject.toml)
+    # via
+    #   katgpucbf (pyproject.toml)
+    #   katcbf-vlbi-resample
 yarl==1.18.3
     # via aiohttp


### PR DESCRIPTION
Add katcbf-vlbi-resample as a dependency, and add cupy-cuda12x to requirements.in so that the Docker image will install that version even though it's not a hard dependency of katcbf-vlbi-resample. That also means developers will need to use CUDA 12.x (and not say 13.x) if they install requirements.txt, but for now it didn't seem worth trying to separate that out.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] (n/a) Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1692.
