### PR TITLE
Update sim_correlator for VLBI data streams

### DIFF
--- a/scratch/sim_correlator.py
+++ b/scratch/sim_correlator.py
@@ -89,8 +89,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         type=str,
         choices=["x,y", "R,L"],
         metavar="P,P",
-        required=True,
-        help=r"Output polarisations (\"x,y\" or \"R,L\")",
+        default="x,y",
+        help='Output polarisations ("x,y" or "R,L")',
     )
     parser.add_argument(
         "--vlbi-station-id", type=str, default="me", help="VDIF Station ID for VLBI output [%(default)s]"
@@ -118,9 +118,6 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     if args.vlbi and args.narrowband_beams == 0:
         args.narrowband_beams = 1
     args.vlbi_pols = comma_split(str, 2)(args.vlbi_pols)
-    for pol in args.vlbi_pols:
-        if pol not in ["x", "y", "L", "R"]:
-            parser.error(f"{pol!r} is not a valid --vlbi-pol value")
     return args
 
 
@@ -188,7 +185,7 @@ def generate_antenna_channelised_voltage(args: argparse.Namespace, outputs: dict
             pass_bandwidth_float = float(pass_bandwidth)
             if pass_bandwidth_float != pass_bandwidth:
                 raise RuntimeError(
-                    "pass_bandwidth could not be computed precisely. Note that --vlbi is only supported for L-band"
+                    "pass_bandwidth could not be computed precisely. Note that --vlbi is only supported for L-band."
                 )
             outputs["narrow0-antenna-channelised-voltage"]["narrowband"]["vlbi"] = {
                 "pass_bandwidth": pass_bandwidth_float


### PR DESCRIPTION
This makes provision for required arguments to create a gpucbf.tied_array_resampled_voltage_stream, as per the 
product-configure schema (v4.7).

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match

Closes NGC-1754.
