### PR TITLE
NGC-1871 pip constraint is deprecated

### DIFF
--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021-2025, National Research Foundation (SARAO)
+ * Copyright (c) 2021-2026, National Research Foundation (SARAO)
  *
  * Licensed under the BSD 3-Clause License (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy

--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -87,8 +87,7 @@ pipeline {
         sh 'echo "pylatex" | uv pip compile - -c qualification/requirements.txt -o constrain-setuptools.txt'
         // Pin setuptools to a version that is known to work (it still warns)
         sh 'echo "setuptools<78" >> constrain-setuptools.txt'
-        // Using PIP_CONSTRAINT pins the version used for the build environment too
-        sh 'PIP_CONSTRAINT="constrain-setuptools.txt" pip install pylatex'
+        sh 'pip install --build-constraint constrain-setuptools.txt pylatex'
         sh 'pip install -r qualification/requirements.txt'
         sh 'pip install --no-deps ".[qualification]" && pip check'
       }

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -424,7 +424,7 @@ tzdata==2025.3
     #   pandas
 tzlocal==5.3.1
     # via dateparser
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -477,7 +477,7 @@ tzdata==2025.3
     # via
     #   -c requirements.txt
     #   pandas
-urllib3==2.6.3
+urllib3==2.7.0
     # via requests
 uv==0.11.6
     # via -r requirements-dev.in


### PR DESCRIPTION
qualification/Jenkinsfile currently uses the PIP_CONSTRAINT environment variable, but it’s deprecated as of pip 25.3 ([Changelog - pip documentation v26.1](https://pip.pypa.io/en/stable/news/#v25-3) ). 

It is updated by passing --build-constraint on the command-line.
