### PR TITLE
Fix sim_correlator when specifying --vlbi --narrowband-beams 4

### DIFF
--- a/scratch/sim_correlator.py
+++ b/scratch/sim_correlator.py
@@ -237,11 +237,7 @@ def generate_tied_array_resampled_voltage(args: argparse.Namespace, outputs: dic
     if args.vlbi:
         outputs["tied-array-resampled-voltage"] = {
             "type": "gpucbf.tied_array_resampled_voltage",
-            "src_streams": [
-                f"narrow0-tied-array-channelised-voltage-{i}{pol_name}"
-                for i in range(args.narrowband_beams)
-                for pol_name in "xy"
-            ],
+            "src_streams": [f"narrow0-tied-array-channelised-voltage-0{pol_name}" for pol_name in "xy"],
             "n_chans": 2,
             "pols": args.vlbi_pols,
             "station_id": args.vlbi_station_id,


### PR DESCRIPTION
(or any number more than 1). It will now use the first narrowband beam as the tied-array-resampled-voltage input, instead of trying to use all of them (which is invalid).

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`.
- [x] (n/a) If new source files are added: add copyright notices dated with the current year.
- [x] (n/a) If qualification tests are changed: attach or link to a sample qualification report.
- [x] (n/a) If design has changed: ensure documentation is up to date.
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match.
- [x] If the interface between the product controller and an engine has changed, update the
      VERSION constant for the engine (update the major number if sensors/requests have been
      removed/changed, minor number if only backwards-compatible changes have been done).
      Also, update doc/control.rst with the new version.
