### PR TITLE
Remove rate limit from <tacv-stream>.weight sensor

### DIFF
--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -460,7 +460,7 @@ class BPipeline(Pipeline[BOutput, BOutQueueItem]):
                 )
             )
             sensors.add(
-                make_rate_limited_sensor(
+                aiokatcp.Sensor(
                     str,
                     f"{output.name}.weight",
                     "The summing weights applied to all the inputs of this beam",


### PR DESCRIPTION
For some reason it was being created with make_rate_limited_sensor. It is only updated in response to a katcp request, so there is no particular reason to rate-limit it.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`
- [x] (n/a) If modules are added/removed: use `sphinx-apidoc -efo doc/ src/` to update files in `doc/`
- [x] Ensure copyright notices are present and up-to-date
- [x] (n/a) If qualification tests are changed: attach a sample qualification report
- [x] (n/a) If design has changed: ensure documentation is up to date
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match
