### PR TITLE
Update uv and ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: no-commit-to-branch # without arguments, master/main will be protected.
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.2
+    rev: v0.14.4
     hooks:
       - id: ruff-format
         types_or: [python, pyi]  # Prevent formatting notebooks
@@ -53,7 +53,7 @@ repos:
             'typing-extensions==4.15.0',
         ]
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.9.5
+    rev: 0.9.8
     hooks:
       - id: pip-compile
         name: pip-compile requirements.txt

--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -82,7 +82,7 @@ pipeline {
       steps {
         // Workaround for https://github.com/JelteF/PyLaTeX/issues/391
         // See NGC-1657
-        sh 'pip install uv==0.9.6'
+        sh 'pip install uv==0.9.8'
         // Extract the pinned versions of pylatex and its dependencies
         sh 'echo "pylatex" | uv pip compile - -c qualification/requirements.txt -o constrain-setuptools.txt'
         // Pin setuptools to a version that is known to work (it still warns)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -435,7 +435,7 @@ tzdata==2025.2
     #   pandas
 urllib3==2.5.0
     # via requests
-uv==0.9.6
+uv==0.9.8
     # via -r requirements-dev.in
 virtualenv==20.34.0
     # via pre-commit


### PR DESCRIPTION
1d1d6ed2e5240fcb57bc633dc9039387b9aec4a8 upgraded uv to 0.9.6, but missed upgrading uv-pre-commit to match. So now upgrade both to the latest. I used 'pre-commit autoupdate', which also pulled in an update to ruff.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] (n/a) Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
