### PR TITLE
Fix leak of sockets from VDIFSender

### DIFF
--- a/src/katgpucbf/vgpu/send.py
+++ b/src/katgpucbf/vgpu/send.py
@@ -177,27 +177,34 @@ class VDIFSender(RateLimiter[list[VDIFFrame]]):
         # Create a socket per destination, distributing them
         # over the interfaces.
         if_addrs = [ipaddress.IPv4Address(address) for address in interfaces]
-        self._socks = []
+        socks = []
         self._sequence = 0
-        for i, dst in enumerate(dsts):
-            if not ipaddress.IPv4Address(dst[0]).is_multicast:
-                raise ValueError(f"Destination address {dst[0]} is not a multicast address")
-            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
-            sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, ttl)
-            if_addr = if_addrs[i % len(if_addrs)]
-            # struct ip_mreq contains an address and an interface address;
-            # IP_MULTICAST_IF only uses the latter.
-            sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, b"\0\0\0\0" + if_addr.packed)
-            try:
-                sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, buffer_size)
-            except OSError as exc:
-                logger.warning("Failed to set socket buffer size to %d: %s", buffer_size, exc)
-            actual_buffer = sock.getsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF)
-            if actual_buffer < buffer_size:
-                logger.warning("Requested socket buffer size %d but actual size is %d", buffer_size, actual_buffer)
-            sock.connect(dst)
-            self._socks.append(sock)
-        self._next_sock = 0
+        try:
+            for i, dst in enumerate(dsts):
+                if not ipaddress.IPv4Address(dst[0]).is_multicast:
+                    raise ValueError(f"Destination address {dst[0]} is not a multicast address")
+                sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+                sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, ttl)
+                if_addr = if_addrs[i % len(if_addrs)]
+                # struct ip_mreq contains an address and an interface address;
+                # IP_MULTICAST_IF only uses the latter.
+                sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, b"\0\0\0\0" + if_addr.packed)
+                try:
+                    sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, buffer_size)
+                except OSError as exc:
+                    logger.warning("Failed to set socket buffer size to %d: %s", buffer_size, exc)
+                actual_buffer = sock.getsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF)
+                if actual_buffer < buffer_size:
+                    logger.warning("Requested socket buffer size %d but actual size is %d", buffer_size, actual_buffer)
+                sock.connect(dst)
+                socks.append(sock)
+            self._next_sock = 0
+            self._socks = socks
+            socks = []  # Prevent the finally from closing anything
+        finally:
+            # Clean up on exception
+            for sock in socks:
+                sock.close()
 
     @override
     def item_size(self, item: list[VDIFFrame]) -> int:
@@ -247,3 +254,10 @@ class VDIFSender(RateLimiter[list[VDIFFrame]]):
     async def _process_item(self, item: list[VDIFFrame]) -> None:
         for frame in item:
             await self._send_frame(frame)
+
+    @override
+    async def stop(self) -> None:
+        await super().stop()
+        for sock in self._socks:
+            sock.close()
+        self._socks.clear()  # Avoid attempting to re-close them if stop() is called again()


### PR DESCRIPTION
On stop(), close the sockets. Also close them if there was an exception in the constructor.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`.
- [x] (n/a) If new source files are added: add copyright notices dated with the current year.
- [x] (n/a) If qualification tests are changed: attach or link to a sample qualification report.
- [x] (n/a) If design has changed: ensure documentation is up to date.
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match.
- [x] (n/a) If the interface between the product controller and an engine has changed, update the
      VERSION constant for the engine (update the major number if sensors/requests have been
      removed/changed, minor number if only backwards-compatible changes have been done).
      Also, update doc/control.rst with the new version.

Closes NGC-1987.
