### PR TITLE
Ngc 1619 solve current pytest check versions not supporting pytest reportlog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ doc = [
     "sphinxcontrib-tikz",
     "sphinx-mathjax-offline",
     "pytest",
-    "pytest-check>=1.3,<2.2.3",  # Upper bound due to https://github.com/okken/pytest-check/issues/173
+    "pytest-check>=2.9.1",
 ]
 
 test = [
@@ -68,7 +68,7 @@ test = [
     "matplotlib",
     "pytest>=8",
     "pytest-asyncio>=1.4.0",
-    "pytest-check>=1.3,<2.2.3",  # Upper bound due to https://github.com/okken/pytest-check/issues/173
+    "pytest-check>=2.9.1",
     "pytest-custom_exit_code",
     "pytest-mock",
     "pytest-reportlog",
@@ -82,7 +82,7 @@ qualification = [
     "pylatex",
     "pytest",
     "pytest-asyncio",
-    "pytest-check>=1.3,<2.2.3",  # Upper bound due to https://github.com/okken/pytest-check/issues/173
+    "pytest-check>=2.9.1",
     "pytest-custom_exit_code",
     "pytest-reportlog",
 ]

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -326,7 +326,7 @@ pytest-asyncio==1.4.0
     # via
     #   -c qualification/../requirements-dev.txt
     #   katgpucbf (pyproject.toml)
-pytest-check==2.2.2
+pytest-check==2.9.1
     # via
     #   -c qualification/../requirements-dev.txt
     #   katgpucbf (pyproject.toml)

--- a/qualification/requirements.txt
+++ b/qualification/requirements.txt
@@ -247,6 +247,7 @@ packaging==25.0
     #   katcbf-vlbi-resample
     #   matplotlib
     #   pytest
+    #   pytest-check
     #   xarray
 pandas==2.3.3
     # via

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -346,7 +346,7 @@ pytest==9.0.3
     #   pytest-xdist
 pytest-asyncio==1.4.0
     # via katgpucbf (pyproject.toml)
-pytest-check==2.2.2
+pytest-check==2.9.1
     # via katgpucbf (pyproject.toml)
 pytest-cov==7.0.0
     # via -r requirements-dev.in

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -244,6 +244,7 @@ packaging==25.0
     #   katcbf-vlbi-resample
     #   matplotlib
     #   pytest
+    #   pytest-check
     #   sphinx
     #   statsmodels
     #   xarray


### PR DESCRIPTION
<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [X] If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`.
- [X] If new source files are added: add copyright notices dated with the current year.
- [X] If qualification tests are changed: attach or link to a sample qualification report.
- [X] If design has changed: ensure documentation is up to date.
- [X] If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match.
- [X] If the interface between the product controller and an engine has changed, update the
      VERSION constant for the engine (update the major number if sensors/requests have been
      removed/changed, minor number if only backwards-compatible changes have been done).
      Also, update doc/control.rst with the new version.

Closes NGC-1619.
