### PR TITLE
Fix sim_correlator

### DIFF
--- a/scratch/sim_correlator.py
+++ b/scratch/sim_correlator.py
@@ -227,17 +227,18 @@ def generate_tied_array_channelised_voltage(args: argparse.Namespace, outputs: d
 
 def generate_tied_array_resampled_voltage(args: argparse.Namespace, outputs: dict) -> None:
     """Populate configuration for tied-array-resampled-voltage streams."""
-    outputs["tied-array-resampled-voltage"] = {
-        "type": "gpucbf.tied_array_resampled_voltage",
-        "src_streams": [
-            f"narrow0-tied-array-channelised-voltage-{i}{pol_name}"
-            for i in range(args.narrowband_beams)
-            for pol_name in "xy"
-        ],
-        "n_chans": 2,
-        "pols": args.vlbi_pols,
-        "station_id": args.vlbi_station_id,
-    }
+    if args.vlbi:
+        outputs["tied-array-resampled-voltage"] = {
+            "type": "gpucbf.tied_array_resampled_voltage",
+            "src_streams": [
+                f"narrow0-tied-array-channelised-voltage-{i}{pol_name}"
+                for i in range(args.narrowband_beams)
+                for pol_name in "xy"
+            ],
+            "n_chans": 2,
+            "pols": args.vlbi_pols,
+            "station_id": args.vlbi_station_id,
+        }
 
 
 def generate_sdp(args: argparse.Namespace, outputs: dict) -> None:


### PR DESCRIPTION
The addition of VLBI support broke the normal case, because it tries to add the tied-array-resampled-voltage stream even if --vlbi is not given.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
