### PR TITLE
Fix crash when there is a gap in input data

### DIFF
--- a/doc/fgpu.design.rst
+++ b/doc/fgpu.design.rst
@@ -485,9 +485,9 @@ count each sample exactly once. Coarse delay changes will cause some samples
 to be counted twice or not at all, but these are sufficiently rare that it is
 not likely to affect the statistics.
 
-Average power is updated at the granularity of output chunks. The PFB kernel
-updates a total power accumulator stored in the output item. This is performed
-using (64-bit) integer arithmetic, as this avoids the pitfalls of
+Average power is updated at the granularity of output batches. The PFB kernel
+updates an array of total power accumulators stored in the output item. This
+is performed using (64-bit) integer arithmetic, as this avoids the pitfalls of
 floating-point precision when accumulating a large number of samples.
 
 Network transmit

--- a/scratch/fgpu/benchmarks/compute_bench.py
+++ b/scratch/fgpu/benchmarks/compute_bench.py
@@ -124,6 +124,7 @@ def main():
             args.send_sample_bits,
             dither=output.dither,
             narrowband=narrowband_config,
+            total_power_spectra=spectra_per_heap,
         )
         command_queue = context.create_tuning_command_queue()
         out_spectra = accel.roundup(args.send_chunk_jones // output.channels, spectra_per_heap)

--- a/src/katgpucbf/fgpu/compute.py
+++ b/src/katgpucbf/fgpu/compute.py
@@ -312,8 +312,8 @@ class Compute(accel.OperationSequence):
         samples
             A device arrays containing the samples
         dig_total_power
-            A device array holding digitiser total power for each pol. This
-            is not zeroed.
+            A device array holding digitiser total power for each spectrum
+            and pol. This is not zeroed.
         in_offsets
             Index of first sample in input array to process (one for each pol).
         out_offset

--- a/src/katgpucbf/fgpu/compute.py
+++ b/src/katgpucbf/fgpu/compute.py
@@ -70,6 +70,9 @@ class ComputeTemplate:
         Type of dithering to apply before quantisation.
     narrowband
         Configuration for narrowband operation. If ``None``, wideband is assumed.
+    total_power_spectra
+        Number of spectra to sum over when reporting total power metrics.
+        If `narrowband` is specified this is ignored.
     """
 
     def __init__(
@@ -81,6 +84,7 @@ class ComputeTemplate:
         out_bits: int,
         dither: DitherType,
         narrowband: NarrowbandConfig | None,
+        total_power_spectra: int = 1,
     ) -> None:
         self.context = context
         self.taps = taps
@@ -93,7 +97,13 @@ class ComputeTemplate:
                 context, channels, self.unzip_factor, complex_pfb=False, out_bits=out_bits, dither=dither
             )
             self.pfb_fir = pfb.PFBFIRTemplate(
-                context, taps, channels, dig_sample_bits, self.unzip_factor, n_pols=N_POLS
+                context,
+                taps,
+                channels,
+                dig_sample_bits,
+                self.unzip_factor,
+                n_pols=N_POLS,
+                total_power_spectra=total_power_spectra,
             )
             self.ddc: ddc.DDCTemplate | None = None
         else:

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1032,7 +1032,7 @@ class Pipeline:
         present
             Whether each output batch is fully present
         """
-        batch_samples = out_item.capacity // len(present) * out_item.spectra_samples
+        batch_samples = self.output.spectra_per_heap * self.output.spectra_samples
         for pol, (accum, trg) in enumerate(zip(dig_total_power_accums, dig_total_power, strict=True)):
             for i, p in enumerate(present):
                 power: int | None = trg[i] if p else None

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -369,7 +369,7 @@ class OutQueueItem(QueueItem):
     spectra: accel.DeviceArray
     #: Output saturation count, per pol
     saturated: accel.DeviceArray
-    #: Output sum of squared samples, per pol
+    #: Output sum of squared samples, per batch and pol
     dig_total_power: accel.DeviceArray | None
     #: Per-spectrum fine delays
     fine_delay: MappedArray
@@ -573,6 +573,7 @@ class Pipeline:
             engine.send_sample_bits,
             output.dither,
             narrowband=narrowband_config,
+            total_power_spectra=output.spectra_per_heap,
         )
         seed = SystemRandom().randrange(2**ENGINE_DITHER_SEED_BITS)
         self._compute = template.instantiate(
@@ -1024,7 +1025,7 @@ class Pipeline:
         dig_total_power_accums
             Accumulators tracking long-term digitiser total power (one per polarisation)
         dig_total_power
-            The total power per spectrum and polarisation in `out_item`
+            The total power per batch and polarisation in `out_item`
         out_item
             The current :class:`OutQueueItem`
         """

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1017,6 +1017,7 @@ class Pipeline:
         dig_total_power_accums: list[Accum],
         dig_total_power: accel.HostArray,
         out_item: OutQueueItem,
+        present: np.ndarray,
     ) -> None:
         """Update digitiser power sensors.
 
@@ -1028,30 +1029,31 @@ class Pipeline:
             The total power per batch and polarisation in `out_item`
         out_item
             The current :class:`OutQueueItem`
+        present
+            Whether each output batch is fully present
         """
-        all_present = np.all(out_item.present)
-        # Sum over spectra
-        dig_total_power_sum = np.sum(dig_total_power, axis=0)
-        for pol, (accum, trg) in enumerate(zip(dig_total_power_accums, dig_total_power_sum, strict=True)):
-            power: int | None = int(trg)
-            if not all_present:
-                power = None
-            if measurement := accum.add(out_item.timestamp, out_item.next_timestamp, power):
-                sensor = self.engine.sensors[f"input{pol}.dig-rms-dbfs"]
-                update_timestamp = self.engine.time_converter.adc_to_unix(measurement.end_timestamp)
-                if measurement.total is not None:
-                    # Normalise relative to full scale. The factor of 2 is because we
-                    # want 1.0 to correspond to a sine wave rather than a square wave.
-                    fs = ((1 << (self.engine.recv_layout.sample_bits - 1)) - 1) ** 2 / 2
-                    avg_power = measurement.total / (measurement.end_timestamp - measurement.start_timestamp) / fs
-                    # If for some reason there's zero power, avoid reporting
-                    # -inf dB by assigning the most negative representable value
-                    avg_power_db = 10 * math.log10(avg_power) if avg_power else np.finfo(np.float64).min
-                    sensor.set_value(avg_power_db, timestamp=update_timestamp)
-                else:
-                    sensor.set_value(
-                        np.finfo(np.float64).min, status=aiokatcp.Sensor.Status.FAILURE, timestamp=update_timestamp
-                    )
+        batch_samples = out_item.capacity // len(present) * out_item.spectra_samples
+        for pol, (accum, trg) in enumerate(zip(dig_total_power_accums, dig_total_power.T, strict=True)):
+            for i, p in enumerate(present):
+                power: int | None = trg[i] if p else None
+                start_timestamp = out_item.timestamp + i * batch_samples
+                stop_timestamp = start_timestamp + batch_samples
+                if measurement := accum.add(start_timestamp, stop_timestamp, power):
+                    sensor = self.engine.sensors[f"input{pol}.dig-rms-dbfs"]
+                    update_timestamp = self.engine.time_converter.adc_to_unix(measurement.end_timestamp)
+                    if measurement.total is not None:
+                        # Normalise relative to full scale. The factor of 2 is because we
+                        # want 1.0 to correspond to a sine wave rather than a square wave.
+                        fs = ((1 << (self.engine.recv_layout.sample_bits - 1)) - 1) ** 2 / 2
+                        avg_power = measurement.total / (measurement.end_timestamp - measurement.start_timestamp) / fs
+                        # If for some reason there's zero power, avoid reporting
+                        # -inf dB by assigning the most negative representable value
+                        avg_power_db = 10 * math.log10(avg_power) if avg_power else np.finfo(np.float64).min
+                        sensor.set_value(avg_power_db, timestamp=update_timestamp)
+                    else:
+                        sensor.set_value(
+                            np.finfo(np.float64).min, status=aiokatcp.Sensor.Status.FAILURE, timestamp=update_timestamp
+                        )
 
     async def run_transmit(self) -> None:
         """Get the processed data from the GPU to the Network.
@@ -1109,7 +1111,7 @@ class Pipeline:
                 await async_wait_for_events([download_marker])
 
             if dig_total_power is not None:
-                self._update_dig_power_sensors(dig_total_power_windows, dig_total_power, out_item)
+                self._update_dig_power_sensors(dig_total_power_windows, dig_total_power, out_item, chunk.present)
 
             n_batches = out_item.n_spectra // self.output.spectra_per_heap
             if last_end_timestamp is not None and out_item.timestamp > last_end_timestamp:

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1033,7 +1033,7 @@ class Pipeline:
             Whether each output batch is fully present
         """
         batch_samples = out_item.capacity // len(present) * out_item.spectra_samples
-        for pol, (accum, trg) in enumerate(zip(dig_total_power_accums, dig_total_power.T, strict=True)):
+        for pol, (accum, trg) in enumerate(zip(dig_total_power_accums, dig_total_power, strict=True)):
             for i, p in enumerate(present):
                 power: int | None = trg[i] if p else None
                 start_timestamp = out_item.timestamp + i * batch_samples

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1024,12 +1024,14 @@ class Pipeline:
         dig_total_power_accums
             Accumulators tracking long-term digitiser total power (one per polarisation)
         dig_total_power
-            The total power per polarisation in `out_item`
+            The total power per spectrum and polarisation in `out_item`
         out_item
             The current :class:`OutQueueItem`
         """
         all_present = np.all(out_item.present)
-        for pol, (accum, trg) in enumerate(zip(dig_total_power_accums, dig_total_power, strict=True)):
+        # Sum over spectra
+        dig_total_power_sum = np.sum(dig_total_power, axis=0)
+        for pol, (accum, trg) in enumerate(zip(dig_total_power_accums, dig_total_power_sum, strict=True)):
             power: int | None = int(trg)
             if not all_present:
                 power = None

--- a/src/katgpucbf/fgpu/engine.py
+++ b/src/katgpucbf/fgpu/engine.py
@@ -1008,9 +1008,9 @@ class Pipeline:
 
         The unit tests mock out this function to replace the value.
         """
-        chunk_samples = self.spectra * self.output.spectra_samples
-        window_chunks = max(1, round(DIG_RMS_DBFS_WINDOW * self.engine.adc_sample_rate / chunk_samples))
-        return window_chunks * chunk_samples
+        batch_samples = self.output.spectra_per_heap * self.output.spectra_samples
+        window_batches = max(1, round(DIG_RMS_DBFS_WINDOW * self.engine.adc_sample_rate / batch_samples))
+        return window_batches * batch_samples
 
     def _update_dig_power_sensors(
         self,

--- a/src/katgpucbf/fgpu/kernels/pfb_fir.mako
+++ b/src/katgpucbf/fgpu/kernels/pfb_fir.mako
@@ -149,45 +149,57 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void pfb_fir(
     // This thread will process up to (but excluding) spectrum `n`.
     n = min(n, spectrum0 + stepy);
 
-% if not complex_input:
-    unsigned long long total_power = 0;
-% endif
     // We'll be at our most memory-bandwidth-efficient if rows >> TAPS.
     // Launching ~256K threads should ensure this.
+% if complex_input:
     for (int i = spectrum0; i < n; i++)
     {
-        // Load the raw data for the sample
-        sample_t sample = unpack_read(&unpack);
-        unpack_advance(&unpack, step);
+        {  // Block just to balance things with the !complex_input case.
+% else:
+    unsigned long long total_power = 0;
+    int spectrum = spectrum0;
+    while (spectrum < n)
+    {
+        // Determine the next boundary at which we need to emit
+        // accumulated total_power.
+        // TODO: rewrite without using division
+        int stop = min(n, (spectrum / TOTAL_POWER_SPECTRA + 1) * TOTAL_POWER_SPECTRA);
+        for (int i = spectrum; i < stop; i++)
+        {
+% endif
+            // Load the raw data for the sample
+            sample_t sample = unpack_read(&unpack);
+            unpack_advance(&unpack, step);
 
-        // Shuffle down the samples to make room for the new one
-        for (int j = 0; j < TAPS - 1; j++)
-            samples[j] = samples[j + 1];
+            // Shuffle down the samples to make room for the new one
+            for (int j = 0; j < TAPS - 1; j++)
+                samples[j] = samples[j + 1];
 
 % if not complex_input:
-        total_power += sample * sample;
-        if ((i + 1) % TOTAL_POWER_SPECTRA == 0 || i == n - 1)
-        {
-            // Reduce total_power across work items, to reduce the number of atomics needed.
-            // TODO: use 32-bit reduction when sample_bits is small enough.
-            LOCAL_DECL scratch_t scratch;
-            total_power = reduce(total_power, lid, &scratch);
-            if (lid == 0)
-                atomicAdd(&out_total_power[i / TOTAL_POWER_SPECTRA * N_POLS], total_power);
-            total_power = 0;
-        }
+            total_power += sample * sample;
 % endif
-        /* Each FIR output sample only needs one new sample, and TAPS-1 old
-         * ones. Read the new one into the array, and also use it to compute
-         * total power.
-         */
-        samples[TAPS - 1] = (float) sample;
+            /* Each FIR output sample only needs one new sample, and TAPS-1 old
+             * ones. Read the new one into the array, and also use it to compute
+             * total power.
+             */
+            samples[TAPS - 1] = (float) sample;
 
-        // Implement the actual FIR filter by multiplying samples by weights and summing.
-        float sum = rweights[0] * samples[0];
-        for (int j = 1; j < TAPS; j++)
-            sum += rweights[j] * samples[j];
-        // Sum written out to global memory.
-        out[i * step] = sum;
+            // Implement the actual FIR filter by multiplying samples by weights and summing.
+            float sum = rweights[0] * samples[0];
+            for (int j = 1; j < TAPS; j++)
+                sum += rweights[j] * samples[j];
+            // Sum written out to global memory.
+            out[i * step] = sum;
+        }
+% if not complex_input:
+        // Reduce total_power across work items, to reduce the number of atomics needed.
+        // TODO: use 32-bit reduction when sample_bits is small enough.
+        LOCAL_DECL scratch_t scratch;
+        total_power = reduce(total_power, lid, &scratch);
+        if (lid == 0)
+            atomicAdd(&out_total_power[spectrum / TOTAL_POWER_SPECTRA * N_POLS], total_power);
+        total_power = 0;
+        spectrum = stop;
+% endif
     }
 }

--- a/src/katgpucbf/fgpu/kernels/pfb_fir.mako
+++ b/src/katgpucbf/fgpu/kernels/pfb_fir.mako
@@ -19,6 +19,7 @@
 #define WGS ${wgs}
 #define TAPS ${taps}
 #define CHANNELS ${channels}
+#define TOTAL_POWER_SPECTRA ${total_power_spectra}
 #define UNZIP_FACTOR ${unzip_factor}
 #define INPUT_SAMPLE_BITS ${input_sample_bits}
 #define WEIGHT_INDEX_SHIFT ${1 if complex_input else 0}
@@ -74,8 +75,8 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void pfb_fir(
     const GLOBAL float * RESTRICT weights,// Weights for the PFB-FIR filter.
     int out_stride,                       // Offset to `out` between pols
     int in_stride,                        // Offset to `in` between pols
-    int n,                                // Size of the `out` array, to avoid going out-of-bounds.
-    int stepy,                            // Size of data that will be worked on by a single thread-block.
+    int n,                                // Size of the `out` array (in spectra), to avoid going out-of-bounds.
+    int stepy,                            // Size of data (in spectra) that will be worked on by a single thread-block.
 % for pol in range(n_pols):
     int in_offset${pol},                  // Number of samples to skip from the start of *in
 % endfor
@@ -86,8 +87,7 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void pfb_fir(
 {
     const unsigned int step = 2 * CHANNELS;
     // Figure out where our thread block has to work.
-    int group_x = get_group_id(0);
-    int group_y = get_group_id(1);
+    int group_y = get_group_id(1) * stepy;
     int pol = get_group_id(2);
     int in_offset;
     switch (pol)
@@ -98,26 +98,23 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void pfb_fir(
         break;
 % endfor
     }
-    in += pol * in_stride;
-    out += pol * out_stride;
 
     // Figure out where this thread has to work.
     int lid = get_local_id(0);
-    int pos = group_x * WGS + lid; // pos is the position within the step (i.e. spectrum) that this thread will work on.
-    int offset = group_y * stepy + pos; // This thread probably doesn't work on the very beginning of the data, so we
-                                        // make the indexing easier for ourselves later.
+    // pos is the position within the step (i.e. spectrum) that this thread will work on.
+    int pos = get_group_id(0) * WGS + lid;
+
+    // can't skip individual (input) samples with pointer arithmetic, so track in_offset
+    in_offset += group_y * step + pos;
+    in += pol * in_stride;
 
     // Increment this pointer because this thread may not need to write to the
     // beginning of the block.
-    out += shuffle_index(offset + out_offset);
+    out += pol * out_stride + shuffle_index(pos);
 % if not complex_input:
-    // TODO: change how parameters are passed to avoid division here
-    out_total_power += (offset + out_offset) / step * N_POLS + pol;
+    out_total_power += pol;
 % endif
-
-    // can't skip individual (input) samples with pointer arithmetic, so track in_offset
-    in_offset += offset;
-    n -= group_y * stepy;
+    int spectrum0 = group_y + out_offset;
 
     /* Here we fill up the taps of the FIR before we bother to do any outputs.
      * We assume we are not interested in the initial transient spectra.
@@ -149,13 +146,15 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void pfb_fir(
     for (int i = 0; i < TAPS; i++)
         rweights[i] = weights[(i * step + pos) >> WEIGHT_INDEX_SHIFT];
 
-    // This thread will process the same equivalent sample in `rows` successive
-    // output "spectra" worth of data.
-    int rows = min(n, stepy) / step;
+    // This thread will process up to (but excluding) spectrum `n`.
+    n = min(n, spectrum0 + stepy);
 
+% if not complex_input:
+    unsigned long long total_power = 0;
+% endif
     // We'll be at our most memory-bandwidth-efficient if rows >> TAPS.
     // Launching ~256K threads should ensure this.
-    for (int i = 0; i < rows; i++)
+    for (int i = spectrum0; i < n; i++)
     {
         // Load the raw data for the sample
         sample_t sample = unpack_read(&unpack);
@@ -166,14 +165,16 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void pfb_fir(
             samples[j] = samples[j + 1];
 
 % if not complex_input:
+        total_power += sample * sample;
+        if ((i + 1) % TOTAL_POWER_SPECTRA == 0 || i == n - 1)
         {
-            unsigned long long total_power = sample * sample;
             // Reduce total_power across work items, to reduce the number of atomics needed.
             // TODO: use 32-bit reduction when sample_bits is small enough.
             LOCAL_DECL scratch_t scratch;
             total_power = reduce(total_power, lid, &scratch);
             if (lid == 0)
-                atomicAdd(&out_total_power[i * N_POLS], total_power);
+                atomicAdd(&out_total_power[i / TOTAL_POWER_SPECTRA * N_POLS], total_power);
+            total_power = 0;
         }
 % endif
         /* Each FIR output sample only needs one new sample, and TAPS-1 old

--- a/src/katgpucbf/fgpu/kernels/pfb_fir.mako
+++ b/src/katgpucbf/fgpu/kernels/pfb_fir.mako
@@ -70,6 +70,7 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void pfb_fir(
     const GLOBAL float * RESTRICT in,     // Input data (down-converted samples)
 % else:
     GLOBAL unsigned long long * RESTRICT out_total_power,  // Sum of squares of samples (incremented)
+    int out_total_power_stride,           // Offset to `out_total_power` between pols
     const GLOBAL unsigned char * RESTRICT in,     // Input data (digitiser samples)
 % endif
     const GLOBAL float * RESTRICT weights,// Weights for the PFB-FIR filter.
@@ -112,7 +113,7 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void pfb_fir(
     // beginning of the block.
     out += pol * out_stride + shuffle_index(pos);
 % if not complex_input:
-    out_total_power += pol;
+    out_total_power += pol * out_total_power_stride;
 % endif
     int spectrum0 = group_y + out_offset;
 
@@ -197,7 +198,7 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void pfb_fir(
         LOCAL_DECL scratch_t scratch;
         total_power = reduce(total_power, lid, &scratch);
         if (lid == 0)
-            atomicAdd(&out_total_power[spectrum / TOTAL_POWER_SPECTRA * N_POLS], total_power);
+            atomicAdd(&out_total_power[spectrum / TOTAL_POWER_SPECTRA], total_power);
         total_power = 0;
         spectrum = stop;
 % endif

--- a/src/katgpucbf/fgpu/kernels/pfb_fir.mako
+++ b/src/katgpucbf/fgpu/kernels/pfb_fir.mako
@@ -155,7 +155,7 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void pfb_fir(
 % if complex_input:
     for (int i = spectrum0; i < n; i++)
     {
-        {  // Block just to balance things with the !complex_input case.
+        {  // Block just to balance things with the not complex_input case.
 % else:
     unsigned long long total_power = 0;
     int spectrum = spectrum0;

--- a/src/katgpucbf/fgpu/kernels/pfb_fir.mako
+++ b/src/katgpucbf/fgpu/kernels/pfb_fir.mako
@@ -110,6 +110,10 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void pfb_fir(
     // Increment this pointer because this thread may not need to write to the
     // beginning of the block.
     out += shuffle_index(offset + out_offset);
+% if not complex_input:
+    // TODO: change how parameters are passed to avoid division here
+    out_total_power += (offset + out_offset) / step * N_POLS + pol;
+% endif
 
     // can't skip individual (input) samples with pointer arithmetic, so track in_offset
     in_offset += offset;
@@ -149,9 +153,6 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void pfb_fir(
     // output "spectra" worth of data.
     int rows = min(n, stepy) / step;
 
-% if not complex_input:
-    unsigned long long total_power = 0;
-% endif
     // We'll be at our most memory-bandwidth-efficient if rows >> TAPS.
     // Launching ~256K threads should ensure this.
     for (int i = 0; i < rows; i++)
@@ -164,13 +165,21 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void pfb_fir(
         for (int j = 0; j < TAPS - 1; j++)
             samples[j] = samples[j + 1];
 
+% if not complex_input:
+        {
+            unsigned long long total_power = sample * sample;
+            // Reduce total_power across work items, to reduce the number of atomics needed.
+            // TODO: use 32-bit reduction when sample_bits is small enough.
+            LOCAL_DECL scratch_t scratch;
+            total_power = reduce(total_power, lid, &scratch);
+            if (lid == 0)
+                atomicAdd(&out_total_power[i * N_POLS], total_power);
+        }
+% endif
         /* Each FIR output sample only needs one new sample, and TAPS-1 old
          * ones. Read the new one into the array, and also use it to compute
          * total power.
          */
-% if not complex_input:
-        total_power += sample * sample;
-% endif
         samples[TAPS - 1] = (float) sample;
 
         // Implement the actual FIR filter by multiplying samples by weights and summing.
@@ -180,12 +189,4 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void pfb_fir(
         // Sum written out to global memory.
         out[i * step] = sum;
     }
-
-% if not complex_input:
-    // Reduce total_power across work items, to reduce the number of atomics needed.
-    LOCAL_DECL scratch_t scratch;
-    total_power = reduce(total_power, lid, &scratch);
-    if (lid == 0)
-        atomicAdd(&out_total_power[pol], total_power);
-% endif
 }

--- a/src/katgpucbf/fgpu/pfb.py
+++ b/src/katgpucbf/fgpu/pfb.py
@@ -165,7 +165,7 @@ class PFBFIR(accel.Operation):
         FIR-filtered time data, ready to be processed by the FFT.
     **weights** : 2*channels*taps, float32
         The time-domain transfer function of the FIR filter to be applied.
-    **total_power** : pols, uint64
+    **total_power** : spectra × pols, uint64
         Sum of squares of input samples. This will not include every input
         sample. Rather, it will contain a specific tap from each PFB window
         (currently, the last tap, but that is an implementation detail).
@@ -260,9 +260,15 @@ class PFBFIR(accel.Operation):
                 np.float32,
             )
             self.slots["weights"] = accel.IOSlot((step * template.taps,), np.float32)
-            self.slots["total_power"] = accel.IOSlot((template.n_pols,), np.uint64)
+            self.slots["total_power"] = accel.IOSlot(
+                (
+                    spectra,
+                    accel.Dimension(template.n_pols, exact=True),
+                ),
+                np.uint64,
+            )
         self.in_offset = np.zeros(template.n_pols, int)  # Number of samples to skip from the start of *in
-        self.out_offset = 0  # Number of "spectra" to skip from the start of *out.
+        self.out_offset = 0  # Number of "spectra" to skip from the start of *out and *total_power.
 
     def _run(self) -> None:
         if self.spectra == 0:

--- a/src/katgpucbf/fgpu/pfb.py
+++ b/src/katgpucbf/fgpu/pfb.py
@@ -62,6 +62,9 @@ class PFBFIRTemplate:
     n_pols
         Number of polarisations to operate over. The polarisations are
         stored contiguously in memory, but have independent offsets.
+    total_power_spectra
+        Number of spectra to sum over when reporting total power metrics.
+        If `complex_input` is true this is ignored.
 
     Raises
     ------
@@ -91,6 +94,7 @@ class PFBFIRTemplate:
         *,
         complex_input: bool = False,
         n_pols: int,
+        total_power_spectra: int = 1,
     ) -> None:
         if taps <= 0:
             raise ValueError("taps must be at least 1")
@@ -101,6 +105,12 @@ class PFBFIRTemplate:
         self.unzip_factor = unzip_factor
         self.complex_input = complex_input
         self.n_pols = n_pols
+        if complex_input:
+            # Ensures that the given value definitely has no effect. Choosing 1
+            # ensures that tests that it divides into other values are
+            # satisfied.
+            total_power_spectra = 1
+        self.total_power_spectra = total_power_spectra
         if complex_input:
             if input_sample_bits != 32:
                 raise ValueError("input_sample_bits must be 32 when complex_input is true")
@@ -125,6 +135,7 @@ class PFBFIRTemplate:
                     "unzip_factor": unzip_factor,
                     "complex_input": complex_input,
                     "n_pols": n_pols,
+                    "total_power_spectra": total_power_spectra,
                 },
                 extra_dirs=[str(resource_dir)],
             )
@@ -165,10 +176,12 @@ class PFBFIR(accel.Operation):
         FIR-filtered time data, ready to be processed by the FFT.
     **weights** : 2*channels*taps, float32
         The time-domain transfer function of the FIR filter to be applied.
-    **total_power** : spectra × pols, uint64
+    **total_power** : spectra/total_power_spectra × pols, uint64
         Sum of squares of input samples. This will not include every input
         sample. Rather, it will contain a specific tap from each PFB window
-        (currently, the last tap, but that is an implementation detail).
+        (currently, the last tap, but that is an implementation detail). One
+        value (per pol) is produced for every ``template.total_power_spectra``
+        output spectra.
 
         This is incremented rather than overwritten. It is the caller's
         responsibility to zero it when desired, or alternatively to track
@@ -189,6 +202,8 @@ class PFBFIR(accel.Operation):
         If ``samples`` is not a multiple of 8 and ``complex_input`` is false
     ValueError
         If ``samples`` is too large (more than 2**29)
+    ValueError
+        If ``spectra`` is not a multiple of ``template.total_power_spectra```.
 
     Parameters
     ----------
@@ -217,6 +232,8 @@ class PFBFIR(accel.Operation):
         if samples > 2**29:
             # This ensures no overflow in samples_to_bytes in the kernel
             raise ValueError("at most 2**29 samples are supported")
+        if spectra % template.total_power_spectra != 0:
+            raise ValueError("spectra must be a multiple of total_power_spectra")
         self.template = template
         self.samples = samples
         self.spectra = spectra  # Can be changed (TODO: documentation)
@@ -262,7 +279,7 @@ class PFBFIR(accel.Operation):
             self.slots["weights"] = accel.IOSlot((step * template.taps,), np.float32)
             self.slots["total_power"] = accel.IOSlot(
                 (
-                    spectra,
+                    spectra // template.total_power_spectra,
                     accel.Dimension(template.n_pols, exact=True),
                 ),
                 np.uint64,
@@ -298,7 +315,6 @@ class PFBFIR(accel.Operation):
         groupsy = max(groupsy, accel.divup(128 * 1024 // self.template.n_pols, real_step))
         # Re-compute work_spectra to balance the load
         work_spectra = accel.divup(self.spectra, groupsy)
-        stepy = work_spectra * real_step
         # Rounding up may have left some workgroups with nothing to do, so recalculate
         # groupsy again.
         groupsy = accel.divup(self.spectra, work_spectra)
@@ -313,12 +329,12 @@ class PFBFIR(accel.Operation):
                 self.buffer("weights").buffer,
                 np.int32(out_buffer.padded_shape[1] * out_buffer.padded_shape[2] * rps),
                 np.int32(in_buffer.padded_shape[1] * rps),
-                np.int32(real_step * self.spectra),
-                np.int32(stepy),
+                np.int32(self.spectra + self.out_offset),
+                np.int32(work_spectra),
             ]
             + list(raw_in_offset)
             + [
-                np.int32(self.out_offset * real_step),
+                np.int32(self.out_offset),
             ]
         )
         if not self.template.complex_input:

--- a/src/katgpucbf/fgpu/pfb.py
+++ b/src/katgpucbf/fgpu/pfb.py
@@ -176,7 +176,7 @@ class PFBFIR(accel.Operation):
         FIR-filtered time data, ready to be processed by the FFT.
     **weights** : 2*channels*taps, float32
         The time-domain transfer function of the FIR filter to be applied.
-    **total_power** : spectra/total_power_spectra × pols, uint64
+    **total_power** : pols × spectra/total_power_spectra, uint64
         Sum of squares of input samples. This will not include every input
         sample. Rather, it will contain a specific tap from each PFB window
         (currently, the last tap, but that is an implementation detail). One
@@ -279,8 +279,8 @@ class PFBFIR(accel.Operation):
             self.slots["weights"] = accel.IOSlot((step * template.taps,), np.float32)
             self.slots["total_power"] = accel.IOSlot(
                 (
+                    template.n_pols,
                     spectra // template.total_power_spectra,
-                    accel.Dimension(template.n_pols, exact=True),
                 ),
                 np.uint64,
             )
@@ -338,7 +338,12 @@ class PFBFIR(accel.Operation):
             ]
         )
         if not self.template.complex_input:
-            kernel_args.insert(1, self.buffer("total_power").buffer)
+            # Insert arguments at position 1
+            total_power_buffer = self.buffer("total_power")
+            kernel_args[1:1] = [
+                total_power_buffer.buffer,
+                np.int32(total_power_buffer.padded_shape[1]),
+            ]
 
         self.command_queue.enqueue_kernel(
             self.template.kernel,

--- a/test/fgpu/test_compute.py
+++ b/test/fgpu/test_compute.py
@@ -68,7 +68,9 @@ def test_compute(context: AbstractContext, command_queue: AbstractCommandQueue, 
     else:
         raise RuntimeError("unexpected mode")
 
-    template = compute.ComputeTemplate(context, pfb_taps, channels, dig_sample_bits, out_bits, dither, narrowband)
+    template = compute.ComputeTemplate(
+        context, pfb_taps, channels, dig_sample_bits, out_bits, dither, narrowband, spectra_per_heap
+    )
     # The sample count is large enough to produce the required number of
     # output spectra for both narrowband modes. For wideband there is more
     # headroom.

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -428,7 +428,6 @@ class TestFEngine:
         timestamps
             Labels for the time axis of `data`
         """
-        # Reshape into heap-size pieces (now has indices pol, heap, offset)
         recv_layout = engine.recv_layout
         channels = output.channels
         spectra_per_heap = output.spectra_per_heap
@@ -971,6 +970,12 @@ class TestFEngine:
         It then checks that the heaps successfully received in the first half match
         the heaps in the second half, up to a tolerance to account for dithering.
         """
+        # Set a non-zero delay as a regression test (NGC-2074).
+        delay_samples = 123
+        delay_s = delay_samples / ADC_SAMPLE_RATE
+        coeffs = [f"{delay_s},0.0:0.0,0.0"] * 2
+        await engine_client.request("delays", output.name, SYNC_TIME, *coeffs)
+
         sensors = [engine.sensors[f"input{pol}.dig-rms-dbfs"] for pol in range(N_POLS)]
         sensor_update_dict = self._watch_sensors(sensors)
         spectra_per_heap = output.spectra_per_heap
@@ -981,7 +986,7 @@ class TestFEngine:
             (8, 10),
             (15, 16),
             (117, 133),
-            (6 * chunk_samples // PACKET_SAMPLES, 8 * chunk_samples // PACKET_SAMPLES),
+            (5 * chunk_samples // PACKET_SAMPLES, 7 * chunk_samples // PACKET_SAMPLES),
         ]
         rng = np.random.default_rng(seed=1)
         dig_data = np.tile(rng.integers(-255, 255, size=(2, n_samples // 2), dtype=np.int16), 2)
@@ -991,20 +996,21 @@ class TestFEngine:
             recv_present[:, a:b] = False
         # The data should have as many samples as the input, minus a reduction
         # from windowing, rounded down to a full batch.
-        total_spectra = (n_samples - output.window) // output.spectra_samples
+        total_spectra = (n_samples + delay_samples - output.window) // output.spectra_samples
         total_batches = total_spectra // spectra_per_heap
         send_present = np.ones(total_batches, bool)
         # Compute which output batches should be missing. first_* and last_* are
         # both inclusive (b is exclusive)
         for a, b in missing_ranges:
-            first_sample = a * PACKET_SAMPLES
-            last_sample = b * PACKET_SAMPLES - 1  # -1 to make it inclusive
+            first_sample = a * PACKET_SAMPLES + delay_samples
+            last_sample = b * PACKET_SAMPLES + delay_samples - 1  # -1 to make it inclusive
             assert last_sample < n_samples // 2  # Make sure gaps are restricted to first half
             first_spectrum = max(0, (first_sample - output.window + 1) // output.spectra_samples)
             last_spectrum = last_sample // output.spectra_samples
             first_batch = first_spectrum // spectra_per_heap
             last_batch = last_spectrum // spectra_per_heap
             send_present[first_batch : last_batch + 1] = False
+        send_present[0] = False  # Corresponds to negative input timestamps
 
         with PromDiff(namespace=METRIC_NAMESPACE) as prom_diff:
             out_data, timestamps = await self._send_data(
@@ -1041,7 +1047,12 @@ class TestFEngine:
         batch_size = batch_samples * COMPLEX * np.dtype(np.int8).itemsize
         assert prom_diff.diff("output_bytes_total") == np.sum(send_present) * batch_size
         assert prom_diff.diff("output_samples_total") == np.sum(send_present) * batch_samples
-        assert prom_diff.diff("output_skipped_heaps_total") == np.sum(~send_present) * n_substreams
+        # The first output chunk starts with heap 1 (the first one which corresponds
+        # to non-negative input timestamps) and so heap 0 is not considered to be
+        # "skipped" because it is before the start of transmission (but if heap 1 is
+        # missing, it *is* counted as skipped: this is a subtle case where the output
+        # chunking is externally visible).
+        assert prom_diff.diff("output_skipped_heaps_total") == (np.sum(~send_present) - 1) * n_substreams
 
         # Sensor is not present in the narrowband mode.
         if output.decimation == 1:

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -69,6 +69,7 @@ TAPS = 16
 FENG_ID = 42
 ADC_SAMPLE_RATE = 1712e6
 DSTS = 16
+DIG_RMS_DBFS_WINDOW_BATCHES = 5  # Number of chunks per window for ``dig-rms-dbfs`` sensors.
 TIME_CONVERTER = TimeConverter(SYNC_TIME, ADC_SAMPLE_RATE)
 
 WIDEBAND_ARGS = f"name=test_wideband,dst=239.10.11.0+{DSTS - 1}:7149,taps={TAPS}"
@@ -95,12 +96,6 @@ def jones_per_batch(channels: int, request: pytest.FixtureRequest) -> int:
         return marker.args[0] * channels
     else:
         return JONES_PER_BATCH
-
-
-@pytest.fixture
-def dig_rms_dbfs_window_batches() -> int:
-    """Number of chunks per window for ``dig-rms-dbfs`` sensors."""
-    return 5
 
 
 @dataclass
@@ -218,13 +213,12 @@ class TestFEngine:
         self,
         monkeypatch: pytest.MonkeyPatch,
         dig_rms_dbfs_window_samples: list[int],
-        dig_rms_dbfs_window_batches: int,
         output: Output,
     ) -> None:
         """Mock :meth:`.Pipeline._dig_rms_dbfs_window_samples`.
 
         This overrides the calculation to use
-        :func:`dig_rms_dbfs_window_batches`, and also populates
+        :data:`DIG_RMS_DBFS_WINDOW_BATCHES`, and also populates
         :meth:`dig_rms_dbfs_window_samples` with the computed value.
 
         This is marked autouse to ensure it will be run before the
@@ -233,7 +227,7 @@ class TestFEngine:
 
         def _dig_rms_dbfs_window_samples(self: Pipeline) -> int:
             batch_samples = self.output.spectra_per_heap * self.output.spectra_samples
-            window_samples = dig_rms_dbfs_window_batches * batch_samples
+            window_samples = DIG_RMS_DBFS_WINDOW_BATCHES * batch_samples
             dig_rms_dbfs_window_samples.append(window_samples)
             return window_samples
 
@@ -962,7 +956,6 @@ class TestFEngine:
         engine_client: aiokatcp.Client,
         output: Output,
         channels: int,
-        dig_rms_dbfs_window_batches: int,
     ) -> None:
         """Test that the right output heaps are omitted when input heaps are missing.
 
@@ -1063,20 +1056,20 @@ class TestFEngine:
                 OPTIONAL_FAILURE = 3
 
             expected_updates = []
-            window_timestamp_step = output.spectra_per_heap * output.spectra_samples * dig_rms_dbfs_window_batches
+            window_timestamp_step = output.spectra_per_heap * output.spectra_samples * DIG_RMS_DBFS_WINDOW_BATCHES
 
             # Round up to a whole number of windows (see after the for loop
             # for some special handling of the final window).
-            total_windows = (total_batches + dig_rms_dbfs_window_batches - 1) // dig_rms_dbfs_window_batches
+            total_windows = (total_batches + DIG_RMS_DBFS_WINDOW_BATCHES - 1) // DIG_RMS_DBFS_WINDOW_BATCHES
             for i in range(total_windows):
-                start_batch = i * dig_rms_dbfs_window_batches
-                stop_batch = (i + 1) * dig_rms_dbfs_window_batches
+                start_batch = i * DIG_RMS_DBFS_WINDOW_BATCHES
+                stop_batch = (i + 1) * DIG_RMS_DBFS_WINDOW_BATCHES
                 n_present = np.sum(send_present[start_batch:stop_batch])
                 # The sensor timestamp is the end of the window
                 sensor_timestamp = TIME_CONVERTER.adc_to_unix(
                     timestamps[start_batch * spectra_per_heap] + window_timestamp_step
                 )
-                if n_present == dig_rms_dbfs_window_batches:
+                if n_present == DIG_RMS_DBFS_WINDOW_BATCHES:
                     expected_updates.append((sensor_timestamp, Update.NORMAL))
                 elif n_present > 0:
                     # TODO: there is a corner case where if this window is

--- a/test/fgpu/test_engine.py
+++ b/test/fgpu/test_engine.py
@@ -73,7 +73,7 @@ TIME_CONVERTER = TimeConverter(SYNC_TIME, ADC_SAMPLE_RATE)
 
 WIDEBAND_ARGS = f"name=test_wideband,dst=239.10.11.0+{DSTS - 1}:7149,taps={TAPS}"
 # Centre frequency is not a multiple of the channel width, but it does ensure
-# that the two copies of the same data in test_missing are separated by a
+# that the two copies of the same data in test_missing_heaps are separated by a
 # whole number of cycles.
 NARROWBAND_ARGS = f"name=test_narrowband,dst=239.10.12.0+{DSTS - 1}:7149,taps={TAPS},centre_frequency=408173015.5944824"
 
@@ -98,9 +98,9 @@ def jones_per_batch(channels: int, request: pytest.FixtureRequest) -> int:
 
 
 @pytest.fixture
-def dig_rms_dbfs_window_chunks() -> int:
+def dig_rms_dbfs_window_batches() -> int:
     """Number of chunks per window for ``dig-rms-dbfs`` sensors."""
-    return 2
+    return 5
 
 
 @dataclass
@@ -218,13 +218,13 @@ class TestFEngine:
         self,
         monkeypatch: pytest.MonkeyPatch,
         dig_rms_dbfs_window_samples: list[int],
-        dig_rms_dbfs_window_chunks: int,
+        dig_rms_dbfs_window_batches: int,
         output: Output,
     ) -> None:
         """Mock :meth:`.Pipeline._dig_rms_dbfs_window_samples`.
 
         This overrides the calculation to use
-        :func:`dig_rms_dbfs_window_chunks`, and also populates
+        :func:`dig_rms_dbfs_window_batches`, and also populates
         :meth:`dig_rms_dbfs_window_samples` with the computed value.
 
         This is marked autouse to ensure it will be run before the
@@ -232,8 +232,8 @@ class TestFEngine:
         """
 
         def _dig_rms_dbfs_window_samples(self: Pipeline) -> int:
-            chunk_samples = self.spectra * self.output.spectra_samples
-            window_samples = dig_rms_dbfs_window_chunks * chunk_samples
+            batch_samples = self.output.spectra_per_heap * self.output.spectra_samples
+            window_samples = dig_rms_dbfs_window_batches * batch_samples
             dig_rms_dbfs_window_samples.append(window_samples)
             return window_samples
 
@@ -962,7 +962,7 @@ class TestFEngine:
         engine_client: aiokatcp.Client,
         output: Output,
         channels: int,
-        dig_rms_dbfs_window_chunks: int,
+        dig_rms_dbfs_window_batches: int,
     ) -> None:
         """Test that the right output heaps are omitted when input heaps are missing.
 
@@ -1063,26 +1063,30 @@ class TestFEngine:
                 OPTIONAL_FAILURE = 3
 
             expected_updates = []
-            spectra_per_output_chunk = engine.chunk_jones // output.channels
-            batches_per_output_chunk = spectra_per_output_chunk // spectra_per_heap
-            batches_per_window = batches_per_output_chunk * dig_rms_dbfs_window_chunks
-            window_timestamp_step = spectra_per_output_chunk * output.spectra_samples * dig_rms_dbfs_window_chunks
+            window_timestamp_step = output.spectra_per_heap * output.spectra_samples * dig_rms_dbfs_window_batches
 
-            total_chunks = (total_batches + batches_per_output_chunk - 1) // batches_per_output_chunk
-            # The last windows is only emitted if we observe its final chunk,
-            # so we round down here.
-            total_windows = total_chunks // dig_rms_dbfs_window_chunks
+            # Round up to a whole number of windows (see after the for loop
+            # for some special handling of the final window).
+            total_windows = (total_batches + dig_rms_dbfs_window_batches - 1) // dig_rms_dbfs_window_batches
             for i in range(total_windows):
-                start_batch = i * batches_per_window
-                stop_batch = (i + 1) * batches_per_window
+                start_batch = i * dig_rms_dbfs_window_batches
+                stop_batch = (i + 1) * dig_rms_dbfs_window_batches
                 n_present = np.sum(send_present[start_batch:stop_batch])
                 # The sensor timestamp is the end of the window
                 sensor_timestamp = TIME_CONVERTER.adc_to_unix(
                     timestamps[start_batch * spectra_per_heap] + window_timestamp_step
                 )
-                if n_present == batches_per_window:
+                if n_present == dig_rms_dbfs_window_batches:
                     expected_updates.append((sensor_timestamp, Update.NORMAL))
                 elif n_present > 0:
+                    # TODO: there is a corner case where if this window is
+                    # incomplete and is missing the final batch, and the
+                    # following window contains only the final batch, the
+                    # former is not reported (because _update_dig_power_sensors
+                    # produces at most one measurement even if two become ready
+                    # at the same time). This doesn't happen for the chosen
+                    # fixtures, but may need to be taken into consideration in
+                    # the future.
                     expected_updates.append((sensor_timestamp, Update.FAILURE))
                 else:
                     # If a window is completely missing, it could indicate that
@@ -1091,6 +1095,12 @@ class TestFEngine:
                     # On the other hand, there might have been some OutQueueItems
                     # present but none of them had valid heaps.
                     expected_updates.append((sensor_timestamp, Update.OPTIONAL_FAILURE))
+            # If the final window is incomplete, it might or might not get sent
+            # depending on how the final chunk aligned with it. We could in
+            # theory work this out, but we don't really care about the exactly
+            # shutdown handling.
+            if expected_updates[-1][1] == Update.FAILURE:
+                expected_updates[-1] = (expected_updates[-1][0], Update.OPTIONAL_FAILURE)
 
             for pol in range(N_POLS):
                 p = 0

--- a/test/fgpu/test_pfb.py
+++ b/test/fgpu/test_pfb.py
@@ -47,7 +47,8 @@ def pfb_fir_host_real(data, channels, input_sample_bits, unzip_factor, weights):
     out = out.reshape(n_pols, -1, channels // unzip_factor, unzip_factor, 2)
     out = out.swapaxes(2, 3)
     out = out.reshape(n_pols, -1, step)
-    total_power = np.sum(np.square(decoded[:, step * (taps - 1) :].astype(np.int64)), axis=1)
+    power_samples = decoded.reshape(decoded.shape[0], -1, step)[:, taps - 1 :, :]
+    total_power = np.sum(np.square(power_samples.astype(np.int64)), axis=2).T
     return out, total_power
 
 

--- a/test/fgpu/test_pfb.py
+++ b/test/fgpu/test_pfb.py
@@ -49,7 +49,7 @@ def pfb_fir_host_real(data, channels, input_sample_bits, unzip_factor, total_pow
     out = out.reshape(n_pols, -1, step)
     power_samples = decoded[:, step * (taps - 1) :]
     power_samples = power_samples.reshape(n_pols, -1, step * total_power_spectra)
-    total_power = np.sum(np.square(power_samples.astype(np.int64)), axis=2).T
+    total_power = np.sum(np.square(power_samples.astype(np.int64)), axis=2)
     return out, total_power
 
 

--- a/test/fgpu/test_pfb.py
+++ b/test/fgpu/test_pfb.py
@@ -27,11 +27,11 @@ from .. import unpackbits
 
 pytestmark = [pytest.mark.cuda_only]
 TAPS = 16
-SPECTRA = 3123
+SPECTRA = 3128
 CHANNELS = 4096
 
 
-def pfb_fir_host_real(data, channels, input_sample_bits, unzip_factor, weights):
+def pfb_fir_host_real(data, channels, input_sample_bits, unzip_factor, total_power_spectra, weights):
     """Apply a PFB-FIR filter to a set of packed real data on the host."""
     step = 2 * channels
     assert len(weights) % step == 0
@@ -47,7 +47,8 @@ def pfb_fir_host_real(data, channels, input_sample_bits, unzip_factor, weights):
     out = out.reshape(n_pols, -1, channels // unzip_factor, unzip_factor, 2)
     out = out.swapaxes(2, 3)
     out = out.reshape(n_pols, -1, step)
-    power_samples = decoded.reshape(decoded.shape[0], -1, step)[:, taps - 1 :, :]
+    power_samples = decoded[:, step * (taps - 1) :]
+    power_samples = power_samples.reshape(n_pols, -1, step * total_power_spectra)
     total_power = np.sum(np.square(power_samples.astype(np.int64)), axis=2).T
     return out, total_power
 
@@ -88,21 +89,30 @@ def _pfb_fir(fn: pfb.PFBFIR, h_in: np.ndarray, weights: np.ndarray, step: int) -
 
 
 @pytest.mark.combinations(
-    "input_sample_bits,unzip_factor",
+    "input_sample_bits,unzip_factor,total_power_spectra",
     DIG_SAMPLE_BITS_VALID,
     [1, 2, 4],
+    [1, 8, 17],  # Must divide into SPECTRA
 )
 def test_pfb_fir_real(
-    context: AbstractContext, command_queue: AbstractCommandQueue, input_sample_bits: int, unzip_factor: int
+    context: AbstractContext,
+    command_queue: AbstractCommandQueue,
+    input_sample_bits: int,
+    unzip_factor: int,
+    total_power_spectra: int,
 ) -> None:
     """Test the real GPU PFB-FIR for numerical correctness."""
     samples = 2 * CHANNELS * (SPECTRA + TAPS - 1)
     rng = np.random.default_rng(seed=1)
     h_in = rng.integers(0, 256, (N_POLS, samples * input_sample_bits // BYTE_BITS), np.uint8)
     weights = rng.uniform(-1.0, 1.0, (2 * CHANNELS * TAPS,)).astype(np.float32)
-    expected_out, expected_total_power = pfb_fir_host_real(h_in, CHANNELS, input_sample_bits, unzip_factor, weights)
+    expected_out, expected_total_power = pfb_fir_host_real(
+        h_in, CHANNELS, input_sample_bits, unzip_factor, total_power_spectra, weights
+    )
 
-    template = pfb.PFBFIRTemplate(context, TAPS, CHANNELS, input_sample_bits, unzip_factor, n_pols=N_POLS)
+    template = pfb.PFBFIRTemplate(
+        context, TAPS, CHANNELS, input_sample_bits, unzip_factor, n_pols=N_POLS, total_power_spectra=total_power_spectra
+    )
     fn = template.instantiate(command_queue, samples, SPECTRA)
     fn.ensure_all_bound()
     fn.buffer("total_power").zero(command_queue)


### PR DESCRIPTION
When there is a gap between input chunks, the output chunk is fast-forwarded to avoid referencing missing data. This is done with batch granularity, so as not to lose more output data than necessary. However, that means that the OutQueueItem is not necessarily aligned (in time) to a multiple of the output chunk size. In our unit tests it generally has been, because there is no delay model and so it ends up aligned to the *input* chunk size; but when there is a non-zero coarse delay, that's no longer the case. Meanwhile, the code for handling the dig-rms-dbfs sensor works with "windows" which are some multiple of the chunk size and aligned to the window size, and does not cope with OutQueueItems that cross a window boundary. In theory this could also be an issue if a non-zero delay was set before the first data arrived.

Fix it by changing the computation of total digitiser power from being done per-output-chunk (on the GPU) to per-output-batch. I initially experimented with doing it per-output-spectrum, but that was too expensive; even with per-output-batch it needed some experimentation to get the CUDA compiler to generate reasonable code that didn't slow things down massively. I've tested with benchmark_fgpu and found no statistically significant impact on performance:

```
./benchmark_fgpu.py -v --narrowband=1 --image harbor.cbf.mkat.karoo.kat.ac.za/dpp/katgpucbf:latest
1873.0 MHz - 1893.0 MHz

./benchmark_fgpu.py -v --narrowband=1 --image harbor.cbf.mkat.karoo.kat.ac.za/dpp/katgpucbf:NGC-2074-data-gap
1868.0 MHz - 1888.0 MHz

./benchmark_fgpu.py -v --image harbor.cbf.mkat.karoo.kat.ac.za/dpp/katgpucbf:latest
1955.0 MHz - 1975.0 MHz

./benchmark_fgpu.py -v --image harbor.cbf.mkat.karoo.kat.ac.za/dpp/katgpucbf:NGC-2074-data-gap
1957.0 MHz - 1977.0 MHz
```

Add a non-zero delay to the existing unit tests for missing data. That made it a lot more complicated unfortunately.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`.
- [x] (n/a) If new source files are added: add copyright notices dated with the current year.
- [x] (n/a) If qualification tests are changed: attach or link to a sample qualification report.
- [x] If design has changed: ensure documentation is up to date.
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match.
- [x] (n/a) If the interface between the product controller and an engine has changed, update the
      VERSION constant for the engine (update the major number if sensors/requests have been
      removed/changed, minor number if only backwards-compatible changes have been done).
      Also, update doc/control.rst with the new version.

Closes NGC-2074.
