### PR TITLE
Add --power-int-time command-line argument

### DIFF
--- a/src/katgpucbf/vgpu/engine.py
+++ b/src/katgpucbf/vgpu/engine.py
@@ -61,6 +61,7 @@ class VEngine(Engine):
         recv_buffer: int,
         recv_pols: tuple[str, str],
         send_pols: tuple[str, str],
+        power_int_time: int,
         monitor: Monitor,
     ) -> None:
         super().__init__(katcp_host, katcp_port)

--- a/src/katgpucbf/vgpu/main.py
+++ b/src/katgpucbf/vgpu/main.py
@@ -123,6 +123,13 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         metavar="SIGMA",
         help="Threshold (in σ) between quantisation levels [%(default)s]",
     )
+    parser.add_argument(
+        "--power-int-time",
+        type=int,
+        default=1,
+        metavar="SECONDS",
+        help="Time (in seconds) over which to normalise power [%(default)s]",
+    )
     parser.add_argument("--monitor-log", help="File to write performance-monitoring data to")
     parser.add_argument("src", type=parse_source_ipv4, nargs=2, help="Source endpoints")
     parser.add_argument("dst", type=endpoint_list_parser(VTP_DEFAULT_PORT), help="Destination endpoints")
@@ -176,6 +183,7 @@ def make_engine(args: argparse.Namespace) -> VEngine:
         recv_buffer=args.recv_buffer,
         recv_pols=tuple(args.recv_pols),
         send_pols=tuple(args.send_pols),
+        power_int_time=args.power_int_time,
         monitor=monitor,
     )
 


### PR DESCRIPTION
It doesn't do anything yet, but it is accepted.

Closes NGC-1812.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
