### PR TITLE
Add a label to Jenkins-built Docker images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,9 +168,10 @@ pipeline {
           registryCredentialsId 'dockerhub'  // Supply credentials to avoid rate limit
 
           /* Use the Jenkins-specific stage of the Dockerfile as the image for
-           * testing. This provides the appropriate dependencies.
+           * testing. This provides the appropriate dependencies. The label
+           * is just to assist with garbage collection.
            */
-          additionalBuildArgs '--target=jenkins'
+          additionalBuildArgs "--target=jenkins --label=za.ac.kat.dpp.jenkins.build=${env.BUILD_ID}"
 
           /* The following arguments needs to be specified in order for the container
            * to launch correctly.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,9 +42,10 @@ pipeline {
           registryCredentialsId 'dockerhub'  // Supply credentials to avoid rate limit
 
           /* Use the Jenkins-specific stage of the Dockerfile as the image for
-           * testing. This provides the appropriate dependencies.
+           * testing. This provides the appropriate dependencies. The label
+           * is just to assist with garbage collection.
            */
-          additionalBuildArgs '--target=jenkins'
+          additionalBuildArgs "--target=jenkins --label=za.ac.kat.dpp.jenkins.build=${env.BUILD_ID}"
 
           /* The following arguments needs to be specified in order for the container
            * to launch correctly.

--- a/qualification/Jenkinsfile
+++ b/qualification/Jenkinsfile
@@ -47,9 +47,10 @@ pipeline {
       registryCredentialsId 'dockerhub'  // Supply credentials to avoid rate limit
 
       /* Use the Jenkins-specific stage of the Dockerfile as the image for
-       * testing. This provides the appropriate dependencies.
+       * testing. This provides the appropriate dependencies. The label
+       * is just to assist with garbage collection.
        */
-      additionalBuildArgs '--target=jenkins'
+      additionalBuildArgs "--target=jenkins --label=za.ac.kat.dpp.jenkins.build=${env.BUILD_ID}"
 
       /* The following argument needs to be specified in order for the container
        * to launch correctly.


### PR DESCRIPTION
This will help in future with filtering them for 'docker image prune'.

See NGC-1995
