### PR TITLE
Update aiohttp to the latest version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
         types_or: [python, pyi]
         additional_dependencies: [
             'aioconsole==0.8.2',
+            'aiohttp==3.14.1',
             'aiokatcp==2.2.0',
             'aiomonitor==0.7.1',
             'astropy==7.2.0',

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -10,7 +10,7 @@ aiohappyeyeballs==2.6.1
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
     #   aiohttp
-aiohttp==3.13.4
+aiohttp==3.14.1
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
@@ -411,6 +411,7 @@ typing-extensions==4.15.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   -c qualification/../requirements.txt
+    #   aiohttp
     #   aiokatcp
     #   aiomonitor
     #   aiosignal

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ aiohappyeyeballs==2.6.1
     # via
     #   -c requirements.txt
     #   aiohttp
-aiohttp==3.13.4
+aiohttp==3.14.1
     # via
     #   -c requirements.txt
     #   katgpucbf (pyproject.toml)
@@ -468,6 +468,7 @@ traitlets==5.14.3
 typing-extensions==4.15.0
     # via
     #   -c requirements.txt
+    #   aiohttp
     #   aiokatcp
     #   aiomonitor
     #   aiosignal

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aioconsole==0.8.2
     # via aiomonitor
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.13.4
+aiohttp==3.14.1
     # via
     #   katgpucbf (pyproject.toml)
     #   aiomonitor
@@ -185,6 +185,7 @@ trafaret==2.1.1
     # via aiomonitor
 typing-extensions==4.15.0
     # via
+    #   aiohttp
     #   aiokatcp
     #   aiomonitor
     #   aiosignal


### PR DESCRIPTION
This is to keep dependabot happy.

I also added it to the mypy config for per-commit, since it is used directly by scratch/benchmarks.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`.
- [x] (n/a) If new source files are added: add copyright notices dated with the current year.
- [x] (n/a) If qualification tests are changed: attach or link to a sample qualification report.
- [x] (n/a) If design has changed: ensure documentation is up to date.
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match.
- [x] (n/a) If the interface between the product controller and an engine has changed, update the
      VERSION constant for the engine (update the major number if sensors/requests have been
      removed/changed, minor number if only backwards-compatible changes have been done).
      Also, update doc/control.rst with the new version.

Closes NGC-2047.
