### PR TITLE
Make test_group_delay a bit more relaxed

### DIFF
--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -801,7 +801,7 @@ async def test_group_delay(
     delay2, period2, std2 = await measure_once((-steps * dsim_resolution, steps * dsim_resolution))
 
     pdf_report.step("Analyse results.")
-    assert 6 * std1 < period2  # Ensure the first test localised things sufficiently
+    assert tolerance * std1 < period2  # Ensure the first test localised things sufficiently
     # Solve (approximately) delay1 = delay2 + k * period2
     k = round((delay1 - delay2) / period2)
     delay = delay2 + k * period2

--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -624,6 +624,10 @@ async def test_group_delay(
     """
     receiver = receive_tied_array_channelised_voltage
     pcc = cbf.product_controller_client
+    # Nominally in sigma, but the test has lots of non-Gaussian things going on,
+    # channel leakages and so, so the measured value tends to exceeed 5 sigma
+    # every now and then.
+    tolerance = 7.0
 
     pdf_report.step("Choose channels.")
     # In VLBI mode we don't have a PFB, and there is too much leakage
@@ -797,7 +801,7 @@ async def test_group_delay(
     delay2, period2, std2 = await measure_once((-steps * dsim_resolution, steps * dsim_resolution))
 
     pdf_report.step("Analyse results.")
-    assert 5 * std1 < period2  # Ensure the first test localised things sufficiently
+    assert 6 * std1 < period2  # Ensure the first test localised things sufficiently
     # Solve (approximately) delay1 = delay2 + k * period2
     k = round((delay1 - delay2) / period2)
     delay = delay2 + k * period2
@@ -808,5 +812,5 @@ async def test_group_delay(
 
     reported_delay = await pcc.sensor_value("antenna-channelised-voltage.filter-group-delay", float)
     pdf_report.detail(f"Reported delay is {reported_delay}.")
-    assert abs(reported_delay - delay) < 5 * std
-    pdf_report.detail("Measured value agrees with reported value to within 5 sigma.")
+    assert abs(reported_delay - delay) < tolerance * std
+    pdf_report.detail(f"Measured value agrees with reported value to within {tolerance} sigma.")


### PR DESCRIPTION
The tolerance in the test was set to 5 sigma, which sounds like a lot but there are various biases that seem to act to pull things out of whack occasionally. Relax it to 7 sigma to hopefully reduce the noise from false negatives.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`.
- [x] (n/a) If new source files are added: add copyright notices dated with the current year.
- [x] If qualification tests are changed: attach or link to a sample qualification report: https://jenkins.cbf.kat.ac.za/job/qualification_katgpucbf_lab/478/ (some configs failed with lack of resources due to concurrent use of the lab)
- [x] (n/a) If design has changed: ensure documentation is up to date.
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match.
- [x] (n/a) If the interface between the product controller and an engine has changed, update the
      VERSION constant for the engine (update the major number if sensors/requests have been
      removed/changed, minor number if only backwards-compatible changes have been done).
      Also, update doc/control.rst with the new version.
