### PR TITLE
Improve vgpu end-to-end unit testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,9 @@ doc = [
 ]
 
 test = [
-    "katsdpsigproc[CUDA]",
     "async-solipsism>=0.6",
+    "baseband",
+    "katsdpsigproc[CUDA]",
     "matplotlib",
     "pytest>=8",
     "pytest-asyncio>=0.24",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,6 +35,7 @@ astropy==7.2.0
     # via
     #   -c requirements.txt
     #   katgpucbf (pyproject.toml)
+    #   baseband
     #   katcbf-vlbi-resample
 astropy-iers-data==0.2026.1.12.0.42.13
     # via
@@ -57,6 +58,8 @@ attrs==25.4.0
     #   aiomonitor
 babel==2.17.0
     # via sphinx
+baseband==4.3.0
+    # via katgpucbf (pyproject.toml)
 certifi==2026.1.4
     # via requests
 cffi==2.0.0

--- a/src/katgpucbf/vgpu/engine.py
+++ b/src/katgpucbf/vgpu/engine.py
@@ -124,6 +124,7 @@ class RecvStream:
                     zero_arr.attrs["time_bias"] = timestamp // self._samples_between_spectra
                     yield zero_arr
                 last_chunk_id = chunk.chunk_id
+                print(chunk.timestamp)
                 yield arr
 
 

--- a/src/katgpucbf/vgpu/engine.py
+++ b/src/katgpucbf/vgpu/engine.py
@@ -315,6 +315,7 @@ class _CaptureSession:
         )
         async for frameset in frameset_it:
             await self._sender.send(frameset)
+        await self._sender.flush()
         self._capture_complete()
 
     async def stop(self) -> None:

--- a/src/katgpucbf/vgpu/engine.py
+++ b/src/katgpucbf/vgpu/engine.py
@@ -124,7 +124,6 @@ class RecvStream:
                     zero_arr.attrs["time_bias"] = timestamp // self._samples_between_spectra
                     yield zero_arr
                 last_chunk_id = chunk.chunk_id
-                print(chunk.timestamp)
                 yield arr
 
 

--- a/src/katgpucbf/vgpu/send.py
+++ b/src/katgpucbf/vgpu/send.py
@@ -72,7 +72,7 @@ class RateLimiter[T](ABC):
         self._per_unit = 1 / rate if rate else 0.0
         # Seconds per unit for `burst_rate`
         self._per_unit_burst = 1 / burst_rate if burst_rate else 0.0
-        self._queue: asyncio.Queue[T | None] = asyncio.Queue(capacity)
+        self._queue: asyncio.Queue[T | asyncio.Future[None] | None] = asyncio.Queue(capacity)
         self._run_task: asyncio.Task = asyncio.create_task(self._run(), name="RateLimiter")
 
     @abstractmethod
@@ -96,6 +96,10 @@ class RateLimiter[T](ABC):
             item = await self._queue.get()
             if item is None:
                 break
+            elif isinstance(item, asyncio.Future):
+                if not item.done():
+                    item.set_result(None)
+                continue
 
             now = loop.time()
             target = max(self._next, self._next_burst)
@@ -130,8 +134,18 @@ class RateLimiter[T](ABC):
             self._next = max(self._next, now)
             self._next_burst = max(self._next_burst, now)
 
-    async def stop(self) -> None:
+    async def flush(self) -> None:
         """Wait until all queued items have been processed."""
+        future = asyncio.Future[None]()
+        await self._queue.put(future)
+        await future
+
+    async def stop(self) -> None:
+        """Shut down the rate limiter.
+
+        This blocks until all queued items have been processed. No other
+        methods should be called after this one, as they may deadlock.
+        """
         if not self._run_task.done():
             await self._queue.put(None)  # Signals run task to stop
         await self._run_task

--- a/src/katgpucbf/vgpu/send.py
+++ b/src/katgpucbf/vgpu/send.py
@@ -72,6 +72,11 @@ class RateLimiter[T](ABC):
         self._per_unit = 1 / rate if rate else 0.0
         # Seconds per unit for `burst_rate`
         self._per_unit_burst = 1 / burst_rate if burst_rate else 0.0
+        # Each item in the queue is either:
+        # - an item to send;
+        # - a future corresponding to a call to `flush`, which will be completed
+        #   once it reaches the front of the queue; or
+        # - None to indicate that `stop` has been called and that `_run` should shut down.
         self._queue: asyncio.Queue[T | asyncio.Future[None] | None] = asyncio.Queue(capacity)
         self._run_task: asyncio.Task = asyncio.create_task(self._run(), name="RateLimiter")
 

--- a/test/vgpu/conftest.py
+++ b/test/vgpu/conftest.py
@@ -16,7 +16,8 @@
 
 """Fixtures for use in vgpu unit tests."""
 
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Buffer, Iterable
+from typing import Any
 
 import pytest
 import spead2
@@ -41,3 +42,21 @@ async def engine(
     await server.start()
     yield server
     await server.stop()
+
+
+@pytest.fixture
+def mock_sendmsg(monkeypatch: pytest.MonkeyPatch) -> list[bytes]:
+    """Mock out socket.sendmsg to append packets to a list.
+
+    This does not capture all features of sendmsg; it is intended only
+    for use with :mod:`katgpucbf.vgpu.send`.
+    """
+
+    def my_sendmsg(self, buffers: Iterable[Buffer], ancdata: Iterable, flags: int = 0, address: Any = None) -> int:
+        packet = b"".join(buffers)
+        packets.append(packet)
+        return len(packet)
+
+    packets: list[bytes] = []
+    monkeypatch.setattr("socket.socket.sendmsg", my_sendmsg)
+    return packets

--- a/test/vgpu/conftest.py
+++ b/test/vgpu/conftest.py
@@ -45,9 +45,10 @@ async def engine(
 
 
 @pytest.fixture
-def mock_sendmsg(monkeypatch: pytest.MonkeyPatch) -> list[bytes]:
+def sendmsg_packets(monkeypatch: pytest.MonkeyPatch) -> list[bytes]:
     """Mock out socket.sendmsg to append packets to a list.
 
+    The value of this fixture is the list to which packets are appended.
     This does not capture all features of sendmsg; it is intended only
     for use with :mod:`katgpucbf.vgpu.send`.
     """

--- a/test/vgpu/test_engine.py
+++ b/test/vgpu/test_engine.py
@@ -17,12 +17,18 @@
 """Unit tests for :mod:`katgpucbf.vgpu.engine`."""
 
 import asyncio
+import io
+import math
+import struct
 from typing import Final
 
 import aiokatcp
+import astropy.units as u
 import numpy as np
 import pytest
 import spead2.send.asyncio
+from astropy.time import Time
+from baseband.vdif import VDIFFrame
 
 from katgpucbf import COMPLEX, N_POLS
 from katgpucbf.utils import TimeConverter
@@ -44,7 +50,9 @@ NB_DECIMATION: Final = 8
 SEND_BANDWIDTH: Final = 64e3
 FIR_TAPS: Final = 7201
 STATION: Final = "me"
-FIRST_TIMESTAMP = 0x30000000  # must be a multiple of chunk_timestamp_step
+SAMPLES_PER_FRAME: Final = 4000  # Reduced to keep the tests small
+FIRST_TIMESTAMP: Final = 0x30000000  # must be a multiple of chunk_timestamp_step
+N_THREADS: Final = 4
 
 
 @pytest.fixture
@@ -57,12 +65,12 @@ def _make_beng(queues: list[spead2.InprocQueue]) -> "spead2.send.asyncio.AsyncSt
     return spead2.send.asyncio.InprocStream(spead2.ThreadPool(), queues, config)
 
 
-async def _send_data(layout: Layout, mock_recv_streams: list[spead2.InprocQueue]) -> None:
+async def _send_data(layout: Layout, chunks: int, mock_recv_streams: list[spead2.InprocQueue]) -> None:
     """Send data to the engine."""
     assert FIRST_TIMESTAMP % layout.chunk_timestamp_step == 0
     beng = _make_beng(mock_recv_streams)
     data = np.zeros(
-        (N_POLS, 4 * layout.n_batches_per_chunk, layout.n_channels, layout.n_spectra_per_heap, COMPLEX), np.int8
+        (N_POLS, chunks * layout.n_batches_per_chunk, layout.n_channels, layout.n_spectra_per_heap, COMPLEX), np.int8
     )
     for heap in gen_heaps(layout, data, FIRST_TIMESTAMP):
         await beng.async_send_heap(heap.heap, substream_index=heap.substream_index)
@@ -112,7 +120,7 @@ class TestVEngine:
             f"--send-bandwidth={SEND_BANDWIDTH}",
             "--send-pols=x,y",
             f"--send-station={STATION}",
-            "--send-samples-per-frame=4000",  # Reduced to keep the test small
+            f"--send-samples-per-frame={SAMPLES_PER_FRAME}",
             f"--fir-taps={FIR_TAPS}",
             f"--adc-sample-rate={ADC_SAMPLE_RATE}",
             f"--sync-time={SYNC_TIME}",
@@ -127,7 +135,7 @@ class TestVEngine:
         engine: VEngine,
         engine_client: aiokatcp.Client,
         mock_recv_streams: list[spead2.InprocQueue],
-        frameset_count: list[int],
+        mock_sendmsg: list[bytes],
         capture_complete_event: asyncio.Event,
     ) -> None:
         """Test that an engine can be started and receives some data.
@@ -135,13 +143,48 @@ class TestVEngine:
         This is a weak test that will need to be filled out later to ensure
         that the framesets contain the right headers and data.
         """
+        chunks = 4
         await engine_client.request("capture-start", 0)
-        await _send_data(engine.config.recv_config.layout, mock_recv_streams)
+        await _send_data(engine.config.recv_config.layout, chunks, mock_recv_streams)
         for queue in mock_recv_streams:
             queue.stop()
         await capture_complete_event.wait()
-        assert frameset_count[0] > 0
         await engine_client.request("capture-stop")
+        frame_rate = round(SEND_BANDWIDTH / SAMPLES_PER_FRAME) * u.Hz
+        # The pipeline rounds things to a 1s boundary, so we should see the
+        # data start at the next second boundary after FIRST_TIMESTAMP. Note
+        # that this only holds if FIRST_TIMESTAMP is not too close to a 1s
+        # boundary, because the filters have a group delay that is compensated
+        # for.
+        start_time_unix = math.ceil(TIME_CONVERTER.adc_to_unix(FIRST_TIMESTAMP))
+        start_time = Time(start_time_unix, format="unix")
+        # The first second of data is incomplete because of the footprint of the
+        # filters. We then align the start to a second boundary, so we expect
+        # data to start 1s after SYNC_TIME.
+        for i, packet in enumerate(mock_sendmsg):
+            assert len(packet) > 40  # Must have at least 8-byte VTP header and 32-byte VDIF header
+            fh = io.BytesIO(packet)
+            seq = struct.unpack("<Q", fh.read(8))[0]
+            frame = VDIFFrame.fromfile(fh)
+            header = frame.header
+            frame_time = frame.get_time(frame_rate=frame_rate)
+            expected_time = start_time + i // N_THREADS / frame_rate
+            assert seq == i
+            assert not header.complex_data
+            assert not header["invalid_data"]
+            assert header.bps == 2
+            assert header.nchan == 1
+            assert header.samples_per_frame == SAMPLES_PER_FRAME
+            assert header.station == STATION
+            assert header["thread_id"] == i % N_THREADS
+            assert (frame_time - expected_time).sec == pytest.approx(0, abs=1e-9)
+        data_timestamps = engine.config.recv_config.layout.chunk_timestamp_step * chunks
+        # Again, this calculation only works if the exact value is
+        # sufficiently far from a 1s boundary that the filter footprint
+        # doesn't mess things up.
+        stop_time_unix = math.floor(TIME_CONVERTER.adc_to_unix(FIRST_TIMESTAMP + data_timestamps))
+        assert stop_time_unix > start_time_unix, "Test did not send enough data to produce output"
+        assert len(mock_sendmsg) == (stop_time_unix - start_time_unix) * frame_rate.value * N_THREADS
 
     async def test_min_timestamp(
         self,
@@ -156,8 +199,9 @@ class TestVEngine:
         # min_timestamp and checks that no data gets through. Once we have
         # more precise tests that model the delays involved, this should be
         # improved.
+        chunks = 4
         await engine_client.request("capture-start", 0xF00000000000)
-        await _send_data(engine.config.recv_config.layout, mock_recv_streams)
+        await _send_data(engine.config.recv_config.layout, chunks, mock_recv_streams)
         for queue in mock_recv_streams:
             queue.stop()
         await capture_complete_event.wait()

--- a/test/vgpu/test_engine.py
+++ b/test/vgpu/test_engine.py
@@ -140,13 +140,14 @@ class TestVEngine:
         engine: VEngine,
         engine_client: aiokatcp.Client,
         mock_recv_streams: list[spead2.InprocQueue],
-        mock_sendmsg: list[bytes],
+        sendmsg_packets: list[bytes],
         capture_complete_event: asyncio.Event,
         min_timestamp: int,
     ) -> None:
-        """Test that an engine can be started and receives some data.
+        """Test that an engine can be started, receives and transmits some data.
 
-        This is a weak test that considers only the headers and not the data.
+        This is a weak test that considers only the VDIF headers of the output
+        and not the payload.
         """
         assert min_timestamp % engine.config.recv_config.layout.chunk_timestamp_step == 0, (
             "min_timestamp is not on a chunk boundary"
@@ -170,7 +171,7 @@ class TestVEngine:
         # The first second of data is incomplete because of the footprint of the
         # filters. We then align the start to a second boundary, so we expect
         # data to start 1s after SYNC_TIME.
-        for i, packet in enumerate(mock_sendmsg):
+        for i, packet in enumerate(sendmsg_packets):
             assert len(packet) > 40  # Must have at least 8-byte VTP header and 32-byte VDIF header
             fh = io.BytesIO(packet)
             seq = struct.unpack("<Q", fh.read(8))[0]
@@ -193,7 +194,7 @@ class TestVEngine:
         # doesn't mess things up.
         stop_time_unix = math.floor(TIME_CONVERTER.adc_to_unix(FIRST_TIMESTAMP + data_timestamps))
         assert stop_time_unix > start_time_unix, "Test did not send enough data to produce output"
-        assert len(mock_sendmsg) == (stop_time_unix - start_time_unix) * frame_rate.value * N_THREADS
+        assert len(sendmsg_packets) == (stop_time_unix - start_time_unix) * frame_rate.value * N_THREADS
 
     async def test_capture_start_while_capturing(self, engine_client: aiokatcp.Client) -> None:
         """Test that ``?capture-start`` while already capturing fails."""

--- a/test/vgpu/test_engine.py
+++ b/test/vgpu/test_engine.py
@@ -20,6 +20,7 @@ import asyncio
 import io
 import math
 import struct
+from collections.abc import Callable
 from typing import Final
 
 import aiokatcp
@@ -43,7 +44,7 @@ from .test_recv import gen_heaps
 ADC_SAMPLE_RATE: Final = 1712e3
 SYNC_TIME: Final = 1234567890
 TIME_CONVERTER: Final = TimeConverter(SYNC_TIME, ADC_SAMPLE_RATE)
-RECV_CHANNELS: Final = 32768
+RECV_CHANNELS: Final = 1024
 RECV_SUBSTREAMS = 4
 RECV_CHANNELS_PER_SUBSTREAM: Final = RECV_CHANNELS // RECV_SUBSTREAMS
 NB_DECIMATION: Final = 8
@@ -65,13 +66,24 @@ def _make_beng(queues: list[spead2.InprocQueue]) -> "spead2.send.asyncio.AsyncSt
     return spead2.send.asyncio.InprocStream(spead2.ThreadPool(), queues, config)
 
 
-async def _send_data(layout: Layout, chunks: int, mock_recv_streams: list[spead2.InprocQueue]) -> None:
-    """Send data to the engine."""
+async def _send_data(
+    layout: Layout,
+    chunks: int,
+    mock_recv_streams: list[spead2.InprocQueue],
+    factory: Callable[[np.ndarray], None] | None = None,
+) -> None:
+    """Send data to the engine.
+
+    If `factory` is given, it is passed the data and should fill in the values. If not
+    given, zeros are sent.
+    """
     assert FIRST_TIMESTAMP % layout.chunk_timestamp_step == 0
     beng = _make_beng(mock_recv_streams)
     data = np.zeros(
         (N_POLS, chunks * layout.n_batches_per_chunk, layout.n_channels, layout.n_spectra_per_heap, COMPLEX), np.int8
     )
+    if factory is not None:
+        factory(data)
     for heap in gen_heaps(layout, data, FIRST_TIMESTAMP):
         await beng.async_send_heap(heap.heap, substream_index=heap.substream_index)
 
@@ -116,6 +128,8 @@ class TestVEngine:
             f"--recv-channels={RECV_CHANNELS}",
             f"--recv-channels-per-substream={RECV_CHANNELS_PER_SUBSTREAM}",
             f"--recv-samples-between-spectra={NB_DECIMATION * RECV_CHANNELS * 2}",
+            "--recv-jones-per-batch=16384",  # Reduce batch sizes to speed up test
+            "--recv-batches-per-chunk=1",  # Reduce chunk sizes to speed up test
             "--send-interface=lo",
             f"--send-bandwidth={SEND_BANDWIDTH}",
             "--send-pols=x,y",
@@ -130,6 +144,10 @@ class TestVEngine:
             "239.10.2.0",
         ]
 
+    @pytest.mark.parametrize(
+        "min_timestamp",
+        [0, FIRST_TIMESTAMP + 0x400000],
+    )
     async def test_smoke(
         self,
         engine: VEngine,
@@ -137,14 +155,17 @@ class TestVEngine:
         mock_recv_streams: list[spead2.InprocQueue],
         mock_sendmsg: list[bytes],
         capture_complete_event: asyncio.Event,
+        min_timestamp: int,
     ) -> None:
         """Test that an engine can be started and receives some data.
 
-        This is a weak test that will need to be filled out later to ensure
-        that the framesets contain the right headers and data.
+        This is a weak test that considers only the headers and not the data.
         """
-        chunks = 4
-        await engine_client.request("capture-start", 0)
+        assert min_timestamp % engine.config.recv_config.layout.chunk_timestamp_step == 0, (
+            "min_timestamp is not on a chunk boundary"
+        )
+        chunks = 60
+        await engine_client.request("capture-start", min_timestamp)
         await _send_data(engine.config.recv_config.layout, chunks, mock_recv_streams)
         for queue in mock_recv_streams:
             queue.stop()
@@ -152,11 +173,12 @@ class TestVEngine:
         await engine_client.request("capture-stop")
         frame_rate = round(SEND_BANDWIDTH / SAMPLES_PER_FRAME) * u.Hz
         # The pipeline rounds things to a 1s boundary, so we should see the
-        # data start at the next second boundary after FIRST_TIMESTAMP. Note
+        # data start at the next second boundary after start_time_adc. Note
         # that this only holds if FIRST_TIMESTAMP is not too close to a 1s
         # boundary, because the filters have a group delay that is compensated
         # for.
-        start_time_unix = math.ceil(TIME_CONVERTER.adc_to_unix(FIRST_TIMESTAMP))
+        start_time_adc = max(FIRST_TIMESTAMP, min_timestamp)
+        start_time_unix = math.ceil(TIME_CONVERTER.adc_to_unix(start_time_adc))
         start_time = Time(start_time_unix, format="unix")
         # The first second of data is incomplete because of the footprint of the
         # filters. We then align the start to a second boundary, so we expect
@@ -185,28 +207,6 @@ class TestVEngine:
         stop_time_unix = math.floor(TIME_CONVERTER.adc_to_unix(FIRST_TIMESTAMP + data_timestamps))
         assert stop_time_unix > start_time_unix, "Test did not send enough data to produce output"
         assert len(mock_sendmsg) == (stop_time_unix - start_time_unix) * frame_rate.value * N_THREADS
-
-    async def test_min_timestamp(
-        self,
-        engine: VEngine,
-        engine_client: aiokatcp.Client,
-        mock_recv_streams: list[spead2.InprocQueue],
-        frameset_count: list[int],
-        capture_complete_event: asyncio.Event,
-    ) -> None:
-        """Test ``?capture-start`` with a non-trivial minimum timestamp."""
-        # TODO: this is a very weak test, which just uses a very large
-        # min_timestamp and checks that no data gets through. Once we have
-        # more precise tests that model the delays involved, this should be
-        # improved.
-        chunks = 4
-        await engine_client.request("capture-start", 0xF00000000000)
-        await _send_data(engine.config.recv_config.layout, chunks, mock_recv_streams)
-        for queue in mock_recv_streams:
-            queue.stop()
-        await capture_complete_event.wait()
-        assert frameset_count[0] == 0
-        await engine_client.request("capture-stop")
 
     async def test_capture_start_while_capturing(self, engine_client: aiokatcp.Client) -> None:
         """Test that ``?capture-start`` while already capturing fails."""

--- a/test/vgpu/test_engine.py
+++ b/test/vgpu/test_engine.py
@@ -35,7 +35,6 @@ from katgpucbf import COMPLEX, N_POLS
 from katgpucbf.utils import TimeConverter
 from katgpucbf.vgpu.engine import VEngine, _CaptureSession
 from katgpucbf.vgpu.recv import Layout
-from katgpucbf.vgpu.send import VDIFSender
 
 from .test_recv import gen_heaps
 
@@ -90,21 +89,6 @@ async def _send_data(
 
 class TestVEngine:
     """Test :class:`.VEngine`."""
-
-    @pytest.fixture
-    def frameset_count(self, monkeypatch: pytest.MonkeyPatch) -> list[int]:
-        """Monkeypatch :meth:`.VDIFSender.send` on the `engine` to count the number of calls.
-
-        The fixture value is a list with a single integer, which will be
-        incremented each time the method is called.
-        """
-        value = [0]
-
-        async def send(self, frameset):
-            value[0] += 1
-
-        monkeypatch.setattr(VDIFSender, "send", send)
-        return value
 
     @pytest.fixture
     def capture_complete_event(self, engine: VEngine, monkeypatch: pytest.MonkeyPatch) -> asyncio.Event:

--- a/test/vgpu/test_engine.py
+++ b/test/vgpu/test_engine.py
@@ -130,7 +130,10 @@ class TestVEngine:
 
     @pytest.mark.parametrize(
         "min_timestamp",
-        [0, FIRST_TIMESTAMP + 0x400000],
+        [
+            0,
+            FIRST_TIMESTAMP + 0x400000,
+        ],
     )
     async def test_smoke(
         self,

--- a/test/vgpu/test_send.py
+++ b/test/vgpu/test_send.py
@@ -22,6 +22,7 @@ import logging
 import socket
 import struct
 from collections.abc import Buffer
+from dataclasses import dataclass
 from typing import override
 from unittest import mock
 
@@ -40,22 +41,29 @@ def event_loop_policy() -> async_solipsism.EventLoopPolicy:
     return async_solipsism.EventLoopPolicy()
 
 
-class DummyRateLimiter(RateLimiter[int]):
-    """Process integers and store the times they were processed."""
+@dataclass(frozen=True)
+class DummyItem:
+    """Item type for :class:`DummyRateLimiter`."""
+
+    size: int  #: Size of the item for the rate-limiting algorithm
+    sleep: float = 0.0  #: Time that processing the item will sleep
+
+
+class DummyRateLimiter(RateLimiter[DummyItem]):
+    """Process items and store the times they were processed."""
 
     def __init__(self, rate: float, burst_rate: float, capacity: int) -> None:
         super().__init__(rate, burst_rate, capacity)
         self.times: list[float] = []
 
     @override
-    def item_size(self, item: int) -> int:
-        return item
+    def item_size(self, item: DummyItem) -> int:
+        return item.size
 
     @override
-    async def _process_item(self, item: int) -> None:
+    async def _process_item(self, item: DummyItem) -> None:
         self.times.append(asyncio.get_running_loop().time())
-        if item == 4:
-            await asyncio.sleep(0.5)
+        await asyncio.sleep(item.sleep)
 
 
 class TestRateLimiter:
@@ -69,17 +77,16 @@ class TestRateLimiter:
         limiter = DummyRateLimiter(10, 20, 2)
         async with asyncio.TaskGroup() as tg:
             # Two back-to-back
-            tg.create_task(limiter.send(1))
-            tg.create_task(limiter.send(1))
+            tg.create_task(limiter.send(DummyItem(size=1)))
+            tg.create_task(limiter.send(DummyItem(size=1)))
             # Long gap so that we reset the reference point
             await asyncio.sleep(0.5)
-            # More back-to-back, for which processing causes delays
-            # (special case in DummyRateLimiter for item=4).
+            # More back-to-back, for which processing causes delays.
             for _ in range(3):
-                tg.create_task(limiter.send(4))
+                tg.create_task(limiter.send(DummyItem(size=4, sleep=0.5)))
             # Some more back-to-back for which we will be catching up
             for _ in range(5):
-                tg.create_task(limiter.send(2))
+                tg.create_task(limiter.send(DummyItem(size=2)))
         await limiter.stop()
         assert limiter.times == pytest.approx(
             [
@@ -103,13 +110,13 @@ class TestRateLimiter:
         start_time = loop.time()
         limiter = DummyRateLimiter(10, 20, 100)
         for _ in range(5):
-            await limiter.send(1)
+            await limiter.send(DummyItem(size=1))
         # Start a flush, and asynchronously also add more data
         async with asyncio.TaskGroup() as tg:
             flush_task = tg.create_task(limiter.flush())
             await asyncio.sleep(0.1)  # Give flush_task time to start
             for _ in range(5):
-                await limiter.send(1)
+                await limiter.send(DummyItem(size=1))
             await flush_task
             assert len(limiter.times) == 5
             assert loop.time() - start_time == pytest.approx(0.4)

--- a/test/vgpu/test_send.py
+++ b/test/vgpu/test_send.py
@@ -43,8 +43,8 @@ def event_loop_policy() -> async_solipsism.EventLoopPolicy:
 class DummyRateLimiter(RateLimiter[int]):
     """Process integers and store the times they were processed."""
 
-    def __init__(self, rate: float, burst_rate: float) -> None:
-        super().__init__(rate, burst_rate, 2)
+    def __init__(self, rate: float, burst_rate: float, capacity: int) -> None:
+        super().__init__(rate, burst_rate, capacity)
         self.times: list[float] = []
 
     @override
@@ -66,7 +66,7 @@ class TestRateLimiter:
         # Use a TaskGroup so that we can schedule items to be sent at
         # precisely-controlled times, regardless of any sleeping that
         # the tasks do.
-        limiter = DummyRateLimiter(10, 20)
+        limiter = DummyRateLimiter(10, 20, 2)
         async with asyncio.TaskGroup() as tg:
             # Two back-to-back
             tg.create_task(limiter.send(1))
@@ -95,6 +95,27 @@ class TestRateLimiter:
                 2.5,  # All caught up now, revert to standard rate
             ]
         )
+
+    async def test_flush(self) -> None:
+        """Test :meth:`.RateLimiter.flush`."""
+        # We use a large capacity so that limiter.send will always be instant
+        loop = asyncio.get_running_loop()
+        start_time = loop.time()
+        limiter = DummyRateLimiter(10, 20, 100)
+        for _ in range(5):
+            await limiter.send(1)
+        # Start a flush, and asynchronously also add more data
+        async with asyncio.TaskGroup() as tg:
+            flush_task = tg.create_task(limiter.flush())
+            await asyncio.sleep(0.1)  # Give flush_task time to start
+            for _ in range(5):
+                await limiter.send(1)
+            print(loop.time() - start_time)
+            await flush_task
+            assert len(limiter.times) == 5
+            assert loop.time() - start_time == pytest.approx(0.4)
+        await limiter.stop()
+        assert len(limiter.times) == 10
 
 
 class TestVDIFSender:

--- a/test/vgpu/test_send.py
+++ b/test/vgpu/test_send.py
@@ -110,7 +110,6 @@ class TestRateLimiter:
             await asyncio.sleep(0.1)  # Give flush_task time to start
             for _ in range(5):
                 await limiter.send(1)
-            print(loop.time() - start_time)
             await flush_task
             assert len(limiter.times) == 5
             assert loop.time() - start_time == pytest.approx(0.4)


### PR DESCRIPTION
Instead of just mocking out the send function at the top level and asserting that it was called, mock out socket.sendmsg at the lower level and collect the actual packet data sent. This allows us to verify the sequence numbers and VDIF header fields. That also simplifies the tests somewhat because the test_min_timestamp test can be eliminated in favour of just having test_smoke handle a min_timestamp, while at the same time making the min_timestamp testing more strict.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`.
- [x] (n/a) If new source files are added: add copyright notices dated with the current year.
- [x] (n/a) If qualification tests are changed: attach or link to a sample qualification report.
- [x] (n/a) If design has changed: ensure documentation is up to date.
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match.
- [x] (n/a) If the interface between the product controller and an engine has changed, update the
      VERSION constant for the engine (update the major number if sensors/requests have been
      removed/changed, minor number if only backwards-compatible changes have been done).
      Also, update doc/control.rst with the new version.

Contributes to NGC-1695.