### PR TITLE
Fix initial value of beam .weight sensors

### DIFF
--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -465,7 +465,7 @@ class BPipeline(Pipeline[BOutput, BOutQueueItem]):
                     f"{output.name}.weight",
                     "The summing weights applied to all the inputs of this beam",
                     # Cast to list first to add comma delimiter
-                    default=str(list(self._weights[i])),
+                    default=str(self._weights[i].tolist()),
                     initial_status=aiokatcp.Sensor.Status.NOMINAL,
                 )
             )

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -1680,3 +1680,18 @@ class TestEngine:
         # populated for the 'real' (first) index.
         for corrprod_output in corrprod_outputs:
             np.testing.assert_equal(corrprod_results[corrprod_output.name][..., 0] != 0, True)
+
+    @DEFAULT_PARAMETERS
+    async def test_initial_steering_sensors(
+        self,
+        client: aiokatcp.Client,
+        beam_outputs: list[BOutput],
+        n_ants: int,
+    ) -> None:
+        """Test that dynamic BPipeline sensors have correct initial state."""
+        for beam in beam_outputs:
+            assert (await client.sensor_value(f"{beam.name}.weight", str)) == "[" + ", ".join(["1.0"] * n_ants) + "]"
+            assert (await client.sensor_value(f"{beam.name}.quantiser-gain", float)) == 1.0
+            expected_delay = "(0" + ", 0.0, 0.0" * n_ants + ")"
+            assert (await client.sensor_value(f"{beam.name}.delay", str)) == expected_delay
+            assert (await client.sensor_value(f"{beam.name}.beng-clip-cnt", int)) == 0


### PR DESCRIPTION
While updates to the sensor were correct, the initial value had "np.float64" in the sensor value due to numpy 2.0's change to repr.

Closes NGC-1773

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
