### PR TITLE
Fix too-low startup time in benchmark_xbgpu

### DIFF
--- a/scratch/benchmarks/benchmark_tools.py
+++ b/scratch/benchmarks/benchmark_tools.py
@@ -124,7 +124,7 @@ def add_common_benchmark_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--startup-time",
         type=float,
-        default=1.0,
+        default=2.0,
         metavar="SECONDS",
         help="Time to run before starting measurement [%(default)s]",
     )

--- a/scratch/benchmarks/benchmark_xbgpu.py
+++ b/scratch/benchmarks/benchmark_xbgpu.py
@@ -147,7 +147,7 @@ class XbgpuBenchmark(Benchmark):
         batches_per_chunk = math.ceil(max(128 / info.spectra_per_heap, target_chunk_size / batch_size))
 
         # At low adc_sample_rates, the reordering buffer can take a long time
-        # to fill and add latency. If the latency is too large it can causes
+        # to fill, and adds latency. If the latency is too large it can cause
         # packets that were lost during startup to only show up after the
         # startup_time has passed. Limit this latency to 1/4 of startup time.
         max_recv_reorder_tol = int(adc_sample_rate * self.args.startup_time / 4)

--- a/scratch/benchmarks/benchmark_xbgpu.py
+++ b/scratch/benchmarks/benchmark_xbgpu.py
@@ -31,6 +31,7 @@ from itertools import chain
 from typing import override
 
 from katgpucbf import COMPLEX, N_POLS
+from katgpucbf.xbgpu import DEFAULT_RECV_REORDER_TOL
 
 from benchmark_tools import (
     PROMETHEUS_PORT_BASE,
@@ -145,6 +146,13 @@ class XbgpuBenchmark(Benchmark):
         target_chunk_size = 64 * 1024**2
         batches_per_chunk = math.ceil(max(128 / info.spectra_per_heap, target_chunk_size / batch_size))
 
+        # At low adc_sample_rates, the reordering buffer can take a long time
+        # to fill and add latency. If the latency is too large it can causes
+        # packets that were lost during startup to only show up after the
+        # startup_time has passed. Limit this latency to 1/4 of startup time.
+        max_recv_reorder_tol = int(adc_sample_rate * self.args.startup_time / 4)
+        recv_reorder_tol = min(max_recv_reorder_tol, DEFAULT_RECV_REORDER_TOL)
+
         command = (
             "docker run "
             "--stop-timeout=2 "
@@ -166,7 +174,8 @@ class XbgpuBenchmark(Benchmark):
             f"--recv-affinity={cores[0]} "
             f"--recv-comp-vector={cores[0]} "
             f"--recv-interface={interface} "
-            f"--recv-ibv "
+            "--recv-ibv "
+            f"--recv-reorder-tol={recv_reorder_tol} "
             f"--send-affinity={cores[1]} "
             f"--send-comp-vector={cores[1]} "
             f"--send-interface={interface} "

--- a/src/katgpucbf/xbgpu/__init__.py
+++ b/src/katgpucbf/xbgpu/__init__.py
@@ -26,3 +26,5 @@ DEFAULT_BPIPELINE_NAME: Final = "bpipeline"
 # NOTE: Too high means too much GPU memory gets allocated
 DEFAULT_N_IN_ITEMS: Final = 3
 DEFAULT_N_OUT_ITEMS: Final = 2
+
+DEFAULT_RECV_REORDER_TOL: Final = 2**29  #: Default value of --recv-reorder-tol argument

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -61,6 +61,7 @@ from ..mapped_array import make_vkgdr
 from ..monitor import FileMonitor, Monitor, NullMonitor
 from ..spead import DEFAULT_PORT
 from ..utils import DitherType
+from . import DEFAULT_RECV_REORDER_TOL
 from .correlation import device_filter
 from .output import BOutput, XOutput
 
@@ -198,7 +199,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--recv-reorder-tol",
         type=int,
-        default=2**29,
+        default=DEFAULT_RECV_REORDER_TOL,
         help="Maximum time (in ADC ticks) that packets can be delayed relative to others "
         "and still be accepted. [%(default)s]",
     )


### PR DESCRIPTION
- Increase default --startup-time to 2 seconds.
- For low ADC rates (below about 1 Gsps), reduce the --recv-reorder-tol for xbgpu to reduce latency and hence the time taken for the first (usually incomplete) heaps to exit the spead2 pipeline.

Relates to NGC-1945.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`.
- [x] (n/a) If new source files are added: add copyright notices dated with the current year.
- [x] (n/a) If qualification tests are changed: attach or link to a sample qualification report.
- [x] (n/a) If design has changed: ensure documentation is up to date.
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match.
- [x] (n/a) If the interface between the product controller and an engine has changed, update the
      VERSION constant for the engine (update the major number if sensors/requests have been
      removed/changed, minor number if only backwards-compatible changes have been done).
      Also, update doc/control.rst with the new version.
