### PR TITLE
Remove 'aiohttp' extra from prometheus_async dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Astronomy",
 ]
 dependencies = [
+    "aiohttp",  # Needed for prometheus-async to serve metrics
     "aiokatcp>=1.9.0",
     "astropy",
     "dask",
@@ -29,7 +30,7 @@ dependencies = [
     "katsdptelstate",
     "numba",
     "numpy",
-    "prometheus-async[aiohttp]",
+    "prometheus-async",
     "prometheus-client>=0.4",  # First version to auto-append _total to counter names
     "pyparsing>=3.0.0",
     "scipy",

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -14,8 +14,8 @@ aiohttp==3.13.4
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
+    #   katgpucbf (pyproject.toml)
     #   aiomonitor
-    #   prometheus-async
 aiokatcp==2.2.0
     # via
     #   -c qualification/../requirements-dev.txt
@@ -269,7 +269,7 @@ pluggy==1.6.0
     #   pytest
 prometheus-api-client==0.7.0
     # via katgpucbf (pyproject.toml)
-prometheus-async==25.1.0
+prometheus-async==26.1.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,8 +11,8 @@ aiohappyeyeballs==2.6.1
 aiohttp==3.13.4
     # via
     #   -c requirements.txt
+    #   katgpucbf (pyproject.toml)
     #   aiomonitor
-    #   prometheus-async
 aiokatcp==2.2.0
     # via
     #   -c requirements.txt
@@ -260,7 +260,7 @@ pluggy==1.6.0
     #   pytest-cov
 pre-commit==4.5.1
     # via -r requirements-dev.in
-prometheus-async==25.1.0
+prometheus-async==26.1.0
     # via
     #   -c requirements.txt
     #   katgpucbf (pyproject.toml)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@ aiohappyeyeballs==2.6.1
     # via aiohttp
 aiohttp==3.13.4
     # via
+    #   katgpucbf (pyproject.toml)
     #   aiomonitor
-    #   prometheus-async
 aiokatcp==2.2.0
     # via katgpucbf (pyproject.toml)
 aiomonitor==0.7.1
@@ -124,7 +124,7 @@ platformdirs==4.5.1
     # via
     #   pycuda
     #   pytools
-prometheus-async==25.1.0
+prometheus-async==26.1.0
     # via katgpucbf (pyproject.toml)
 prometheus-client==0.24.0
     # via


### PR DESCRIPTION
The latest version (which we're also upgrading to) no longer provides this as an extra, which was causing uv to issue warnings in a downstream project that depended on katgpucbf. So we just explicitly list aiohttp as a dependency instead of using the extra.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`.
- [x] (n/a) If new source files are added: add copyright notices dated with the current year.
- [x] (n/a) If qualification tests are changed: attach or link to a sample qualification report.
- [x] (n/a) If design has changed: ensure documentation is up to date.
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match.
- [x] (n/a) If the interface between the product controller and an engine has changed, update the
      VERSION constant for the engine (update the major number if sensors/requests have been
      removed/changed, minor number if only backwards-compatible changes have been done).
      Also, update doc/control.rst with the new version.
