### PR TITLE
Allow for per-output send-enabled in xbgpu

### DIFF
--- a/doc/control.rst
+++ b/doc/control.rst
@@ -280,7 +280,7 @@ This describes version ``katgpucbf-xbgpu-1.0`` of the katcp-device API.
 :samp:`?capture-start {stream} [{timestamp}]`, :samp:`?capture-stop {stream}`
     Enable or disable transmission of output data. This does not affect
     transmission of descriptors, which cannot be disabled. In the initial
-    state transmission is disabled, unless the :option:`!--send-enabled`
+    state transmission is disabled, unless the :option:`!send_enabled=True`
     command-line option has been passed.
 
     If :samp:`{timestamp}` is specified, heaps with timestamps less than this

--- a/scratch/benchmarks/benchmark_xbgpu.py
+++ b/scratch/benchmarks/benchmark_xbgpu.py
@@ -176,19 +176,19 @@ class XbgpuBenchmark(Benchmark):
             f"--send-comp-vector={cores[1]} "
             f"--send-interface={interface} "
             f"--send-ibv "
-            f"--send-enabled "
             f"{self.fsim_addresses_queue.popleft()}:7148 "
         )
         for i in range(self.args.beams):
             for j in range(N_POLS):
                 idx = N_POLS * i + j
-                command += f"--beam=name=beam{idx},dst={self.multicast_allocator()},pol={j} "
+                command += f"--beam=name=beam{idx},dst={self.multicast_allocator()},pol={j},send_enabled=True "
 
         for i in range(self.args.corrprods):
             corrprod_number = index * self.args.corrprods + i
             command += f"--corrprod=name=corrprod{corrprod_number},"
             command += f"dst={self.multicast_allocator()},"
-            command += f"heap_accumulation_threshold={threshold} "
+            command += f"heap_accumulation_threshold={threshold},"
+            command += "send_enabled=True "
         return command
 
     @override

--- a/scratch/xbgpu/run-xbgpu.sh
+++ b/scratch/xbgpu/run-xbgpu.sh
@@ -33,8 +33,8 @@ declare -a beam_args
 beams=${beams:-4}
 i=0
 while [ "$i" -lt "$beams" ]; do
-    beam_args+=("--beam=name=beam_${i}x,pol=0,dst=239.10.$((12 + index)).$((i * 2)):7148")
-    beam_args+=("--beam=name=beam_${i}y,pol=1,dst=239.10.$((12 + index)).$((i * 2 + 1)):7148")
+    beam_args+=("--beam=name=beam_${i}x,pol=0,dst=239.10.$((12 + index)).$((i * 2)):7148,send_enabled=True")
+    beam_args+=("--beam=name=beam_${i}y,pol=1,dst=239.10.$((12 + index)).$((i * 2 + 1)):7148,send_enabled=True")
     i="$((i + 1))"
 done
 
@@ -74,7 +74,7 @@ exec schedrr spead2_net_raw numactl -C $other_affinity xbgpu \
     --recv-interface $iface \
     --send-interface $iface \
     --recv-ibv --send-ibv \
-    --corrprod=name=bcp1,heap_accumulation_threshold=${heap_accumulation_threshold},dst=$dst \
+    --corrprod=name=bcp1,heap_accumulation_threshold=${heap_accumulation_threshold},dst=$dst,send_enabled=True \
     "${beam_args[@]}" \
     --adc-sample-rate ${adc_sample_rate} \
     --array-size ${array_size:-64} \
@@ -87,5 +87,4 @@ exec schedrr spead2_net_raw numactl -C $other_affinity xbgpu \
     --sync-time 0 \
     --katcp-port $katcp_port \
     --prometheus-port $prom_port \
-    --send-enabled \
     $src

--- a/src/katgpucbf/xbgpu/bsend.py
+++ b/src/katgpucbf/xbgpu/bsend.py
@@ -416,9 +416,8 @@ class BSend(Send):
         context: AbstractContext,
         stream_factory: Callable[[spead2.send.StreamConfig, Sequence[np.ndarray]], "spead2.send.asyncio.AsyncStream"],
         packet_payload: int = DEFAULT_PACKET_PAYLOAD_BYTES,
-        send_enabled: bool = False,
     ) -> None:
-        self.send_enabled = [send_enabled] * len(outputs)
+        self.send_enabled = [output.send_enabled for output in outputs]
         self.send_enabled_timestamp = [0] * len(outputs)
         n_beams = len(outputs)
         self.output_names = [output.name for output in outputs]

--- a/src/katgpucbf/xbgpu/bsend.py
+++ b/src/katgpucbf/xbgpu/bsend.py
@@ -394,8 +394,6 @@ class BSend(Send):
     packet_payload
         Size, in bytes, for the output packets (tied array channelised voltage
         payload only; headers and padding are added to this).
-    send_enabled
-        Enable/Disable transmission.
     """
 
     descriptor_heap: spead2.send.Heap

--- a/src/katgpucbf/xbgpu/engine.py
+++ b/src/katgpucbf/xbgpu/engine.py
@@ -343,7 +343,6 @@ class BPipeline(Pipeline[BOutput, BOutQueueItem]):
         engine: "XBEngine",
         context: AbstractContext,
         vkgdr_handle: vkgdr.Vkgdr,
-        init_send_enabled: bool,
         name: str = DEFAULT_BPIPELINE_NAME,
     ) -> None:
         super().__init__(outputs, name, engine, context)
@@ -410,7 +409,6 @@ class BPipeline(Pipeline[BOutput, BOutQueueItem]):
                 stream_config=stream_config,
                 buffers=buffers,
             ),
-            send_enabled=init_send_enabled,
         )
 
         self._populate_sensors(seed)
@@ -678,7 +676,6 @@ class XPipeline(Pipeline[XOutput, XOutQueueItem]):
         engine: "XBEngine",
         context: AbstractContext,
         vkgdr_handle: vkgdr.Vkgdr,
-        init_send_enabled: bool,
         name: str = DEFAULT_XPIPELINE_NAME,
     ) -> None:
         super().__init__([output], name, engine, context)
@@ -736,7 +733,7 @@ class XPipeline(Pipeline[XOutput, XOutQueueItem]):
                 stream_config=stream_config,
                 buffers=buffers,
             ),
-            send_enabled=init_send_enabled,
+            send_enabled=output.send_enabled,
         )
 
         self._populate_sensors()
@@ -1095,9 +1092,6 @@ class XBEngine(Engine):
     send_comp_vector
         Completion vector for transmission, or -1 for polling.
         See :class:`spead2.send.UdpIbvConfig` for further information.
-    send_enabled
-        Start with correlator output transmission enabled, without having to
-        issue a katcp command.
     monitor
         :class:`Monitor` to use for generating multiple :class:`~asyncio.Queue`
         objects needed to communicate between functions, and handling basic
@@ -1142,7 +1136,6 @@ class XBEngine(Engine):
         send_comp_vector: int,
         heaps_per_fengine_per_chunk: int,  # Used for GPU memory tuning
         recv_reorder_tol: int,
-        send_enabled: bool,
         monitor: Monitor,
         context: AbstractContext,
         vkgdr_handle: vkgdr.Vkgdr,
@@ -1237,9 +1230,9 @@ class XBEngine(Engine):
         self._pipelines: list[Pipeline] = []
         x_outputs = [output for output in outputs if isinstance(output, XOutput)]
         b_outputs = [output for output in outputs if isinstance(output, BOutput)]
-        self._pipelines = [XPipeline(x_output, self, context, vkgdr_handle, send_enabled) for x_output in x_outputs]
+        self._pipelines = [XPipeline(x_output, self, context, vkgdr_handle) for x_output in x_outputs]
         if b_outputs:
-            self._pipelines.append(BPipeline(b_outputs, self, context, vkgdr_handle, send_enabled))
+            self._pipelines.append(BPipeline(b_outputs, self, context, vkgdr_handle))
         self._upload_command_queue = context.create_command_queue()
 
         # This queue is extended in the monitor class, allowing for the

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -71,23 +71,23 @@ logger = logging.getLogger(__name__)
 def _add_stream_args(parser: SubParser) -> None:
     parser.add_argument("name", type=str, required=True)
     parser.add_argument("dst", type=endpoint_parser(DEFAULT_PORT), required=True)
-    parser.add_argument("send_enabled", type=_parse_send_enabled, default=False)
+    parser.add_argument("send_enabled", type=_parse_bool, default=False)
 
 
 def _parse_pol(value: str) -> int:
     pol = int(value)
     if pol not in {0, 1}:
-        raise argparse.ArgumentTypeError("pol must be either 0 or 1")
+        raise argparse.ArgumentTypeError("must be either 0 or 1")
     return pol
 
 
-def _parse_send_enabled(value: str) -> bool:
+def _parse_bool(value: str) -> bool:
     if value.lower() in {"true", "1"}:
         return True
     elif value.lower() in {"false", "0"}:
         return False
     else:
-        raise argparse.ArgumentTypeError("send_enabled must be a boolean value (true/false, 1/0)")
+        raise argparse.ArgumentTypeError("must be a boolean value (true/false, 1/0)")
 
 
 def parse_beam(value: str) -> BOutput:

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -82,12 +82,12 @@ def _parse_pol(value: str) -> int:
 
 
 def _parse_send_enabled(value: str) -> bool:
-    if value.lower() in {"true", "1", "yes"}:
+    if value.lower() in {"true", "1"}:
         return True
-    elif value.lower() in {"false", "0", "no"}:
+    elif value.lower() in {"false", "0"}:
         return False
     else:
-        raise argparse.ArgumentTypeError("send_enabled must be a boolean value (true/false, 1/0, yes/no)")
+        raise argparse.ArgumentTypeError("send_enabled must be a boolean value (true/false, 1/0)")
 
 
 def parse_beam(value: str) -> BOutput:

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -71,6 +71,7 @@ logger = logging.getLogger(__name__)
 def _add_stream_args(parser: SubParser) -> None:
     parser.add_argument("name", type=str, required=True)
     parser.add_argument("dst", type=endpoint_parser(DEFAULT_PORT), required=True)
+    parser.add_argument("send_enabled", type=_parse_send_enabled, default=False)
 
 
 def _parse_pol(value: str) -> int:
@@ -78,6 +79,15 @@ def _parse_pol(value: str) -> int:
     if pol not in {0, 1}:
         raise argparse.ArgumentTypeError("pol must be either 0 or 1")
     return pol
+
+
+def _parse_send_enabled(value: str) -> bool:
+    if value.lower() in {"true", "1", "yes"}:
+        return True
+    elif value.lower() in {"false", "0", "no"}:
+        return False
+    else:
+        raise argparse.ArgumentTypeError("send_enabled must be a boolean value (true/false, 1/0, yes/no)")
 
 
 def parse_beam(value: str) -> BOutput:
@@ -211,11 +221,6 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         default=DEFAULT_PACKET_PAYLOAD_BYTES,
         help="Size in bytes for output packets (payload only) [%(default)s]",
     )
-    parser.add_argument(
-        "--send-enabled",
-        action="store_true",
-        help="Start with correlator output transmission enabled, without having to issue a katcp command.",
-    )
     parser.add_argument("--monitor-log", type=str, help="File to write performance-monitoring data to")
     parser.add_argument("src", type=parse_source_ipv4, help="Multicast address data is received from.")
 
@@ -290,7 +295,6 @@ def make_engine(
         send_comp_vector=args.send_comp_vector,
         heaps_per_fengine_per_chunk=args.heaps_per_fengine_per_chunk,
         recv_reorder_tol=args.recv_reorder_tol,
-        send_enabled=args.send_enabled,
         monitor=monitor,
         context=context,
         vkgdr_handle=vkgdr_handle,

--- a/src/katgpucbf/xbgpu/main.py
+++ b/src/katgpucbf/xbgpu/main.py
@@ -136,7 +136,8 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         default=[],
         action="append",
         metavar="KEY=VALUE[,KEY=VALUE...]",
-        help="Add a half-beam output (may be repeated). The required keys are: name, dst, pol. Optional keys: dither.",
+        help="Add a half-beam output (may be repeated). The required keys are: name, dst, pol. "
+        "Optional keys: dither, send_enabled.",
     )
     parser.add_argument(
         "--corrprod",
@@ -145,7 +146,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         action="append",
         metavar="KEY=VALUE[,KEY=VALUE...]",
         help="Add a baseline-correlation-products output (may be repeated). The required keys are: "
-        "name, dst, heap_accumulation_threshold.",
+        "name, dst, heap_accumulation_threshold. Optional keys: send_enabled.",
     )
     add_common_arguments(parser)
     add_time_converter_arguments(parser)

--- a/src/katgpucbf/xbgpu/output.py
+++ b/src/katgpucbf/xbgpu/output.py
@@ -30,6 +30,7 @@ class Output(ABC):
 
     name: str
     dst: Endpoint
+    send_enabled: bool
 
 
 @dataclass

--- a/test/xbgpu/test_bsend.py
+++ b/test/xbgpu/test_bsend.py
@@ -52,8 +52,8 @@ def time_converter() -> TimeConverter:
 def outputs() -> Sequence[BOutput]:
     """Simulate `--beam` configuration."""
     return [
-        BOutput(name="foo", dst=Endpoint("239.10.11.0", 7149), pol=0, dither=DitherType.DEFAULT),
-        BOutput(name="bar", dst=Endpoint("239.10.12.0", 7149), pol=1, dither=DitherType.DEFAULT),
+        BOutput(name="foo", dst=Endpoint("239.10.11.0", 7149), pol=0, dither=DitherType.DEFAULT, send_enabled=False),
+        BOutput(name="bar", dst=Endpoint("239.10.12.0", 7149), pol=1, dither=DitherType.DEFAULT, send_enabled=False),
     ]
 
 

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -641,15 +641,15 @@ class TestXBEngine:
     def corrprod_args(self, heap_accumulation_threshold: tuple[int, int]) -> list[str]:
         """Arguments to pass to the command-line parser for multiple --corrprods."""
         return [
-            f"name=bcp1,dst=239.10.11.0:7148,heap_accumulation_threshold={heap_accumulation_threshold[0]}",
-            f"name=bcp2,dst=239.10.11.1:7148,heap_accumulation_threshold={heap_accumulation_threshold[1]}",
+            f"name=bcp1,dst=239.10.11.0:7148,heap_accumulation_threshold={heap_accumulation_threshold[0]},send_enabled=True",
+            f"name=bcp2,dst=239.10.11.1:7148,heap_accumulation_threshold={heap_accumulation_threshold[1]},send_enabled=True",
         ]
 
     @pytest.fixture
     def beam_args(self) -> list[str]:
         """Arguments to pass to the command-line parser for multiple beams."""
         return [
-            "name=beam_0x,dst=239.10.12.0:7148,pol=0,send_enabled=False",
+            "name=beam_0x,dst=239.10.12.0:7148,pol=0,send_enabled=True",
             "name=beam_0y,dst=239.10.12.1:7148,pol=1,send_enabled=True",
         ]
 

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -1521,8 +1521,7 @@ class TestXBEngine:
     ) -> None:
         """Test capture-start and capture-stop requests.
 
-        TODO: Update below docstring
-        First issue a capture-stop as `engine` is initialised with --send-enabled.
+        First issue a capture-stop as all streams are initialised with `send_enabled=True`.
         """
 
         def get_stream_status(stream_name: str) -> bool:

--- a/test/xbgpu/test_engine.py
+++ b/test/xbgpu/test_engine.py
@@ -649,8 +649,8 @@ class TestXBEngine:
     def beam_args(self) -> list[str]:
         """Arguments to pass to the command-line parser for multiple beams."""
         return [
-            "name=beam_0x,dst=239.10.12.0:7148,pol=0",
-            "name=beam_0y,dst=239.10.12.1:7148,pol=1",
+            "name=beam_0x,dst=239.10.12.0:7148,pol=0,send_enabled=False",
+            "name=beam_0y,dst=239.10.12.1:7148,pol=1,send_enabled=True",
         ]
 
     @pytest.fixture
@@ -1022,7 +1022,6 @@ class TestXBEngine:
             f"--sync-time={SYNC_TIME}",
             "--recv-interface=lo",
             "--send-interface=lo",
-            "--send-enabled",
             "239.10.11.4:7149",  # src
         ]
         for corrprod in corrprod_args:
@@ -1522,6 +1521,7 @@ class TestXBEngine:
     ) -> None:
         """Test capture-start and capture-stop requests.
 
+        TODO: Update below docstring
         First issue a capture-stop as `engine` is initialised with --send-enabled.
         """
 

--- a/test/xbgpu/test_main.py
+++ b/test/xbgpu/test_main.py
@@ -31,12 +31,12 @@ class TestParseBeam:
 
     def test_maximal(self) -> None:
         """Test with all valid arguments."""
-        assert parse_beam("name=beam1,dst=239.1.2.3:7148,pol=1,dither=none") == BOutput(
+        assert parse_beam("name=beam1,dst=239.1.2.3:7148,pol=1,dither=none,send_enabled=True") == BOutput(
             name="beam1",
             dst=Endpoint("239.1.2.3", 7148),
             pol=1,
             dither=DitherType.NONE,
-            send_enabled=False,
+            send_enabled=True,
         )
 
     def test_minimal(self) -> None:
@@ -60,9 +60,11 @@ class TestParseCorrprod:
 
     def test_maximal(self) -> None:
         """Test with all valid arguments."""
-        assert parse_corrprod("name=foo,heap_accumulation_threshold=52,dst=239.2.3.4:7148") == XOutput(
+        assert parse_corrprod(
+            "name=foo,heap_accumulation_threshold=52,dst=239.2.3.4:7148,send_enabled=True"
+        ) == XOutput(
             name="foo",
             heap_accumulation_threshold=52,
             dst=Endpoint("239.2.3.4", 7148),
-            send_enabled=False,
+            send_enabled=True,
         )

--- a/test/xbgpu/test_main.py
+++ b/test/xbgpu/test_main.py
@@ -17,6 +17,7 @@
 """Unit tests for argument parsing."""
 
 import argparse
+import re
 
 import pytest
 from katsdptelstate.endpoint import Endpoint
@@ -51,8 +52,18 @@ class TestParseBeam:
 
     def test_bad_pol(self) -> None:
         """Test with a polarisation value that isn't 0 or 1."""
-        with pytest.raises(argparse.ArgumentTypeError, match="pol must be either 0 or 1"):
+        with pytest.raises(argparse.ArgumentTypeError, match="pol: must be either 0 or 1"):
             parse_beam("name=foo,dst=239.1.2.3:7148,pol=2")
+
+    def test_bad_send_enabled(self) -> None:
+        """Test with a send_enabled value that isn't true/false or 1/0.
+
+        This is shared with :func:`.parse_corrprod`.
+        """
+        with pytest.raises(
+            argparse.ArgumentTypeError, match=re.escape("send_enabled: must be a boolean value (true/false, 1/0)")
+        ):
+            parse_beam("name=foo,dst=239.1.2.3:7148,pol=1,send_enabled=maybe")
 
 
 class TestParseCorrprod:

--- a/test/xbgpu/test_main.py
+++ b/test/xbgpu/test_main.py
@@ -36,6 +36,7 @@ class TestParseBeam:
             dst=Endpoint("239.1.2.3", 7148),
             pol=1,
             dither=DitherType.NONE,
+            send_enabled=False,
         )
 
     def test_minimal(self) -> None:
@@ -45,6 +46,7 @@ class TestParseBeam:
             dst=Endpoint("239.1.2.3", 7148),
             pol=1,
             dither=DitherType.DEFAULT,
+            send_enabled=False,
         )
 
     def test_bad_pol(self) -> None:
@@ -62,4 +64,5 @@ class TestParseCorrprod:
             name="foo",
             heap_accumulation_threshold=52,
             dst=Endpoint("239.2.3.4", 7148),
+            send_enabled=False,
         )


### PR DESCRIPTION
Specifically add this to the `--beam` and `--corrprod` command-line CSVs.

Also, tweak the unit tests accordingly to either maintain previous functionality
or test the updated configuration syntax.

Re: The two unchecked points below
- I'm not entirely sure if the **design** has changed, and
- Similarly, I'm not sure where the line is to declare and _Interface change_ between product controller and engine.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`.
- [x] (n/a) If new source files are added: add copyright notices dated with the current year.
- [x] (n/a) If qualification tests are changed: attach or link to a sample qualification report.
- [x] If design has changed: ensure documentation is up to date.
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match.
- [x] (n/a) If the interface between the product controller and an engine has changed, update the
      VERSION constant for the engine (update the major number if sensors/requests have been
      removed/changed, minor number if only backwards-compatible changes have been done).
      Also, update doc/control.rst with the new version.

Closes NGC-1990.
