### PR TITLE
Make NGC-1657 workaround work again

### DIFF
--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -82,8 +82,13 @@ pipeline {
       steps {
         // Workaround for https://github.com/JelteF/PyLaTeX/issues/391
         // See NGC-1657
-        sh 'echo "setuptools<78" > constrain-setuptools.txt'
-        sh 'PIP_CONSTRAINT="constrain-setuptools.txt qualification/requirements.txt" pip install pylatex'
+        sh 'pip install uv==0.8.24'
+        // Extract the pinned versions of pylatex and its dependencies
+        sh 'echo "pylatex" | uv pip compile - -c qualification/requirements.txt -o constrain-setuptools.txt'
+        // Pin setuptools to a version that is known to work (it still warns)
+        sh 'echo "setuptools<78" >> constrain-setuptools.txt'
+        // Using PIP_CONSTRAINT pins the version used for the build environment too
+        sh 'PIP_CONSTRAINT="constrain-setuptools.txt" pip install pylatex'
         sh 'pip install -r qualification/requirements.txt'
         sh 'pip install --no-deps ".[qualification]" && pip check'
       }


### PR DESCRIPTION
<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] If qualification tests are changed: attach a sample qualification report (still in progress: https://jenkins.cbf.kat.ac.za/job/qualification_katgpucbf_lab/261/console)
- [x] If design has changed: ensure documentation is up to date (n/a)
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1657.
