### PR TITLE
benchmark_xbgpu: use deque instead of chains of iterators

### DIFF
--- a/scratch/benchmarks/benchmark_fgpu.py
+++ b/scratch/benchmarks/benchmark_fgpu.py
@@ -77,7 +77,7 @@ class FgpuBenchmark(Benchmark):
     ) -> str:
         """Generate command to run dsim.
 
-        The multicast address(es) used for the dsims are appended to `self.dsim_addresses`.
+        The multicast address(es) used for the dsims are appended to `self.dsim_addresses_queue`.
         """
         # Use as many CPUs as we can to speed up startup. We need at least 3
         # (main thread, network thread and worker thread).

--- a/scratch/benchmarks/benchmark_xbgpu.py
+++ b/scratch/benchmarks/benchmark_xbgpu.py
@@ -25,9 +25,8 @@ import argparse
 import asyncio
 import functools
 import math
-from collections.abc import Iterator
+from collections import deque
 from contextlib import AsyncExitStack
-from itertools import chain
 from typing import override
 
 from katgpucbf import COMPLEX, N_POLS
@@ -61,7 +60,7 @@ class XbgpuBenchmark(Benchmark):
         samples_between_spectra = 2 * args.channels * args.narrowband_decimation
         spectra_per_heap = args.jones_per_batch // args.channels
         heap_samples = samples_between_spectra * spectra_per_heap
-        self.fsim_addresses: Iterator[str] = iter([])
+        self.fsim_addresses_queue: deque[str] = deque()
         super().__init__(
             args,
             generator_server=servers[args.fsim_server],
@@ -90,7 +89,7 @@ class XbgpuBenchmark(Benchmark):
         name = f"fsim-{index}"
         info = StreamInfo(self.args, adc_sample_rate)
         address = self.multicast_allocator()
-        self.fsim_addresses = chain(self.fsim_addresses, iter([address]))
+        self.fsim_addresses_queue.append(address)
         command = (
             "docker run --init "  # --init is needed because fsim doesn't catch SIGTERM itself
             f"--name={name} --cap-add=SYS_NICE --net=host --stop-timeout=2 "
@@ -181,7 +180,7 @@ class XbgpuBenchmark(Benchmark):
             f"--send-interface={interface} "
             f"--send-ibv "
             f"--send-enabled "
-            f"{next(self.fsim_addresses)}:7148 "
+            f"{self.fsim_addresses_queue.popleft()}:7148 "
         )
         for i in range(self.args.beams):
             for j in range(N_POLS):
@@ -198,7 +197,7 @@ class XbgpuBenchmark(Benchmark):
     @override
     def reset(self) -> None:
         super().reset()
-        self.fsim_addresses = iter([])
+        self.fsim_addresses_queue = deque()
 
     @override
     async def run_producers(self, adc_sample_rate: float, sync_time: int) -> AsyncExitStack:


### PR DESCRIPTION
This change was done for benchmark_fgpu as part of #1026, but it was missed for benchmark_xbgpu.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`.
- [x] (n/a) If new source files are added: add copyright notices dated with the current year.
- [x] (n/a) If qualification tests are changed: attach or link to a sample qualification report.
- [x] (n/a) If design has changed: ensure documentation is up to date.
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match.
- [x] (n/a) If the interface between the product controller and an engine has changed, update the
      VERSION constant for the engine (update the major number if sensors/requests have been
      removed/changed, minor number if only backwards-compatible changes have been done).
      Also, update doc/control.rst with the new version.
