### PR TITLE
NGC-1985: pytest asyncio event loop policies are deprecated

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -347,6 +347,8 @@ def mock_recv_streams(
 
 
 class TestDiscardingIteratorEventLoopPolicy(async_solipsism.EventLoopPolicy):
+    """Event loop policy used by tests."""
+
     pass
 
 
@@ -359,10 +361,10 @@ def _make_loop():
 
 @pytest_asyncio.fixture
 def event_loop_factories():
-    # Return default mapping
+    """Return the default mapping of asyncio event-loop factories."""
     return {"default": _make_loop}
 
 
 def pytest_asyncio_loop_factories(config, item):
-    # Return default mapping
+    """Provide the default asyncio event-loop factory for pytest-asyncio."""
     return {"default": asyncio.new_event_loop}

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -42,6 +42,7 @@ combination is a candidate.
 """
 
 import asyncio
+import async_solipsism
 import itertools
 from collections import deque
 from collections.abc import AsyncGenerator, Awaitable, Callable
@@ -53,6 +54,7 @@ import aiokatcp
 import katsdpsigproc.cuda
 import pycuda.driver
 import pytest
+import pytest_asyncio
 import spead2
 import vkgdr
 from katsdpsigproc.abc import AbstractDevice
@@ -342,3 +344,21 @@ def mock_recv_streams(
         in the list is determined by :func:`n_recv_streams`.
     """
     return make_mock_recv_streams(n_recv_streams)
+
+class TestDiscardingIteratorEventLoopPolicy(async_solipsism.EventLoopPolicy):
+    pass
+
+def _make_loop():
+    # Set the policy for this loop instance
+    asyncio.set_event_loop_policy(TestDiscardingIteratorEventLoopPolicy())
+    policy = asyncio.get_event_loop_policy()
+    return policy.new_event_loop()
+
+@pytest_asyncio.fixture
+def event_loop_factories():
+    # Return default mapping
+    return {"default": _make_loop}  
+
+def pytest_asyncio_loop_factories(config, item):
+    # Return default mapping
+    return {"default": asyncio.new_event_loop}

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -42,7 +42,6 @@ combination is a candidate.
 """
 
 import asyncio
-import async_solipsism
 import itertools
 from collections import deque
 from collections.abc import AsyncGenerator, Awaitable, Callable
@@ -51,6 +50,7 @@ from ipaddress import IPv4Address, IPv4Network
 from typing import Any
 
 import aiokatcp
+import async_solipsism
 import katsdpsigproc.cuda
 import pycuda.driver
 import pytest
@@ -345,8 +345,10 @@ def mock_recv_streams(
     """
     return make_mock_recv_streams(n_recv_streams)
 
+
 class TestDiscardingIteratorEventLoopPolicy(async_solipsism.EventLoopPolicy):
     pass
+
 
 def _make_loop():
     # Set the policy for this loop instance
@@ -354,10 +356,12 @@ def _make_loop():
     policy = asyncio.get_event_loop_policy()
     return policy.new_event_loop()
 
+
 @pytest_asyncio.fixture
 def event_loop_factories():
     # Return default mapping
-    return {"default": _make_loop}  
+    return {"default": _make_loop}
+
 
 def pytest_asyncio_loop_factories(config, item):
     # Return default mapping

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -66,18 +66,10 @@ class SpyDiscardingIterator(DiscardingIterator[int]):
 
 # Note: function must be async because DiscardingIterator requires an event loop
 @pytest.fixture
+@pytest.mark.asyncio(scope="function")
 async def discarding_iterator(counter: AsyncIterable[int]) -> SpyDiscardingIterator:
     """Fixture for :class:`.DiscardingIterator` tests."""
     return SpyDiscardingIterator(counter)
-
-
-class TestDiscardingIterator:
-    """Test :class:`.DiscardingIterator`."""
-
-    @pytest.fixture
-    def event_loop_policy(self) -> async_solipsism.EventLoopPolicy:
-        """Use async_solipsism event loop."""
-        return async_solipsism.EventLoopPolicy()
 
     async def test_simple(self, discarding_iterator: SpyDiscardingIterator) -> None:
         """Test basic operations."""
@@ -228,13 +220,9 @@ class TestDeviceStatusSensor:
         assert ds.reading == aiokatcp.Reading(3456789012.0, aiokatcp.Sensor.Status.NOMINAL, DeviceStatus.OK)
 
 
+@pytest.mark.asyncio(scope="class")
 class TestTimeoutSensorStatus:
     """Tests for :func:`katgpucbf.utils.timeout_sensor_status`."""
-
-    @pytest.fixture
-    def event_loop_policy(self) -> async_solipsism.EventLoopPolicy:
-        """Use async_solipsism event loop."""
-        return async_solipsism.EventLoopPolicy()
 
     @pytest.fixture
     def sensor(self) -> aiokatcp.Sensor:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -25,7 +25,6 @@ from typing import override
 from unittest import mock
 
 import aiokatcp
-import async_solipsism
 import pytest
 from aiokatcp import DeviceStatus
 
@@ -66,7 +65,6 @@ class SpyDiscardingIterator(DiscardingIterator[int]):
 
 # Note: function must be async because DiscardingIterator requires an event loop
 @pytest.fixture
-@pytest.mark.asyncio(scope="function")
 async def discarding_iterator(counter: AsyncIterable[int]) -> SpyDiscardingIterator:
     """Fixture for :class:`.DiscardingIterator` tests."""
     return SpyDiscardingIterator(counter)
@@ -220,7 +218,6 @@ class TestDeviceStatusSensor:
         assert ds.reading == aiokatcp.Reading(3456789012.0, aiokatcp.Sensor.Status.NOMINAL, DeviceStatus.OK)
 
 
-@pytest.mark.asyncio(scope="class")
 class TestTimeoutSensorStatus:
     """Tests for :func:`katgpucbf.utils.timeout_sensor_status`."""
 

--- a/test/vgpu/conftest.py
+++ b/test/vgpu/conftest.py
@@ -57,8 +57,10 @@ def sendmsg_packets(monkeypatch: pytest.MonkeyPatch) -> list[bytes]:
     monkeypatch.setattr("socket.socket.sendmsg", my_sendmsg)
     return packets
 
+
 class TestEventLoopPolicy(async_solipsism.EventLoopPolicy):
     pass
+
 
 def _make_loop():
     # Set the policy for this loop instance
@@ -66,10 +68,12 @@ def _make_loop():
     policy = asyncio.get_event_loop_policy()
     return policy.new_event_loop()
 
+
 @pytest_asyncio.fixture
 def event_loop_factories():
     # Return default mapping
-    return {"default": _make_loop}  
+    return {"default": _make_loop}
+
 
 def pytest_asyncio_loop_factories(config, item):
     # Return default mapping

--- a/test/vgpu/conftest.py
+++ b/test/vgpu/conftest.py
@@ -20,7 +20,9 @@ import functools
 from collections.abc import Buffer, Callable, Iterable
 from typing import Any
 
+import async_solipsism
 import pytest
+import pytest_asyncio
 
 from katgpucbf.vgpu.engine import VEngine
 from katgpucbf.vgpu.main import make_engine, parse_args
@@ -54,3 +56,21 @@ def sendmsg_packets(monkeypatch: pytest.MonkeyPatch) -> list[bytes]:
     packets: list[bytes] = []
     monkeypatch.setattr("socket.socket.sendmsg", my_sendmsg)
     return packets
+
+class TestEventLoopPolicy(async_solipsism.EventLoopPolicy):
+    pass
+
+def _make_loop():
+    # Set the policy for this loop instance
+    asyncio.set_event_loop_policy(TestEventLoopPolicy())
+    policy = asyncio.get_event_loop_policy()
+    return policy.new_event_loop()
+
+@pytest_asyncio.fixture
+def event_loop_factories():
+    # Return default mapping
+    return {"default": _make_loop}  
+
+def pytest_asyncio_loop_factories(config, item):
+    # Return default mapping
+    return {"default": _make_loop}

--- a/test/vgpu/conftest.py
+++ b/test/vgpu/conftest.py
@@ -16,6 +16,7 @@
 
 """Fixtures for use in vgpu unit tests."""
 
+import asyncio
 import functools
 from collections.abc import Buffer, Callable, Iterable
 from typing import Any
@@ -59,6 +60,8 @@ def sendmsg_packets(monkeypatch: pytest.MonkeyPatch) -> list[bytes]:
 
 
 class TestEventLoopPolicy(async_solipsism.EventLoopPolicy):
+    """Event loop policy used by tests."""
+
     pass
 
 
@@ -71,10 +74,10 @@ def _make_loop():
 
 @pytest_asyncio.fixture
 def event_loop_factories():
-    # Return default mapping
+    """Return the default mapping of asyncio event-loop factories."""
     return {"default": _make_loop}
 
 
 def pytest_asyncio_loop_factories(config, item):
-    # Return default mapping
+    """Provide the default asyncio event-loop factory for pytest-asyncio."""
     return {"default": _make_loop}

--- a/test/vgpu/test_send.py
+++ b/test/vgpu/test_send.py
@@ -26,7 +26,6 @@ from dataclasses import dataclass
 from typing import override
 from unittest import mock
 
-import async_solipsism
 import numpy as np
 import pytest
 import pytest_mock
@@ -43,7 +42,6 @@ class DummyItem:
     sleep: float = 0.0  #: Time that processing the item will sleep
 
 
-@pytest.mark.asyncio(scope="class")
 class DummyRateLimiter(RateLimiter[DummyItem]):
     """Process items and store the times they were processed."""
 
@@ -61,7 +59,6 @@ class DummyRateLimiter(RateLimiter[DummyItem]):
         await asyncio.sleep(item.sleep)
 
 
-@pytest.mark.asyncio(scope="class")
 class TestRateLimiter:
     """Test :class:`.RateLimiter`."""
 
@@ -120,7 +117,6 @@ class TestRateLimiter:
         assert len(limiter.times) == 10
 
 
-@pytest.mark.asyncio(scope="class")
 class TestVDIFSender:
     """Test :class:.`VDIFSender`."""
 

--- a/test/vgpu/test_send.py
+++ b/test/vgpu/test_send.py
@@ -42,6 +42,7 @@ class DummyItem:
     size: int  #: Size of the item for the rate-limiting algorithm
     sleep: float = 0.0  #: Time that processing the item will sleep
 
+
 @pytest.mark.asyncio(scope="class")
 class DummyRateLimiter(RateLimiter[DummyItem]):
     """Process items and store the times they were processed."""
@@ -58,6 +59,7 @@ class DummyRateLimiter(RateLimiter[DummyItem]):
     async def _process_item(self, item: DummyItem) -> None:
         self.times.append(asyncio.get_running_loop().time())
         await asyncio.sleep(item.sleep)
+
 
 @pytest.mark.asyncio(scope="class")
 class TestRateLimiter:
@@ -116,6 +118,7 @@ class TestRateLimiter:
             assert loop.time() - start_time == pytest.approx(0.4)
         await limiter.stop()
         assert len(limiter.times) == 10
+
 
 @pytest.mark.asyncio(scope="class")
 class TestVDIFSender:

--- a/test/vgpu/test_send.py
+++ b/test/vgpu/test_send.py
@@ -35,12 +35,6 @@ from katgpucbf.vgpu.main import VTP_DEFAULT_PORT
 from katgpucbf.vgpu.send import RateLimiter, VDIFFrame, VDIFSender
 
 
-@pytest.fixture
-def event_loop_policy() -> async_solipsism.EventLoopPolicy:
-    """Use async_solipsism event loop."""
-    return async_solipsism.EventLoopPolicy()
-
-
 @dataclass(frozen=True)
 class DummyItem:
     """Item type for :class:`DummyRateLimiter`."""
@@ -48,7 +42,7 @@ class DummyItem:
     size: int  #: Size of the item for the rate-limiting algorithm
     sleep: float = 0.0  #: Time that processing the item will sleep
 
-
+@pytest.mark.asyncio(scope="class")
 class DummyRateLimiter(RateLimiter[DummyItem]):
     """Process items and store the times they were processed."""
 
@@ -65,7 +59,7 @@ class DummyRateLimiter(RateLimiter[DummyItem]):
         self.times.append(asyncio.get_running_loop().time())
         await asyncio.sleep(item.sleep)
 
-
+@pytest.mark.asyncio(scope="class")
 class TestRateLimiter:
     """Test :class:`.RateLimiter`."""
 
@@ -123,7 +117,7 @@ class TestRateLimiter:
         await limiter.stop()
         assert len(limiter.times) == 10
 
-
+@pytest.mark.asyncio(scope="class")
 class TestVDIFSender:
     """Test :class:.`VDIFSender`."""
 


### PR DESCRIPTION
<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [X] If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`.
- [X] If new source files are added: add copyright notices dated with the current year.
- [X] If qualification tests are changed: attach or link to a sample qualification report.
- [X] If design has changed: ensure documentation is up to date.
- [X] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match.
- [X] If the interface between the product controller and an engine has changed, update the
      VERSION constant for the engine (update the major number if sensors/requests have been
      removed/changed, minor number if only backwards-compatible changes have been done).
      Also, update doc/control.rst with the new version.

Closes NGC-1985.
