### PR TITLE
Increase timeout for Jenkins testing of microbenchmarks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,7 +66,7 @@ pipeline {
         stage('Parallel stage') {
           parallel {
             stage('Compile and test microbenchmarks') {
-              options { timeout(time: 5, unit: 'MINUTES') }
+              options { timeout(time: 10, unit: 'MINUTES') }
               steps {
                 dir('scratch') {
                   sh 'make clean'


### PR DESCRIPTION
They shouldn't actually take long, but we're running them in parallel with pytest and that seems to slow things down a lot and they're sometimes timing out.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
