### PR TITLE
Update send enabled usages for correlator startup

### DIFF
--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -428,7 +428,23 @@ async def cbf_cache(pytestconfig: pytest.Config) -> AsyncGenerator[CBFCache, Non
 
 
 @pytest.fixture
-async def capture_start_streams(request: pytest.FixtureRequest, cbf_config: dict) -> list[str]:
+async def capture_stop_streams(cbf_config: dict, vlbi: bool) -> list[str]:
+    """List of streams for which capture-stop will automatically be issued."""
+    out = []
+    for name, conf in cbf_config["outputs"].items():
+        if conf["type"] in _CAPTURE_TYPES:
+            out.append(name)
+
+    if vlbi:
+        vlbi_config = cbf_config["outputs"]["tied-array-resampled-voltage"]
+        for beam_stream in vlbi_config["src_streams"]:
+            logger.info(f"Beam {beam_stream} required for VLBI")
+            out.remove(beam_stream)
+    return out
+
+
+@pytest.fixture
+async def capture_start_streams(request: pytest.FixtureRequest, capture_stop_streams: list[str]) -> list[str]:
     """List of streams for which capture-start will automatically be issued."""
     no_capture_start: set[str] = set()
     for marker in request.node.iter_markers("no_capture_start"):
@@ -437,8 +453,8 @@ async def capture_start_streams(request: pytest.FixtureRequest, cbf_config: dict
         no_capture_start.update(marker.args)
 
     out = []
-    for name, conf in cbf_config["outputs"].items():
-        if name not in no_capture_start and conf["type"] in _CAPTURE_TYPES:
+    for name in capture_stop_streams:
+        if name not in no_capture_start:
             out.append(name)
     return out
 
@@ -527,6 +543,7 @@ async def cbf(
     cbf_mode_config: dict,
     core_allocator: CoreAllocator,
     capture_start_streams: list[str],
+    capture_stop_streams: list[str],
     tied_array_channelised_voltage_receive_streams: list[str],
     pdf_report: Reporter,
 ) -> AsyncGenerator[CBFRemoteControl, None]:
@@ -588,9 +605,8 @@ async def cbf(
 
     yield cbf
 
-    for name, conf in cbf.config["outputs"].items():
-        if conf["type"] in _CAPTURE_TYPES:
-            await pcc.request("capture-stop", name)
+    for name in capture_stop_streams:
+        await pcc.request("capture-stop", name)
 
 
 @pytest.fixture

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -436,10 +436,11 @@ async def capture_stop_streams(cbf_config: dict, vlbi: bool) -> list[str]:
             out.append(name)
 
     if vlbi:
-        vlbi_config = cbf_config["outputs"]["tied-array-resampled-voltage"]
-        for beam_stream in vlbi_config["src_streams"]:
-            logger.info(f"Beam {beam_stream} required for VLBI")
-            out.remove(beam_stream)
+        for conf in cbf_config["outputs"].values():
+            if conf["type"].startswith("gpucbf."):
+                presence_filter = filter(lambda src_stream: src_stream in out, conf["src_streams"])
+                for stream in presence_filter:
+                    out.remove(stream)
     return out
 
 

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -428,19 +428,17 @@ async def cbf_cache(pytestconfig: pytest.Config) -> AsyncGenerator[CBFCache, Non
 
 
 @pytest.fixture
-async def capture_stop_streams(cbf_config: dict, vlbi: bool) -> list[str]:
+async def capture_stop_streams(cbf_config: dict) -> list[str]:
     """List of streams for which capture-stop will automatically be issued."""
     out = []
     for name, conf in cbf_config["outputs"].items():
         if conf["type"] in _CAPTURE_TYPES:
             out.append(name)
 
-    if vlbi:
-        for conf in cbf_config["outputs"].values():
-            if conf["type"].startswith("gpucbf."):
-                presence_filter = filter(lambda src_stream: src_stream in out, conf["src_streams"])
-                for stream in presence_filter:
-                    out.remove(stream)
+    for conf in cbf_config["outputs"].values():
+        for stream in conf.get("src_streams", []):
+            if stream in out:
+                out.remove(stream)
     return out
 
 

--- a/qualification/tied_array_channelised_voltage/test_steady_state.py
+++ b/qualification/tied_array_channelised_voltage/test_steady_state.py
@@ -14,22 +14,7 @@
 # limitations under the License.
 ################################################################################
 
-"""Test capture-start following state change requests.
-
-.. note::
-
-    capture-start requests cannot be issued to tied-array-channelised-voltage
-    streams that feed tied-array-resampled-voltage (VLBI) streams.
-    :meth:`._test_capture_start` filters out any such streams from the list
-    to which capture-start requests are issued.
-
-    Due to the way the CBF config is generated, tied-array-channelised-voltage-{0x, 0y}
-    are always used as src_streams for a tied-array-resampled-voltage stream. These two
-    beam streams are always first in the list of stream names for a
-    :class:`.TiedArrayChannelisedVoltageReceiver`. As a result, the tests herein only
-    only issue state change requests to the last beam stream, which is guaranteed to
-    not be a src_stream for any tied-array-resampled-voltage stream.
-"""
+"""Test capture-start following state change requests."""
 
 import asyncio
 from collections.abc import Awaitable, Callable
@@ -43,9 +28,28 @@ from ..cbf import CBFRemoteControl
 from ..recv import TiedArrayChannelisedVoltageReceiver
 
 
+@pytest.fixture
+def streams_in_use(
+    receive_tied_array_channelised_voltage: TiedArrayChannelisedVoltageReceiver, capture_stop_streams: list[str]
+) -> list[str]:
+    """The streams that are both in the receiver and in `capture_stop_streams`."""
+    return sorted(list(set(receive_tied_array_channelised_voltage.stream_names) & set(capture_stop_streams)))
+
+
+@pytest.fixture
+def stream_index_under_test(
+    streams_in_use: list[str],
+    receive_tied_array_channelised_voltage: TiedArrayChannelisedVoltageReceiver,
+    stream_index_in_use: int = 0,
+) -> int:
+    """Index of the first stream in `streams_in_use` in the receiver."""
+    return receive_tied_array_channelised_voltage.stream_names.index(streams_in_use[stream_index_in_use])
+
+
 async def _test_capture_start(
     cbf: CBFRemoteControl,
     receiver: TiedArrayChannelisedVoltageReceiver,
+    streams_in_use: list[str],
     pdf_report: Reporter,
     prepare: Callable[[], Awaitable],
 ) -> np.ndarray:
@@ -54,6 +58,13 @@ async def _test_capture_start(
     Each test provides a callback that issues a request to the product
     controller. The received data is returned for the test to do
     verification.
+
+    capture-start requests cannot be issued to tied-array-channelised-voltage
+    streams that feed tied-array-resampled-voltage (VLBI) streams. `streams_in_use`
+    is filtered to exclude such streams.
+
+    The tests are run with the assumption that the first stream in `streams_in_use`
+    is the stream under test.
     """
     pcc = cbf.product_controller_client
 
@@ -69,7 +80,7 @@ async def _test_capture_start(
     pdf_report.step("Wait for injected signal to reach XB-engines Tx.")
     # Only need to query one stream, since it's the same engine backing
     # all of them.
-    stream_name = receiver.stream_names[0]
+    stream_name = streams_in_use[0]
     for _ in range(30):
         tasks = []
         async with asyncio.TaskGroup() as tg:
@@ -88,17 +99,9 @@ async def _test_capture_start(
     await prepare()
 
     pdf_report.step("Capture and verify output")
-    # Make a copy of this list as the metohd (and its fixtures) are reused between tests
-    capture_start_streams = receiver.stream_names.copy()
-    # Note: If CBF has a VLBI stream, we cannot issue ?capture-start to its
-    # src beam streams.
-    vlbi_config = cbf.config["outputs"].get("tied-array-resampled-voltage", None)
-    if vlbi_config is not None:
-        for src_beam_stream in vlbi_config["src_streams"]:
-            capture_start_streams.remove(src_beam_stream)
 
     async with asyncio.TaskGroup() as tg:
-        for stream in capture_start_streams:
+        for stream in streams_in_use:
             tg.create_task(pcc.request("capture-start", stream))
     # We use dsim_timestamp as a minimum to ensure that we're not receiving
     # data from a *previous* capture-start/stop.
@@ -111,6 +114,8 @@ async def _test_capture_start(
 async def test_beam_quant_gains_capture_start(
     cbf: CBFRemoteControl,
     receive_tied_array_channelised_voltage: TiedArrayChannelisedVoltageReceiver,
+    streams_in_use: list[str],
+    stream_index_under_test: int,
     pdf_report: Reporter,
 ) -> None:
     """Test that beam-quant-gains issued before capture-start is not delayed.
@@ -124,12 +129,14 @@ async def test_beam_quant_gains_capture_start(
 
     async def prepare() -> None:
         pdf_report.step("Send request.")
-        pdf_report.detail("Set beam-quant-gains to 0 on first beam.")
-        await cbf.product_controller_client.request("beam-quant-gains", receiver.stream_names[-1], 0.0)
+        pdf_report.detail(f"Set beam-quant-gains to 0 on beam {streams_in_use[0]}.")
+        await cbf.product_controller_client.request("beam-quant-gains", streams_in_use[0], 0.0)
 
-    data = await _test_capture_start(cbf, receiver, pdf_report, prepare)
-    assert np.all(data[-1] == 0)
-    assert np.sum(data[1] != 0) >= data[1].size // 2  # Should be mostly non-zero
+    data = await _test_capture_start(cbf, receiver, streams_in_use, pdf_report, prepare)
+    assert np.all(data[stream_index_under_test] == 0)
+    assert (
+        np.sum(data[stream_index_under_test + 1] != 0) >= data[stream_index_under_test + 1].size // 2
+    )  # Should be mostly non-zero
     pdf_report.detail("Output reflects effects of beam-quant-gains.")
 
 
@@ -138,6 +145,8 @@ async def test_beam_quant_gains_capture_start(
 async def test_beam_weights_capture_start(
     cbf: CBFRemoteControl,
     receive_tied_array_channelised_voltage: TiedArrayChannelisedVoltageReceiver,
+    streams_in_use: list[str],
+    stream_index_under_test: int,
     pdf_report: Reporter,
 ) -> None:
     """Test that beam-weights issued before capture-start is not delayed.
@@ -151,13 +160,15 @@ async def test_beam_weights_capture_start(
 
     async def prepare() -> None:
         pdf_report.step("Send request.")
-        pdf_report.detail("Set beam-weights to 0 on first beam.")
+        pdf_report.detail(f"Set beam-weights to 0 on beam {streams_in_use[0]}.")
         weights = [0.0] * len(receiver.source_indices[0])
-        await cbf.product_controller_client.request("beam-weights", receiver.stream_names[-1], *weights)
+        await cbf.product_controller_client.request("beam-weights", streams_in_use[0], *weights)
 
-    data = await _test_capture_start(cbf, receiver, pdf_report, prepare)
-    assert np.all(data[-1] == 0)
-    assert np.sum(data[1] != 0) >= data[1].size // 2  # Should be mostly non-zero
+    data = await _test_capture_start(cbf, receiver, streams_in_use, pdf_report, prepare)
+    assert np.all(data[stream_index_under_test] == 0)
+    assert (
+        np.sum(data[stream_index_under_test + 1] != 0) >= data[stream_index_under_test + 1].size // 2
+    )  # Should be mostly non-zero
     pdf_report.detail("Output reflects effects of beam-weights.")
 
 
@@ -166,6 +177,8 @@ async def test_beam_weights_capture_start(
 async def test_beam_delays_capture_start(
     cbf: CBFRemoteControl,
     receive_tied_array_channelised_voltage: TiedArrayChannelisedVoltageReceiver,
+    streams_in_use: list[str],
+    stream_index_under_test: int,
     pdf_report: Reporter,
 ) -> None:
     """Test that beam-delays issued before capture-start is not delayed.
@@ -179,14 +192,16 @@ async def test_beam_delays_capture_start(
 
     async def prepare() -> None:
         pdf_report.step("Send request.")
-        pdf_report.detail("Set beam-delays to phase π on first beam.")
+        pdf_report.detail(f"Set beam-delays to phase π on beam {streams_in_use[0]}.")
         delays = [f"0:{np.pi}"] * len(receiver.source_indices[0])
-        await cbf.product_controller_client.request("beam-delays", receiver.stream_names[-1], *delays)
+        await cbf.product_controller_client.request("beam-delays", streams_in_use[0], *delays)
 
-    data = await _test_capture_start(cbf, receiver, pdf_report, prepare)
-    assert np.sum(data[-1] != 0) >= data[-1].size // 2  # Should be mostly non-zero
-    # We use data[2] instead of data[1], because data[1] is the other
-    # polarisation and so experiences different F-engine dithering. The
-    # tolerance allows for some rounding error plus dithered quantisation.
-    np.testing.assert_allclose(data[-1], -data[-3], atol=2)
+    data = await _test_capture_start(cbf, receiver, streams_in_use, pdf_report, prepare)
+    assert (
+        np.sum(data[stream_index_under_test] != 0) >= data[stream_index_under_test].size // 2
+    )  # Should be mostly non-zero
+    # We use a data subset two indices over because the immediate neighbour
+    # is the other polarisation and so experiences different F-engine dithering.
+    # The tolerance allows for some rounding error plus dithered quantisation.
+    np.testing.assert_allclose(data[stream_index_under_test], -data[stream_index_under_test + 2], atol=2)
     pdf_report.detail("Output reflects effects of beam-delays.")

--- a/qualification/tied_array_channelised_voltage/test_steady_state.py
+++ b/qualification/tied_array_channelised_voltage/test_steady_state.py
@@ -14,7 +14,22 @@
 # limitations under the License.
 ################################################################################
 
-"""Test capture-start following state change requests."""
+"""Test capture-start following state change requests.
+
+.. note::
+
+    capture-start requests cannot be issued to tied-array-channelised-voltage
+    streams that feed tied-array-resampled-voltage (VLBI) streams.
+    :meth:`._test_capture_start` filters out any such streams from the list
+    to which capture-start requests are issued.
+
+    Due to the way the CBF config is generated, tied-array-channelised-voltage-{0x, 0y}
+    are always used as src_streams for a tied-array-resampled-voltage stream. These two
+    beam streams are always first in the list of stream names for a
+    :class:`.TiedArrayChannelisedVoltageReceiver`. As a result, the tests herein only
+    only issue state change requests to the last beam stream, which is guaranteed to
+    not be a src_stream for any tied-array-resampled-voltage stream.
+"""
 
 import asyncio
 from collections.abc import Awaitable, Callable
@@ -73,8 +88,17 @@ async def _test_capture_start(
     await prepare()
 
     pdf_report.step("Capture and verify output")
+    # Make a copy of this list as the metohd (and its fixtures) are reused between tests
+    capture_start_streams = receiver.stream_names.copy()
+    # Note: If CBF has a VLBI stream, we cannot issue ?capture-start to its
+    # src beam streams.
+    vlbi_config = cbf.config["outputs"].get("tied-array-resampled-voltage", None)
+    if vlbi_config is not None:
+        for src_beam_stream in vlbi_config["src_streams"]:
+            capture_start_streams.remove(src_beam_stream)
+
     async with asyncio.TaskGroup() as tg:
-        for stream in receiver.stream_names:
+        for stream in capture_start_streams:
             tg.create_task(pcc.request("capture-start", stream))
     # We use dsim_timestamp as a minimum to ensure that we're not receiving
     # data from a *previous* capture-start/stop.
@@ -101,10 +125,10 @@ async def test_beam_quant_gains_capture_start(
     async def prepare() -> None:
         pdf_report.step("Send request.")
         pdf_report.detail("Set beam-quant-gains to 0 on first beam.")
-        await cbf.product_controller_client.request("beam-quant-gains", receiver.stream_names[0], 0.0)
+        await cbf.product_controller_client.request("beam-quant-gains", receiver.stream_names[-1], 0.0)
 
     data = await _test_capture_start(cbf, receiver, pdf_report, prepare)
-    assert np.all(data[0] == 0)
+    assert np.all(data[-1] == 0)
     assert np.sum(data[1] != 0) >= data[1].size // 2  # Should be mostly non-zero
     pdf_report.detail("Output reflects effects of beam-quant-gains.")
 
@@ -129,10 +153,10 @@ async def test_beam_weights_capture_start(
         pdf_report.step("Send request.")
         pdf_report.detail("Set beam-weights to 0 on first beam.")
         weights = [0.0] * len(receiver.source_indices[0])
-        await cbf.product_controller_client.request("beam-weights", receiver.stream_names[0], *weights)
+        await cbf.product_controller_client.request("beam-weights", receiver.stream_names[-1], *weights)
 
     data = await _test_capture_start(cbf, receiver, pdf_report, prepare)
-    assert np.all(data[0] == 0)
+    assert np.all(data[-1] == 0)
     assert np.sum(data[1] != 0) >= data[1].size // 2  # Should be mostly non-zero
     pdf_report.detail("Output reflects effects of beam-weights.")
 
@@ -157,12 +181,12 @@ async def test_beam_delays_capture_start(
         pdf_report.step("Send request.")
         pdf_report.detail("Set beam-delays to phase π on first beam.")
         delays = [f"0:{np.pi}"] * len(receiver.source_indices[0])
-        await cbf.product_controller_client.request("beam-delays", receiver.stream_names[0], *delays)
+        await cbf.product_controller_client.request("beam-delays", receiver.stream_names[-1], *delays)
 
     data = await _test_capture_start(cbf, receiver, pdf_report, prepare)
-    assert np.sum(data[0] != 0) >= data[0].size // 2  # Should be mostly non-zero
+    assert np.sum(data[-1] != 0) >= data[-1].size // 2  # Should be mostly non-zero
     # We use data[2] instead of data[1], because data[1] is the other
     # polarisation and so experiences different F-engine dithering. The
     # tolerance allows for some rounding error plus dithered quantisation.
-    np.testing.assert_allclose(data[0], -data[2], atol=2)
+    np.testing.assert_allclose(data[-1], -data[2], atol=2)
     pdf_report.detail("Output reflects effects of beam-delays.")

--- a/qualification/tied_array_channelised_voltage/test_steady_state.py
+++ b/qualification/tied_array_channelised_voltage/test_steady_state.py
@@ -33,17 +33,16 @@ def streams_in_use(
     receive_tied_array_channelised_voltage: TiedArrayChannelisedVoltageReceiver, capture_stop_streams: list[str]
 ) -> list[str]:
     """The streams that are both in the receiver and in `capture_stop_streams`."""
-    return sorted(list(set(receive_tied_array_channelised_voltage.stream_names) & set(capture_stop_streams)))
+    return sorted(set(receive_tied_array_channelised_voltage.stream_names) & set(capture_stop_streams))
 
 
 @pytest.fixture
 def stream_index_under_test(
     streams_in_use: list[str],
     receive_tied_array_channelised_voltage: TiedArrayChannelisedVoltageReceiver,
-    stream_index_in_use: int = 0,
 ) -> int:
     """Index of the first stream in `streams_in_use` in the receiver."""
-    return receive_tied_array_channelised_voltage.stream_names.index(streams_in_use[stream_index_in_use])
+    return receive_tied_array_channelised_voltage.stream_names.index(streams_in_use[0])
 
 
 async def _test_capture_start(
@@ -202,6 +201,11 @@ async def test_beam_delays_capture_start(
     )  # Should be mostly non-zero
     # We use a data subset two indices over because the immediate neighbour
     # is the other polarisation and so experiences different F-engine dithering.
+    reference_stream_index = stream_index_under_test + 2
+    if stream_index_under_test >= 2:
+        # NOTE: The `receiver` only requires that we have 2 dual-pol beams (4 tacv streams).
+        # If streams 0 and 1 are used for VLBI, we might index off the end of the array.
+        reference_stream_index = stream_index_under_test - 2
     # The tolerance allows for some rounding error plus dithered quantisation.
-    np.testing.assert_allclose(data[stream_index_under_test], -data[stream_index_under_test + 2], atol=2)
+    np.testing.assert_allclose(data[stream_index_under_test], -data[reference_stream_index], atol=2)
     pdf_report.detail("Output reflects effects of beam-delays.")

--- a/qualification/tied_array_channelised_voltage/test_steady_state.py
+++ b/qualification/tied_array_channelised_voltage/test_steady_state.py
@@ -188,5 +188,5 @@ async def test_beam_delays_capture_start(
     # We use data[2] instead of data[1], because data[1] is the other
     # polarisation and so experiences different F-engine dithering. The
     # tolerance allows for some rounding error plus dithered quantisation.
-    np.testing.assert_allclose(data[-1], -data[2], atol=2)
+    np.testing.assert_allclose(data[-1], -data[-3], atol=2)
     pdf_report.detail("Output reflects effects of beam-delays.")

--- a/scratch/sim_correlator.py
+++ b/scratch/sim_correlator.py
@@ -39,8 +39,7 @@ from katgpucbf.main import comma_split
 from katgpucbf.meerkat import BANDS
 
 #: Stream types for which ``?capture-start`` is valid
-GPUCBF_DATA_STREAMS = {
-    "gpucbf.antenna_channelised_voltage",
+CAPTURE_START_TYPES = {
     "gpucbf.baseline_correlation_products",
     "gpucbf.tied_array_channelised_voltage",
     "gpucbf.tied_array_resampled_voltage",
@@ -311,15 +310,14 @@ async def issue_config(host: str, port: int, name: str, config: dict) -> int:
 
         product_client = await aiokatcp.Client.connect(product_host, product_port)
         capture_start_streams = []
-        src_streams = []
-        for output_name, output in config["outputs"].items():
-            if output["type"] in GPUCBF_DATA_STREAMS:
-                capture_start_streams.append(output_name)
-                src_streams.extend(output["src_streams"])
+        for name, conf in config["outputs"].items():
+            if conf["type"] in CAPTURE_START_TYPES:
+                capture_start_streams.append(name)
 
-        for output_name, output in config["outputs"].items():
-            if output["type"].startswith("gpucbf.") and output_name in src_streams:
-                capture_start_streams.remove(output_name)
+        for conf in config["outputs"].values():
+            for stream in conf.get("src_streams", []):
+                if stream in capture_start_streams:
+                    capture_start_streams.remove(stream)
 
         for output_name in capture_start_streams:
             print(f"Enabling {output_name} transmission...")

--- a/scratch/sim_correlator.py
+++ b/scratch/sim_correlator.py
@@ -39,7 +39,8 @@ from katgpucbf.main import comma_split
 from katgpucbf.meerkat import BANDS
 
 #: Stream types for which ``?capture-start`` is valid
-CAPTURE_START_TYPES = {
+GPUCBF_DATA_STREAMS = {
+    "gpucbf.antenna_channelised_voltage",
     "gpucbf.baseline_correlation_products",
     "gpucbf.tied_array_channelised_voltage",
     "gpucbf.tied_array_resampled_voltage",
@@ -292,7 +293,7 @@ def generate_config(args: argparse.Namespace) -> dict:
     return config
 
 
-async def issue_config(host: str, port: int, name: str, config: dict, has_vlbi: bool) -> int:
+async def issue_config(host: str, port: int, name: str, config: dict) -> int:
     """Connect to the product controller and issue ``?product-configure``).
 
     Returns
@@ -309,13 +310,20 @@ async def issue_config(host: str, port: int, name: str, config: dict, has_vlbi: 
         print(f"Product controller is at {product_host}:{product_port}")
 
         product_client = await aiokatcp.Client.connect(product_host, product_port)
+        capture_start_streams = []
+        src_streams = []
         for output_name, output in config["outputs"].items():
-            if output["type"] in CAPTURE_START_TYPES:
-                if has_vlbi and "narrow0-tied-array-channelised-voltage" in output_name:
-                    # vgpu src-streams are pre-enabled by katsdpcontroller
-                    continue
-                print(f"Enabling {output_name} transmission...")
-                await product_client.request("capture-start", output_name)
+            if output["type"] in GPUCBF_DATA_STREAMS:
+                capture_start_streams.append(output_name)
+                src_streams.extend(output["src_streams"])
+
+        for output_name, output in config["outputs"].items():
+            if output["type"].startswith("gpucbf.") and output_name in src_streams:
+                capture_start_streams.remove(output_name)
+
+        for output_name in capture_start_streams:
+            print(f"Enabling {output_name} transmission...")
+            await product_client.request("capture-start", output_name)
     except (aiokatcp.FailReply, ConnectionError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
@@ -335,8 +343,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             f.write("\n")  # json.dump doesn't write a final newline
         return 0
     else:
-        # Pass a boolean that indicates VLBI or not
-        return asyncio.run(issue_config(args.controller, args.port, args.name, config, args.vlbi))
+        return asyncio.run(issue_config(args.controller, args.port, args.name, config))
 
 
 if __name__ == "__main__":

--- a/scratch/sim_correlator.py
+++ b/scratch/sim_correlator.py
@@ -315,10 +315,10 @@ async def issue_config(host: str, port: int, name: str, config: dict) -> int:
                 capture_start_streams.append(name)
 
         for conf in config["outputs"].values():
-            for stream in conf.get("src_streams", []):
-                if stream in capture_start_streams:
-                    capture_start_streams.remove(stream)
-
+            if conf["type"].startswith("gpucbf."):
+                for stream in conf["src_streams"]:
+                    if stream in capture_start_streams:
+                        capture_start_streams.remove(stream)
         for output_name in capture_start_streams:
             print(f"Enabling {output_name} transmission...")
             await product_client.request("capture-start", output_name)

--- a/scratch/sim_correlator.py
+++ b/scratch/sim_correlator.py
@@ -292,7 +292,7 @@ def generate_config(args: argparse.Namespace) -> dict:
     return config
 
 
-async def issue_config(host: str, port: int, name: str, config: dict) -> int:
+async def issue_config(host: str, port: int, name: str, config: dict, has_vlbi: bool) -> int:
     """Connect to the product controller and issue ``?product-configure``).
 
     Returns
@@ -311,6 +311,9 @@ async def issue_config(host: str, port: int, name: str, config: dict) -> int:
         product_client = await aiokatcp.Client.connect(product_host, product_port)
         for output_name, output in config["outputs"].items():
             if output["type"] in CAPTURE_START_TYPES:
+                if has_vlbi and "narrow0-tied-array-channelised-voltage" in output_name:
+                    # vgpu src-streams are pre-enabled by katsdpcontroller
+                    continue
                 print(f"Enabling {output_name} transmission...")
                 await product_client.request("capture-start", output_name)
     except (aiokatcp.FailReply, ConnectionError) as exc:
@@ -332,7 +335,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             f.write("\n")  # json.dump doesn't write a final newline
         return 0
     else:
-        return asyncio.run(issue_config(args.controller, args.port, args.name, config))
+        # Pass a boolean that indicates VLBI or not
+        return asyncio.run(issue_config(args.controller, args.port, args.name, config, args.vlbi))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As per @bmerry's comment on NGC-1990, this PR ensures both `scratch/sim_correlator.py` and
the qualification tests are updated according to #1061 and https://github.com/ska-sa/katsdpcontroller/pull/845

Leaving this as draft as I still need to run do a full qualification run with the branch in its current state.

@EatonEmmerich mainly an FYI in the hopes I haven't made your life more difficult with whatever you're working on.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`.
- [x] (n/a) If new source files are added: add copyright notices dated with the current year.
- [x] If qualification tests are changed: attach or link to a sample qualification report - https://jenkins.cbf.kat.ac.za/job/qualification_katgpucbf_lab/627/ (PDF report is too large for GitHub)
- [x] If design has changed: ensure documentation is up to date --> This has been updated in #1061.
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match.
- [x] (n/a) If the interface between the product controller and an engine has changed, update the
      VERSION constant for the engine (update the major number if sensors/requests have been
      removed/changed, minor number if only backwards-compatible changes have been done).
      Also, update doc/control.rst with the new version.

Contributes to: NGC-1990.

