### PR TITLE
Dockerfile: don't use --link for copying schedrr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -182,7 +182,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
 
 ENV PATH=/venv/bin:$PATH KATSDPSIGPROC_TUNE_MATCH=nearest
 
-COPY --link --from=build-c /tmp/tools/schedrr /usr/local/bin
+COPY --from=build-c /tmp/tools/schedrr /usr/local/bin
 RUN setcap cap_sys_nice+ep /usr/local/bin/schedrr
 COPY --link --from=build-py-requirements /venv /venv
 COPY --link docker/tuning.db /root/.cache/katsdpsigproc/tuning.db


### PR DESCRIPTION
For reasons I haven't investigated (possibly it being run with a newer Docker version), it lead to an error message when trying to run setcap against it.
