### PR TITLE
Support overriding digitiser sample-bits and samples-per-heap in scratch scripts

### DIFF
--- a/qualification/cbf.py
+++ b/qualification/cbf.py
@@ -29,7 +29,7 @@ from uuid import UUID, uuid4
 import aiokatcp
 import pytest
 
-from katgpucbf import DIG_SAMPLE_BITS
+from katgpucbf import DEFAULT_DIG_SAMPLE_BITS
 from katgpucbf.pytest_plugins.reporter import Reporter, custom_report_log
 
 from .host_config import HostConfigQuerier
@@ -187,7 +187,7 @@ class CBFRemoteControl(CBFBase):
         """
         if pdf_report is not None:
             pdf_report.step("Configure the D-sim with Gaussian noise.")
-        dig_max = 2 ** (DIG_SAMPLE_BITS - 1) - 1
+        dig_max = 2 ** (DEFAULT_DIG_SAMPLE_BITS - 1) - 1
         amplitude /= dig_max  # Convert to be relative to full-scale
         signal = f"common=nodither(wgn({amplitude}));common;common;"
         if period is None:

--- a/qualification/recv.py
+++ b/qualification/recv.py
@@ -38,7 +38,7 @@ from spead2.numba import intp_to_voidptr
 from spead2.recv.numba import chunk_place_data
 
 import katgpucbf.recv
-from katgpucbf import COMPLEX, DEFAULT_RECV_BUFFER_SIZE, DIG_SAMPLE_BITS
+from katgpucbf import COMPLEX, DEFAULT_DIG_SAMPLE_BITS, DEFAULT_RECV_BUFFER_SIZE
 from katgpucbf.spead import BEAM_ANTS_ID, DEFAULT_PORT, FREQUENCY_ID, TIMESTAMP_ID
 from katgpucbf.utils import TimeConverter
 
@@ -306,7 +306,7 @@ class XBReceiver:
             the target. The target may also be reduced if necessary to avoid
             saturating the X-engine output.
         """
-        dig_max = 2 ** (DIG_SAMPLE_BITS - 1) - 1
+        dig_max = 2 ** (DEFAULT_DIG_SAMPLE_BITS - 1) - 1
         # The PFB is scaled for fixed incoherent gain, but we need to be concerned
         # about coherent gain to avoid overflowing the F-engine output. Coherent gain
         # scales approximately with sqrt(bw / chan_bw / 2).

--- a/qualification/tied_array_channelised_voltage/test_gain.py
+++ b/qualification/tied_array_channelised_voltage/test_gain.py
@@ -20,7 +20,7 @@ import numpy as np
 import pytest
 from pytest_check import check
 
-from katgpucbf import DIG_SAMPLE_BITS
+from katgpucbf import DEFAULT_DIG_SAMPLE_BITS
 from katgpucbf.pytest_plugins.reporter import Reporter
 
 from ..cbf import CBFRemoteControl
@@ -46,7 +46,7 @@ async def test_gain(
     pcc = cbf.product_controller_client
 
     pdf_report.step("Configure the D-sim with Gaussian noise.")
-    dig_max = 2 ** (DIG_SAMPLE_BITS - 1) - 1
+    dig_max = 2 ** (DEFAULT_DIG_SAMPLE_BITS - 1) - 1
     amplitude = 32 / dig_max
     await pcc.request("dsim-signals", cbf.dsim_names[0], f"common=nodither(wgn({amplitude}));common;common;")
     pdf_report.detail(f"Set D-sim with wgn amplitude={amplitude}.")

--- a/scratch/fgpu/benchmarks/compute_bench.py
+++ b/scratch/fgpu/benchmarks/compute_bench.py
@@ -23,7 +23,7 @@ import numpy as np
 from katsdpsigproc import accel
 from katsdptelstate.endpoint import Endpoint
 
-from katgpucbf import DEFAULT_JONES_PER_BATCH, DIG_SAMPLE_BITS
+from katgpucbf import DEFAULT_DIG_SAMPLE_BITS, DEFAULT_JONES_PER_BATCH
 from katgpucbf.fgpu.compute import ComputeTemplate, NarrowbandConfig
 from katgpucbf.fgpu.engine import generate_ddc_weights, generate_pfb_weights
 from katgpucbf.fgpu.main import DEFAULT_DDC_TAPS_RATIO
@@ -45,7 +45,7 @@ def main():
     parser.add_argument("--send-chunk-jones", type=int, default=8 * 1024 * 1024)
     parser.add_argument("--channels", type=int, default=32768)
     parser.add_argument("--jones-per-batch", type=int, default=DEFAULT_JONES_PER_BATCH)
-    parser.add_argument("--dig-sample-bits", type=int, default=DIG_SAMPLE_BITS)
+    parser.add_argument("--dig-sample-bits", type=int, default=DEFAULT_DIG_SAMPLE_BITS)
     parser.add_argument("--send-sample-bits", type=int, default=8, choices=[4, 8])
     parser.add_argument("--passes", type=int, default=1000)
     parser.add_argument("--ddc-taps", type=int)  # Default is computed from decimation

--- a/scratch/fgpu/benchmarks/ddc_bench.py
+++ b/scratch/fgpu/benchmarks/ddc_bench.py
@@ -22,7 +22,7 @@ from fractions import Fraction
 import numpy as np
 from katsdpsigproc import accel
 
-from katgpucbf import DIG_SAMPLE_BITS, N_POLS
+from katgpucbf import DEFAULT_DIG_SAMPLE_BITS, N_POLS
 from katgpucbf.fgpu.ddc import DDCTemplate
 from katgpucbf.fgpu.main import DEFAULT_DDC_TAPS_RATIO
 
@@ -32,7 +32,7 @@ def main():
     parser.add_argument("--taps", type=int)  # Default is computed
     parser.add_argument("--subsampling", type=int, default=8)
     parser.add_argument("--samples", type=int, default=32 * 1024 * 1024)
-    parser.add_argument("--input-sample-bits", type=int, default=DIG_SAMPLE_BITS)
+    parser.add_argument("--input-sample-bits", type=int, default=DEFAULT_DIG_SAMPLE_BITS)
     parser.add_argument("--pols", type=int, default=N_POLS)
     parser.add_argument("--passes", type=int, default=1000)
     args = parser.parse_args()

--- a/scratch/fgpu/run-dsim-hbw.sh
+++ b/scratch/fgpu/run-dsim-hbw.sh
@@ -17,7 +17,9 @@ for i in 0 1; do
         --affinity "${cpu[$i]}" \
         --ibv \
         --interface "${iface[$i]}" \
-        --adc-sample-rate ${adc_sample_rate:-7000000000} \
+        --adc-sample-rate ${adc_sample_rate:-5992000000} \
+        --sample-bits ${dig_sample_bits:-6} \
+        --heap-samples ${dig_heap_samples:-8192} \
         --ttl 2 \
         --katcp-port $(($i + 7140)) \
         --prometheus-port $(($i + 7150)) \

--- a/scratch/fgpu/run-dsim.sh
+++ b/scratch/fgpu/run-dsim.sh
@@ -38,6 +38,8 @@ exec spead2_net_raw taskset -c $cpu2 dsim \
     --ibv \
     --interface $iface \
     --adc-sample-rate ${adc_sample_rate:-1712000000} \
+    --sample-bits ${dig_sample_bits:-10} \
+    --heap-samples ${dig_heap_samples:-4096} \
     --ttl 2 \
     --katcp-port $katcp_port \
     --prometheus-port $prom_port \

--- a/scratch/fgpu/run-fgpu-hbw.sh
+++ b/scratch/fgpu/run-fgpu-hbw.sh
@@ -28,7 +28,9 @@ exec spead2_net_raw taskset -c $other_affinity fgpu \
     --send-interface $iface1,$iface2 --send-ibv \
     --recv-affinity $recv_affinity --recv-comp-vector=$recv_comp \
     --send-affinity $send_affinity --send-comp-vector=$send_comp \
-    --adc-sample-rate ${adc_sample_rate:-7000000000} \
+    --adc-sample-rate ${adc_sample_rate:-5992000000} \
+    --dig-sample-bits ${dig_sample_bits:-6} \
+    --recv-packet-samples ${dig_heap_samples:-8192} \
     --jones-per-batch ${jones_per_batch:-1048576} \
     --katcp-port $katcp_port \
     --prometheus-port $prom_port \

--- a/scratch/fgpu/run-fgpu.sh
+++ b/scratch/fgpu/run-fgpu.sh
@@ -54,6 +54,8 @@ exec spead2_net_raw taskset -c $other_affinity fgpu \
     --recv-affinity $recv_affinity --recv-comp-vector=$recv_comp \
     --send-affinity $send_affinity --send-comp-vector=$send_comp \
     --adc-sample-rate ${adc_sample_rate:-1712000000} \
+    --dig-sample-bits ${dig_sample_bits:-10} \
+    --recv-packet-samples ${dig_heap_samples:-4096} \
     --jones-per-batch ${jones_per_batch:-1048576} \
     --katcp-port $katcp_port \
     --prometheus-port $prom_port \

--- a/scratch/sim_correlator.py
+++ b/scratch/sim_correlator.py
@@ -35,6 +35,7 @@ from fractions import Fraction
 import aiokatcp
 
 import katgpucbf.configure_tools
+from katgpucbf import DEFAULT_DIG_HEAP_SAMPLES, DEFAULT_DIG_SAMPLE_BITS
 from katgpucbf.main import comma_split
 from katgpucbf.meerkat import BANDS
 
@@ -78,6 +79,18 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--band", default="l", choices=BANDS.keys(), help="Band ID [%(default)s]")
     parser.add_argument("--adc-sample-rate", type=float, help="ADC sample rate in Hz [from --band]")
     parser.add_argument("--centre-frequency", type=float, help="Sky centre frequency in Hz [from --band]")
+    parser.add_argument(
+        "--dig-heap-samples",
+        type=int,
+        default=DEFAULT_DIG_HEAP_SAMPLES,
+        help="Number of samples per digitiser heap [%(default)s]",
+    )
+    parser.add_argument(
+        "--dig-sample-bits",
+        type=int,
+        default=DEFAULT_DIG_SAMPLE_BITS,
+        help="Number of bits per digitised sample [%(default)s]",
+    )
     parser.add_argument("--beams", type=int, default=0, help="Number of dual-polarisation wideband beams [%(default)s]")
     parser.add_argument("--narrowband", action="store_true", help="Enable a narrowband output [no]")
     parser.add_argument(
@@ -143,13 +156,18 @@ def generate_digitisers(args: argparse.Namespace, config: dict) -> list[str]:
         for pol in ["h", "v"]:
             name = f"m{number}{pol}"
             dig_names.append(name)
+            dig_config_common = {
+                "band": args.band[:1],
+                "adc_sample_rate": args.adc_sample_rate,
+                "centre_frequency": args.centre_frequency,
+                "bits_per_sample": args.dig_sample_bits,
+                "samples_per_heap": args.dig_heap_samples,
+            }
             if args.digitiser_address is None:
                 config["outputs"][name] = {
                     "type": "sim.dig.baseband_voltage",
-                    "band": args.band[:1],
-                    "adc_sample_rate": args.adc_sample_rate,
-                    "centre_frequency": args.centre_frequency,
                     "antenna": f"m{number}, 0:0:0, 0:0:0, 0, 0",
+                    **dig_config_common,
                 }
                 if args.sync_time is not None:
                     config["outputs"][name]["sync_time"] = args.sync_time
@@ -157,11 +175,9 @@ def generate_digitisers(args: argparse.Namespace, config: dict) -> list[str]:
                 config["inputs"][name] = {
                     "type": "dig.baseband_voltage",
                     "sync_time": args.sync_time,
-                    "band": args.band[:1],
-                    "adc_sample_rate": args.adc_sample_rate,
-                    "centre_frequency": args.centre_frequency,
                     "antenna": f"m{number}, 0:0:0, 0:0:0, 0, 0",
                     "url": f"spead://{next_dig_ip}+7:7148",
+                    **dig_config_common,
                 }
                 next_dig_ip += 8
     return dig_names
@@ -267,7 +283,7 @@ def generate_sdp(args: argparse.Namespace, outputs: dict) -> None:
 def generate_config(args: argparse.Namespace) -> dict:
     """Produce the configuration dict from the parsed command-line arguments."""
     config: dict = {
-        "version": "4.7",
+        "version": "4.9",
         "config": {"mirror_sensors": False},
         "inputs": {},
         "outputs": {},

--- a/scratch/sim_correlator.py
+++ b/scratch/sim_correlator.py
@@ -75,6 +75,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         metavar="ADDRESS",
         help="Starting IP address for external digitisers",
     )
+    parser.add_argument(
+        "--digitiser-multicast-groups",
+        type=int,
+        metavar="N",
+        default=8,
+        help="Number of multicast groups per digitiser [%(default)s]",
+    )
     parser.add_argument("--sync-time", type=float, help="Digitiser sync time [current time]")
     parser.add_argument("--band", default="l", choices=BANDS.keys(), help="Band ID [%(default)s]")
     parser.add_argument("--adc-sample-rate", type=float, help="ADC sample rate in Hz [from --band]")
@@ -150,6 +157,7 @@ def generate_digitisers(args: argparse.Namespace, config: dict) -> list[str]:
         Names of the digitiser streams
     """
     next_dig_ip = args.digitiser_address
+    n = args.digitiser_multicast_groups
     dig_names = []
     for ant_index in range(args.digitisers):
         number = 800 + ant_index  # Avoid confusion with real antennas
@@ -176,10 +184,10 @@ def generate_digitisers(args: argparse.Namespace, config: dict) -> list[str]:
                     "type": "dig.baseband_voltage",
                     "sync_time": args.sync_time,
                     "antenna": f"m{number}, 0:0:0, 0:0:0, 0, 0",
-                    "url": f"spead://{next_dig_ip}+7:7148",
+                    "url": f"spead://{next_dig_ip}+{n - 1}:7148",
                     **dig_config_common,
                 }
-                next_dig_ip += 8
+                next_dig_ip += n
     return dig_names
 
 

--- a/src/katgpucbf/__init__.py
+++ b/src/katgpucbf/__init__.py
@@ -42,8 +42,8 @@ DEFAULT_RECV_BUFFER_SIZE: Final = 2**27  # 128 MiB
 DEFAULT_KATCP_HOST: Final = ""  # All interfaces
 DEFAULT_KATCP_PORT: Final = 7147
 DEFAULT_JONES_PER_BATCH: Final = 2**20
-DIG_HEAP_SAMPLES: Final = 4096
-DIG_SAMPLE_BITS: Final = 10
+DEFAULT_DIG_HEAP_SAMPLES: Final = 4096
+DEFAULT_DIG_SAMPLE_BITS: Final = 10
 ENGINE_DITHER_SEED_BITS: Final = 64
 #: Minimum update period (in seconds) for katcp sensors where the underlying
 #: value may update extremely rapidly.

--- a/src/katgpucbf/dsim/descriptors.py
+++ b/src/katgpucbf/dsim/descriptors.py
@@ -19,7 +19,7 @@
 import spead2
 import spead2.send.asyncio
 
-from .. import DIG_HEAP_SAMPLES
+from .. import DEFAULT_DIG_HEAP_SAMPLES
 from ..spead import (
     ADC_SAMPLES_ID,
     DIGITISER_ID_ID,
@@ -62,7 +62,7 @@ def create_descriptors_heap() -> spead2.send.Heap:
         ADC_SAMPLES_ID,
         "adc_samples",
         "Digitiser Raw ADC Sample Data",
-        shape=(DIG_HEAP_SAMPLES,),
+        shape=(DEFAULT_DIG_HEAP_SAMPLES,),
         format=[("i", 10)],
     )
     descriptor_heap = item_group.get_heap(descriptors="all", data="none")

--- a/src/katgpucbf/dsim/main.py
+++ b/src/katgpucbf/dsim/main.py
@@ -32,7 +32,7 @@ import numpy as np
 import pyparsing as pp
 from katsdptelstate.endpoint import endpoint_list_parser
 
-from .. import BYTE_BITS, SPEAD_DESCRIPTOR_INTERVAL_S
+from .. import BYTE_BITS, DEFAULT_DIG_HEAP_SAMPLES, DEFAULT_DIG_SAMPLE_BITS, SPEAD_DESCRIPTOR_INTERVAL_S
 from ..main import add_common_arguments, add_send_arguments, add_time_converter_arguments, engine_main
 from ..send import DescriptorSender
 from ..utils import TimeConverter
@@ -52,8 +52,12 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         help="Specification for the signals to generate (see the usage guide). "
         "The specification must produce either a single signal, or one per output stream. [%(default)s]",
     )
-    parser.add_argument("--heap-samples", type=int, default=4096, help="Number of samples per heap [%(default)s]")
-    parser.add_argument("--sample-bits", type=int, default=10, help="Number of bits per sample [%(default)s]")
+    parser.add_argument(
+        "--heap-samples", type=int, default=DEFAULT_DIG_HEAP_SAMPLES, help="Number of samples per heap [%(default)s]"
+    )
+    parser.add_argument(
+        "--sample-bits", type=int, default=DEFAULT_DIG_SAMPLE_BITS, help="Number of bits per sample [%(default)s]"
+    )
     parser.add_argument("--first-id", type=int, default=0, help="Digitiser ID for first stream [%(default)s]")
     add_send_arguments(parser, prefix="", rate_factor=False)
     parser.add_argument(

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -34,6 +34,7 @@ from katsdpsigproc.abc import AbstractContext
 from katsdptelstate.endpoint import endpoint_list_parser
 
 from .. import (
+    DEFAULT_DIG_HEAP_SAMPLES,
     DEFAULT_DIG_SAMPLE_BITS,
     DEFAULT_JONES_PER_BATCH,
     DEFAULT_PACKET_PAYLOAD_BYTES,
@@ -170,7 +171,10 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     add_common_arguments(parser)
     add_recv_arguments(parser, multi=True)
     parser.add_argument(
-        "--recv-packet-samples", type=int, default=4096, help="Number of samples per digitiser packet [%(default)s]"
+        "--recv-packet-samples",
+        type=int,
+        default=DEFAULT_DIG_HEAP_SAMPLES,
+        help="Number of samples per digitiser packet [%(default)s]",
     )
     add_send_arguments(parser, multi=True)
     parser.add_argument(

--- a/src/katgpucbf/fgpu/main.py
+++ b/src/katgpucbf/fgpu/main.py
@@ -34,9 +34,9 @@ from katsdpsigproc.abc import AbstractContext
 from katsdptelstate.endpoint import endpoint_list_parser
 
 from .. import (
+    DEFAULT_DIG_SAMPLE_BITS,
     DEFAULT_JONES_PER_BATCH,
     DEFAULT_PACKET_PAYLOAD_BYTES,
-    DIG_SAMPLE_BITS,
 )
 from ..main import (
     SubParser,
@@ -224,7 +224,7 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--dig-sample-bits",
         type=int,
-        default=DIG_SAMPLE_BITS,
+        default=DEFAULT_DIG_SAMPLE_BITS,
         choices=DIG_SAMPLE_BITS_VALID,
         metavar="BITS",
         help="Number of bits per digitised sample [%(default)s]",

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -24,7 +24,7 @@ import numpy as np
 import prometheus_client
 from numpy.typing import NDArray
 
-from katgpucbf import BYTE_BITS, DIG_SAMPLE_BITS
+from katgpucbf import BYTE_BITS, DEFAULT_DIG_SAMPLE_BITS
 
 
 class PromDiff:
@@ -135,10 +135,10 @@ class PromDiff:
         return ret
 
 
-def unpackbits(data: NDArray[np.uint8], sample_bits: int = DIG_SAMPLE_BITS) -> np.ndarray:
+def unpackbits(data: NDArray[np.uint8], sample_bits: int = DEFAULT_DIG_SAMPLE_BITS) -> np.ndarray:
     """Unpack a bit-packed array of signed big-endian integers.
 
-    Typically `sample_bits` will be DIG_SAMPLE_BITS, but can be up to 64. The
+    Typically `sample_bits` will be DEFAULT_DIG_SAMPLE_BITS, but can be up to 64. The
     dtype of the result depends on the number of bits.
     """
     dtype: np.dtype
@@ -160,7 +160,7 @@ def unpackbits(data: NDArray[np.uint8], sample_bits: int = DIG_SAMPLE_BITS) -> n
     return packed.view(dtype.newbyteorder(">")).astype(dtype)
 
 
-def packbits(data: np.ndarray, sample_bits: int = DIG_SAMPLE_BITS) -> NDArray[np.uint8]:
+def packbits(data: np.ndarray, sample_bits: int = DEFAULT_DIG_SAMPLE_BITS) -> NDArray[np.uint8]:
     """Pack a bit-packed array of signed big-endian integers.
 
     This is the inverse of :meth:`unpackbits`, but it also handles

--- a/test/dsim/conftest.py
+++ b/test/dsim/conftest.py
@@ -25,10 +25,10 @@ import spead2.send.asyncio
 
 from katgpucbf import (
     BYTE_BITS,
+    DEFAULT_DIG_HEAP_SAMPLES,
+    DEFAULT_DIG_SAMPLE_BITS,
     DEFAULT_SEND_BUFFER_SIZE,
     DEFAULT_TTL,
-    DIG_HEAP_SAMPLES,
-    DIG_SAMPLE_BITS,
     SPEAD_DESCRIPTOR_INTERVAL_S,
     spead,
 )
@@ -80,8 +80,8 @@ def send_stream(
             heap_sets=[],  # Only needed for UdpIbvStream, which we're not using
             n_pols=N_POLS,
             adc_sample_rate=ADC_SAMPLE_RATE,
-            heap_samples=DIG_HEAP_SAMPLES,
-            sample_bits=DIG_SAMPLE_BITS,
+            heap_samples=DEFAULT_DIG_HEAP_SAMPLES,
+            sample_bits=DEFAULT_DIG_SAMPLE_BITS,
             max_heaps=SIGNAL_HEAPS * N_POLS,
             ttl=DEFAULT_TTL,
             interface_address="",
@@ -103,7 +103,10 @@ def heap_sets(timestamps: np.ndarray) -> Sequence[send.HeapSet]:
     """Two instances of :class:`~katgpucbf.dsim.send.HeapSet` with random payload bytes and one with zeros."""
     heap_sets = [
         send.HeapSet.create(
-            timestamps, [N_ENDPOINTS_PER_POL] * N_POLS, DIG_HEAP_SAMPLES * DIG_SAMPLE_BITS // BYTE_BITS, range(N_POLS)
+            timestamps,
+            [N_ENDPOINTS_PER_POL] * N_POLS,
+            DEFAULT_DIG_HEAP_SAMPLES * DEFAULT_DIG_SAMPLE_BITS // BYTE_BITS,
+            range(N_POLS),
         )
         for _ in range(3)
     ]
@@ -116,7 +119,7 @@ def heap_sets(timestamps: np.ndarray) -> Sequence[send.HeapSet]:
 @pytest.fixture
 def sender(send_stream: "spead2.send.asyncio.AsyncStream", heap_sets: Sequence[send.HeapSet]) -> send.Sender:
     """A :class:`~katgpucbf.dsim.Sender` using the first of :func:`heaps_sets`."""
-    return send.Sender(send_stream, heap_sets[0], DIG_HEAP_SAMPLES)
+    return send.Sender(send_stream, heap_sets[0], DEFAULT_DIG_HEAP_SAMPLES)
 
 
 @pytest.fixture

--- a/test/dsim/test_send.py
+++ b/test/dsim/test_send.py
@@ -27,7 +27,7 @@ import spead2.recv.asyncio
 import spead2.send.asyncio
 from spead2 import ItemGroup
 
-from katgpucbf import DIG_HEAP_SAMPLES
+from katgpucbf import DEFAULT_DIG_HEAP_SAMPLES
 from katgpucbf.dsim import send
 from katgpucbf.send import DescriptorSender
 from katgpucbf.utils import TimeConverter
@@ -121,7 +121,7 @@ async def test_sender(
     # Check that the descriptors received make sense.
     assert set(ig.keys()) == {"timestamp", "digitiser_id", "digitiser_status", "adc_samples"}
     assert ig["adc_samples"].format == [("i", 10)]
-    assert ig["adc_samples"].shape == (DIG_HEAP_SAMPLES,)
+    assert ig["adc_samples"].shape == (DEFAULT_DIG_HEAP_SAMPLES,)
 
     # Now proceed with DSim data using received descriptors (in ItemGroup)(ig)
     with PromDiff(namespace=send.METRIC_NAMESPACE) as prom_diff:
@@ -141,7 +141,7 @@ async def test_sender(
                 updated = ig.update(heap)
             except spead2.Stopped:
                 break
-            assert updated["timestamp"].value == i * DIG_HEAP_SAMPLES
+            assert updated["timestamp"].value == i * DEFAULT_DIG_HEAP_SAMPLES
             assert updated["digitiser_id"].value == pol
             assert updated["digitiser_status"].value == 0
             side = int(i >= switch_heap)
@@ -150,7 +150,7 @@ async def test_sender(
             np.testing.assert_equal(updated["adc_samples"].value, expected_unpacked)
         assert i == SIGNAL_HEAPS * repeats  # Check that all the data arrived
     assert switch_task is not None
-    assert (await switch_task) == switch_heap * DIG_HEAP_SAMPLES
+    assert (await switch_task) == switch_heap * DEFAULT_DIG_HEAP_SAMPLES
 
     # Check the Prometheus counters
     assert prom_diff.diff("output_heaps_total") == SIGNAL_HEAPS * repeats * N_POLS

--- a/test/dsim/test_server.py
+++ b/test/dsim/test_server.py
@@ -23,7 +23,7 @@ import aiokatcp
 import numpy as np
 import pytest
 
-from katgpucbf import DIG_HEAP_SAMPLES, DIG_SAMPLE_BITS
+from katgpucbf import DEFAULT_DIG_HEAP_SAMPLES, DEFAULT_DIG_SAMPLE_BITS
 from katgpucbf.dsim.send import HeapSet, Sender
 from katgpucbf.dsim.server import DEngine
 from katgpucbf.dsim.signal import parse_signals
@@ -45,7 +45,7 @@ async def engine(
         descriptor_sender=descriptor_sender,
         heap_sets=heap_sets,
         adc_sample_rate=ADC_SAMPLE_RATE,
-        sample_bits=DIG_SAMPLE_BITS,
+        sample_bits=DEFAULT_DIG_SAMPLE_BITS,
         dither_seed=dither_seed,
         host="127.0.0.1",
         port=0,
@@ -61,8 +61,8 @@ async def test_sensors(engine_client: aiokatcp.Client) -> None:
     assert await engine_client.sensor_value("signals-orig", str) == "cw(0.2, 123); cw(0.3, 456);"
     assert await engine_client.sensor_value("signals", str) == "cw(0.2, 123); cw(0.3, 456);"
     assert await engine_client.sensor_value("adc-sample-rate") == ADC_SAMPLE_RATE
-    assert await engine_client.sensor_value("sample-bits") == DIG_SAMPLE_BITS
-    assert await engine_client.sensor_value("max-period") == DIG_HEAP_SAMPLES * SIGNAL_HEAPS
+    assert await engine_client.sensor_value("sample-bits") == DEFAULT_DIG_SAMPLE_BITS
+    assert await engine_client.sensor_value("max-period") == DEFAULT_DIG_HEAP_SAMPLES * SIGNAL_HEAPS
     assert await engine_client.sensor_value("period") == SIGNAL_HEAPS
 
 
@@ -98,13 +98,13 @@ async def test_signals(
     )
     if period is None:  # The tests below depend on having enough unique data
         # Check that pol 1 is saturated about as much as expected
-        assert np.mean(status.isel(pol=1).data >> 32) / DIG_HEAP_SAMPLES == pytest.approx(2 / 3, abs=0.01)
+        assert np.mean(status.isel(pol=1).data >> 32) / DEFAULT_DIG_HEAP_SAMPLES == pytest.approx(2 / 3, abs=0.01)
         # Check that some heaps are entirely unsaturated, so that the
         # saturation flag consistency test is not vacuous.
         assert not np.all(status.isel(pol=1).data & (1 << DIGITISER_STATUS_SATURATION_FLAG_BIT))
     # Check that sensors were updated
     assert await engine_client.sensor_value("signals-orig", str) == signals_str
-    assert await engine_client.sensor_value("period") == (period or DIG_HEAP_SAMPLES * SIGNAL_HEAPS)
+    assert await engine_client.sensor_value("period") == (period or DEFAULT_DIG_HEAP_SAMPLES * SIGNAL_HEAPS)
     assert parse_signals(await engine_client.sensor_value("signals", str)) == parse_signals(signals_str)
 
 

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -33,7 +33,7 @@ import spead2.send
 from katsdpsigproc.accel import roundup
 from numpy.typing import ArrayLike
 
-from katgpucbf import COMPLEX, DIG_SAMPLE_BITS, N_POLS
+from katgpucbf import COMPLEX, DEFAULT_DIG_SAMPLE_BITS, N_POLS
 from katgpucbf.fgpu import METRIC_NAMESPACE
 from katgpucbf.fgpu.delay import wrap_angle
 from katgpucbf.fgpu.engine import (
@@ -700,7 +700,7 @@ class TestFEngine:
         "dig_sample_bits,send_sample_bits",
         [
             pytest.param(
-                DIG_SAMPLE_BITS, 4, marks=[pytest.mark.cmdline_args("--send-sample-bits=4"), pytest.mark.slow]
+                DEFAULT_DIG_SAMPLE_BITS, 4, marks=[pytest.mark.cmdline_args("--send-sample-bits=4"), pytest.mark.slow]
             ),
             pytest.param(12, 8, marks=pytest.mark.cmdline_args("--dig-sample-bits=12", "--send-sample-bits=8")),
         ],
@@ -913,7 +913,7 @@ class TestFEngine:
         dig_data = np.sum([self._make_tone(tone_timestamps, tone, 0) for tone in tones], axis=0)
         dig_data[1] = dig_data[0]  # Copy data from pol 0 to pol 1
         # Ensure we haven't saturated
-        assert np.max(np.abs(dig_data)) < 2 ** (DIG_SAMPLE_BITS - 1) - 1
+        assert np.max(np.abs(dig_data)) < 2 ** (DEFAULT_DIG_SAMPLE_BITS - 1) - 1
 
         expected_first_timestamp = first_timestamp
         # The data should have as many samples as the input, minus a reduction
@@ -1329,7 +1329,7 @@ class TestFEngine:
         rng = np.random.default_rng(seed=1)
         # Should be low enough to limit saturation but high enough to minimise
         # impact of quantisation noise.
-        dig_max = 2 ** (DIG_SAMPLE_BITS - 1) - 1
+        dig_max = 2 ** (DEFAULT_DIG_SAMPLE_BITS - 1) - 1
         sigma = 40.0
         dig_data = np.rint(rng.normal(scale=sigma, size=(2, n_samples)).clip(-dig_max, dig_max)).astype(int)
         out_data, timestamps = await self._send_data(


### PR DESCRIPTION
<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`.
- [x] (n/a) If new source files are added: add copyright notices dated with the current year.
- [x] (n/a) If qualification tests are changed: attach or link to a sample qualification report.
- [x] (n/a) If design has changed: ensure documentation is up to date.
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match.
- [x] (n/a) If the interface between the product controller and an engine has changed, update the
      VERSION constant for the engine (update the major number if sensors/requests have been
      removed/changed, minor number if only backwards-compatible changes have been done).
      Also, update doc/control.rst with the new version.

Closes NGC-1796.
