### PR TITLE
Improve debugging of qualification test packet drops

### DIFF
--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -706,6 +706,39 @@ async def test_group_delay(
     await pcc.request("delays", "antenna-channelised-voltage", receiver.sync_time, *delay_models)
     pdf_report.detail(f"Set delays to {delay_model} for all inputs.")
 
+    def compute_delay(
+        rel_freqs: tuple[float, float], first_timestamp: int, raw_data: np.ndarray
+    ) -> tuple[float, float, float]:
+        """Process the data collected by :func:`measure_once` to get the result.
+
+        This is split into a helper function so that it can be dispatched to
+        a worker thread to avoid blocking the event loop.
+        """
+        # Convert Gaussian integers to complex128
+        data = raw_data.astype(np.float64).view(np.complex128)[..., 0]
+        phase = np.angle(data[1] * data[0].conj())  # Takes the difference between phases
+        del data  # Free up some memory
+        # Pick a reference timestamp at which we know the dsim will be outputting
+        # both signals with phase 0.
+        ref_timestamp = first_timestamp // dsim_period * dsim_period
+        # Phase-rotate everything to be referenced to ref_timestamp
+        rel_timestamps = np.arange(n_spectra) * receiver.n_samples_between_spectra + (first_timestamp - ref_timestamp)
+        rel_times = rel_timestamps / receiver.scale_factor_timestamp
+        delta = rel_freqs[1] - rel_freqs[0]
+        phase -= 2 * np.pi * delta * rel_times[np.newaxis, :]
+        # The phases should all be similar, but we need to avoid steps of 2pi.
+        # np.unwrap is problematic since it accumulates rounding errors. The
+        # following is good enough as long as all phases are within pi of each
+        # other.
+        phase = wrap_angle(phase - phase[0, 0]) + phase[0, 0]
+        mean_phase = wrap_angle(np.mean(phase))
+        std_phase = np.std(phase) / np.sqrt(phase.size - 1)
+        scale = receiver.scale_factor_timestamp / (2 * np.pi * delta)
+        delay = -mean_phase * scale
+        period = 2 * np.pi * scale
+        std = std_phase * scale
+        return delay, period, std
+
     async def measure_once(rel_freqs: tuple[float, float]) -> tuple[float, float, float]:
         """Estimate group delay for a single pair of frequency offsets.
 
@@ -766,29 +799,8 @@ async def test_group_delay(
         except TimeoutError:
             pytest.fail("Timed out.")
 
-        # Convert Gaussian integers to complex128
-        data = raw_data.astype(np.float64).view(np.complex128)[..., 0]
-        phase = np.angle(data[1] * data[0].conj())  # Takes the difference between phases
-        del data  # Free up some memory
-        # Pick a reference timestamp at which we know the dsim will be outputting
-        # both signals with phase 0.
-        ref_timestamp = first_timestamp // dsim_period * dsim_period
-        # Phase-rotate everything to be referenced to ref_timestamp
-        rel_timestamps = np.arange(n_spectra) * receiver.n_samples_between_spectra + (first_timestamp - ref_timestamp)
-        rel_times = rel_timestamps / receiver.scale_factor_timestamp
-        delta = rel_freqs[1] - rel_freqs[0]
-        phase -= 2 * np.pi * delta * rel_times[np.newaxis, :]
-        # The phases should all be similar, but we need to avoid steps of 2pi.
-        # np.unwrap is problematic since it accumulates rounding errors. The
-        # following is good enough as long as all phases are within pi of each
-        # other.
-        phase = wrap_angle(phase - phase[0, 0]) + phase[0, 0]
-        mean_phase = wrap_angle(np.mean(phase))
-        std_phase = np.std(phase) / np.sqrt(phase.size - 1)
-        scale = receiver.scale_factor_timestamp / (2 * np.pi * delta)
-        delay = -mean_phase * scale
-        period = 2 * np.pi * scale
-        std = std_phase * scale
+        loop = asyncio.get_event_loop()
+        delay, period, std = await loop.run_in_executor(None, compute_delay, rel_freqs, first_timestamp, raw_data)
         pdf_report.detail(f"Delay is {delay} + k*{period} ± {std} samples.")
         return delay, period, std
 

--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -20,6 +20,7 @@ import asyncio
 import math
 from ast import literal_eval
 from collections.abc import Callable
+from contextlib import aclosing
 
 import numpy as np
 import pytest
@@ -775,8 +776,8 @@ async def test_group_delay(
         # First axis corresponds to the 2 signals we're comparing.
         raw_data = np.ones((2, n_channels, n_spectra, COMPLEX), np.int8)
         try:
-            async with asyncio.timeout(acc_time * 3 + 10.0):
-                async for timestamp, chunk in receiver.complete_chunks():
+            async with asyncio.timeout(acc_time * 3 + 10.0), aclosing(receiver.complete_chunks()) as it:
+                async for timestamp, chunk in it:
                     with chunk:
                         if i == 0 or timestamp != first_timestamp + i * chunk_timestamp_step:
                             first_timestamp = timestamp

--- a/qualification/antenna_channelised_voltage/test_delay.py
+++ b/qualification/antenna_channelised_voltage/test_delay.py
@@ -78,17 +78,10 @@ async def test_delay_application_time(
         target_ts = round(receiver.time_converter.unix_to_adc(target))
         target_acc_ts = target_ts // receiver.timestamp_step * receiver.timestamp_step
         acc = None
-        async for timestamp, chunk in receiver.complete_chunks(min_timestamp=target_acc_ts, time_limit=10.0):
-            with chunk:
-                pdf_report.detail(f"Received chunk with timestamp {timestamp}, target is {target_acc_ts}.")
-                total = np.sum(chunk.data[:, bl_idx, :], axis=0)  # Sum over channels
-                if timestamp == target_acc_ts:
-                    acc = total
-                if timestamp >= target_acc_ts:
-                    break
-        else:
-            pdf_report.detail("Did not reach the target timestamp within 10s.")
-        if acc is not None:
+        timestamp, data = await receiver.next_complete_chunk(min_timestamp=target_acc_ts, timeout=10.0)
+        pdf_report.detail(f"Received chunk with timestamp {timestamp}, target is {target_acc_ts}.")
+        if timestamp == target_acc_ts:
+            acc = np.sum(data[:, bl_idx, :], axis=0)  # Sum over channels
             break
 
         pdf_report.detail("Did not receive all the expected chunks; reset delay and try again.")

--- a/qualification/conftest.py
+++ b/qualification/conftest.py
@@ -35,7 +35,7 @@ from katgpucbf.meerkat import BANDS
 from katgpucbf.pytest_plugins.reporter import Reporter, custom_report_log
 
 from .cbf import CBFCache, CBFRemoteControl, FailedCBF
-from .recv import DEFAULT_TIMEOUT, BaselineCorrelationProductsReceiver, TiedArrayChannelisedVoltageReceiver
+from .recv import DEFAULT_TIMEOUT, BaselineCorrelationProductsReceiver, TiedArrayChannelisedVoltageReceiver, diff_stats
 
 pytest_plugins = ["katgpucbf.pytest_plugins.numpy_dump", "katgpucbf.pytest_plugins.reporter_plugin"]
 logger = logging.getLogger(__name__)
@@ -631,7 +631,8 @@ def pass_channels(band: str, narrowband_decimation: int, vlbi: bool, pass_bandwi
 async def receive_baseline_correlation_products(
     cbf: CBFRemoteControl,
     capture_start_streams: list[str],
-) -> BaselineCorrelationProductsReceiver:
+    pdf_report: Reporter,
+) -> AsyncGenerator[BaselineCorrelationProductsReceiver, None]:
     """Get the spead2 receive stream for ingesting X-engine output."""
     receiver = cbf.baseline_correlation_products_receiver
     assert receiver is not None
@@ -641,14 +642,17 @@ async def receive_baseline_correlation_products(
     # data flowing at the start.
     if "baseline-correlation_products" in capture_start_streams:
         await receiver.wait_complete_chunk(max_delay=0, timeout=3 * DEFAULT_TIMEOUT)
-    return receiver
+    with diff_stats(receiver.stream_group) as delta_stats:
+        yield receiver
+    pdf_report.spead2_statistics("baseline_correlation_products", delta_stats)
 
 
 @pytest.fixture
 async def receive_tied_array_channelised_voltage(
     cbf: CBFRemoteControl,
     capture_start_streams: list[str],
-) -> TiedArrayChannelisedVoltageReceiver:
+    pdf_report: Reporter,
+) -> AsyncGenerator[TiedArrayChannelisedVoltageReceiver, None]:
     """Get the spead2 receive stream for ingesting the tied-array-channelised-voltage streams."""
     receiver = cbf.tied_array_channelised_voltage_receiver
     assert receiver is not None
@@ -662,4 +666,6 @@ async def receive_tied_array_channelised_voltage(
         if config["type"] == "gpucbf.tied_array_channelised_voltage"
     ):
         await receiver.wait_complete_chunk(max_delay=0, timeout=3 * DEFAULT_TIMEOUT)
-    return receiver
+    with diff_stats(receiver.stream_group) as delta_stats:
+        yield receiver
+    pdf_report.spead2_statistics("tied_array_channelised_voltage", delta_stats)

--- a/qualification/general/test_control.py
+++ b/qualification/general/test_control.py
@@ -20,6 +20,7 @@ import asyncio
 import math
 import time
 from collections.abc import AsyncGenerator, Awaitable
+from contextlib import aclosing
 
 import aiokatcp
 import numpy as np
@@ -81,9 +82,10 @@ async def consume_chunks(receiver: XBReceiver, timestamps: list[int]) -> None:
     The timestamps of the complete chunks are appended to `timestamps`.
     """
     max_delay = math.ceil(MAX_DELAY * receiver.scale_factor_timestamp)
-    async for timestamp, chunk in receiver.complete_chunks(max_delay=max_delay):
-        with chunk:
-            timestamps.append(timestamp)
+    async with aclosing(receiver.complete_chunks(max_delay=max_delay)) as it:
+        async for timestamp, chunk in it:
+            with chunk:
+                timestamps.append(timestamp)
 
 
 async def control_acv_delays(rng: np.random.Generator, cbf: CBFRemoteControl, pdf_report: Reporter, name: str) -> None:

--- a/qualification/recv.py
+++ b/qualification/recv.py
@@ -18,11 +18,14 @@
 
 import ast
 import asyncio
+import contextlib
 import ctypes
+import functools
 import logging
 import math
+import operator
 import os
-from collections.abc import AsyncGenerator, Callable, Sequence
+from collections.abc import AsyncGenerator, Callable, Generator, Sequence
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 import numba
@@ -53,6 +56,7 @@ class XBReceiver:
     """Base for :class:`BaselineCorrelationProductsReceiver` and :class:`TiedArrayChannelisedVoltageReceiver`."""
 
     # Attributes instantiated by the derived classes
+    stream_group: spead2.recv.ChunkStreamRingGroup
     timestamp_step: int  # Step (in ADC samples) between chunk timestamps
     _chunk_iter: DiscardingChunkIterator
 
@@ -684,3 +688,21 @@ def create_tied_array_channelised_voltage_receive_stream_group(
             sink=stream_group,
         ),
     )
+
+
+@contextlib.contextmanager
+def diff_stats(stream_group: spead2.recv.ChunkStreamRingGroup) -> Generator[dict[str, int], None, None]:
+    """Collect stream group statistics on entry and exit and return differences.
+
+    The context manager value is a dictionary of statistics. Only "counter"
+    mode statistics are returned, as maximum-value statistics cannot be
+    meaningfully differenced. Note that the dictionary is only populated on
+    exit from the context manager.
+    """
+    delta_stats: dict[str, int] = {}
+    init_stats = functools.reduce(operator.add, [stream.stats for stream in stream_group])
+    yield delta_stats
+    final_stats = functools.reduce(operator.add, [stream.stats for stream in stream_group])
+    for stat in final_stats.config:
+        if stat.mode == spead2.recv.StreamStatConfig.Mode.COUNTER:
+            delta_stats[stat.name] = final_stats[stat.name] - init_stats[stat.name]

--- a/qualification/recv.py
+++ b/qualification/recv.py
@@ -26,6 +26,7 @@ import math
 import operator
 import os
 from collections.abc import AsyncGenerator, Callable, Generator, Sequence
+from contextlib import aclosing
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 import numba
@@ -177,6 +178,10 @@ class XBReceiver:
 
         Each yielded value is a ``(timestamp, chunk)`` pair.
 
+        It is important that this asynchronous generator is closed as soon as
+        it is no longer needed, for example, by using
+        :func:`contextlib.aclosing`.
+
         Parameters
         ----------
         min_timestamp
@@ -301,8 +306,11 @@ class XBReceiver:
            with enough chunks and update this comment.
         """
         chunks: list[tuple[int, katgpucbf.recv.Chunk]] = []
-        async with asyncio.timeout(timeout):
-            async for timestamp, chunk in self.complete_chunks(min_timestamp=min_timestamp, all_timestamps=True):
+        async with (
+            asyncio.timeout(timeout),
+            aclosing(self.complete_chunks(min_timestamp=min_timestamp, all_timestamps=True)) as it,
+        ):
+            async for timestamp, chunk in it:
                 if chunk is None:
                     # Throw away failed attempt at getting an adjacent set
                     for _, old_chunk in chunks:

--- a/qualification/recv.py
+++ b/qualification/recv.py
@@ -39,6 +39,7 @@ from spead2.recv.numba import chunk_place_data
 
 import katgpucbf.recv
 from katgpucbf import COMPLEX, DEFAULT_DIG_SAMPLE_BITS, DEFAULT_RECV_BUFFER_SIZE
+from katgpucbf.recv import DiscardingChunkIterator
 from katgpucbf.spead import BEAM_ANTS_ID, DEFAULT_PORT, FREQUENCY_ID, TIMESTAMP_ID
 from katgpucbf.utils import TimeConverter
 
@@ -52,8 +53,8 @@ class XBReceiver:
     """Base for :class:`BaselineCorrelationProductsReceiver` and :class:`TiedArrayChannelisedVoltageReceiver`."""
 
     # Attributes instantiated by the derived classes
-    stream_group: spead2.recv.ChunkStreamRingGroup
     timestamp_step: int  # Step (in ADC samples) between chunk timestamps
+    _chunk_iter: DiscardingChunkIterator
 
     def __init__(self, cbf: CBFRemoteControl, stream_names: Sequence[str]) -> None:
         # Some metadata we know already from the config.
@@ -96,6 +97,45 @@ class XBReceiver:
     def is_complete_chunk(self, chunk: katgpucbf.recv.Chunk) -> bool:
         """Check whether this chunk is complete (no missing data)."""
         return bool(np.all(chunk.present))
+
+    # The overloads ensure that when all_timestamps is known to be False, the
+    # returned chunks are inferred to not be optional.
+    @overload
+    async def _next_complete_chunk(
+        self, min_timestamp: int, *, all_timestamps: Literal[False] = False
+    ) -> tuple[int, katgpucbf.recv.Chunk]: ...
+
+    @overload
+    async def _next_complete_chunk(
+        self, min_timestamp: int, *, all_timestamps: bool = False
+    ) -> tuple[int, katgpucbf.recv.Chunk | None]: ...
+
+    async def _next_complete_chunk(self, min_timestamp, *, all_timestamps=False):
+        """Return the data from the next complete chunk from the stream.
+
+        This implements the functionality of :meth:`next_complete_chunk`, but
+        the caller is responsible for computing `min_timestamp`, putting the
+        iterator into capturing mode, and recycling the returned chunk.
+
+        Raises
+        ------
+        StopAsyncIteration
+            If the stream closed or was interrupted before we received a complete chunk.
+        """
+        while True:
+            chunk = await anext(self._chunk_iter)
+            timestamp = chunk.chunk_id * self.timestamp_step
+            if min_timestamp is not None and timestamp < min_timestamp:
+                logger.debug("Skipping chunk with timestamp %d (< %d)", timestamp, min_timestamp)
+            elif not self.is_complete_chunk(chunk):
+                logger.debug("Incomplete chunk %d", chunk.chunk_id)
+            else:
+                chunk.timestamp = timestamp
+                return timestamp, chunk
+            # If we get here, the chunk is ignored.
+            chunk.recycle()
+            if all_timestamps:
+                return timestamp, None
 
     # The overloads ensure that when all_timestamps is known to be False, the
     # returned chunks are inferred to not be optional.
@@ -153,24 +193,14 @@ class XBReceiver:
         if min_timestamp is None:
             min_timestamp = await self.cbf.steady_state_timestamp(max_delay=max_delay)
 
-        data_ringbuffer = self.stream_group.data_ringbuffer
-        assert isinstance(data_ringbuffer, spead2.recv.asyncio.ChunkRingbuffer)
         try:
             async with asyncio.timeout(time_limit) as timer:
-                async for chunk in data_ringbuffer:
-                    assert isinstance(chunk, katgpucbf.recv.Chunk)  # keeps mypy happy
-                    timestamp = chunk.chunk_id * self.timestamp_step
-                    if min_timestamp is not None and timestamp < min_timestamp:
-                        logger.debug("Skipping chunk with timestamp %d (< %d)", timestamp, min_timestamp)
-                    elif not self.is_complete_chunk(chunk):
-                        logger.debug("Incomplete chunk %d", chunk.chunk_id)
-                    else:
-                        yield timestamp, chunk
-                        continue
-                    # If we get here, the chunk is ignored
-                    chunk.recycle()
-                    if all_timestamps:
-                        yield timestamp, None
+                with self._chunk_iter:
+                    while True:
+                        try:
+                            yield await self._next_complete_chunk(min_timestamp, all_timestamps=all_timestamps)
+                        except StopAsyncIteration:
+                            break
         except TimeoutError:
             if not timer.expired():
                 raise  # The TimeoutError came from something else
@@ -200,11 +230,16 @@ class XBReceiver:
         RuntimeError
             If the stream is stopped before a complete chunk is received
         """
+        if min_timestamp is None:
+            min_timestamp = await self.cbf.steady_state_timestamp(max_delay=max_delay)
         async with asyncio.timeout(timeout):
-            async for timestamp, chunk in self.complete_chunks(min_timestamp=min_timestamp, max_delay=max_delay):
+            with self._chunk_iter:
+                try:
+                    timestamp, chunk = await self._next_complete_chunk(min_timestamp)
+                except StopAsyncIteration:
+                    raise RuntimeError("stream was shut down before we received a complete chunk") from None
                 with chunk:
                     return timestamp, np.array(chunk.data)  # Makes a copy before we return the chunk
-        raise RuntimeError("stream was shut down before we received a complete chunk")
 
     async def wait_complete_chunk(
         self,
@@ -233,11 +268,16 @@ class XBReceiver:
         RuntimeError
             If the stream is stopped before a complete chunk is received
         """
+        if min_timestamp is None:
+            min_timestamp = await self.cbf.steady_state_timestamp(max_delay=max_delay)
         async with asyncio.timeout(timeout):
-            async for timestamp, chunk in self.complete_chunks(min_timestamp=min_timestamp, max_delay=max_delay):
+            with self._chunk_iter:
+                try:
+                    timestamp, chunk = await self._next_complete_chunk(min_timestamp)
+                except StopAsyncIteration:
+                    raise RuntimeError("stream was shut down before we received a complete chunk") from None
                 chunk.recycle()
                 return timestamp
-        raise RuntimeError("stream was shut down before we received a complete chunk")
 
     async def consecutive_chunks(
         self,
@@ -350,6 +390,7 @@ class BaselineCorrelationProductsReceiver(XBReceiver):
             n_samples_between_spectra=self.n_samples_between_spectra,
             use_ibv=use_ibv,
         )
+        self._chunk_iter = DiscardingChunkIterator(self.stream_group.data_ringbuffer)  # type: ignore
 
     def is_complete_chunk(self, chunk: katgpucbf.recv.Chunk) -> bool:  # noqa: D102
         if not super().is_complete_chunk(chunk):
@@ -411,6 +452,7 @@ class TiedArrayChannelisedVoltageReceiver(XBReceiver):
             decimation_factor=self.decimation_factor,
             use_ibv=use_ibv,
         )
+        self._chunk_iter = DiscardingChunkIterator(self.stream_group.data_ringbuffer)  # type: ignore
 
     def is_complete_chunk(self, chunk: katgpucbf.recv.Chunk) -> bool:  # noqa: D102
         return super().is_complete_chunk(chunk) and (chunk.extra is None or np.min(chunk.extra) == self.n_ants)

--- a/qualification/report/generate_pdf.py
+++ b/qualification/report/generate_pdf.py
@@ -374,6 +374,7 @@ class Result:
     blurb: str = ""
     requirements: list[str] = field(default_factory=list)
     steps: list[Step] = field(default_factory=list)
+    spead2_statistics: dict[str, dict[str, int]] = field(default_factory=dict)
     outcome: Literal["passed", "failed", "skipped", "xfail"] = "failed"
     xfail_reason: str | None = None
     failure_messages: list[str] = field(default_factory=list)
@@ -506,6 +507,8 @@ def _parse_report_data(result: Result, msg: dict) -> None:
         if "correlator" in msg:  # Backwards compatibility: handle this old name
             msg["cbf"] = msg.pop("correlator")
         result.config.update(msg)
+    elif msg_type == "spead2_statistics":
+        result.spead2_statistics[msg["name"]] = msg["stats"]
     else:
         raise ValueError(f"Do not know how to parse $msg_type of {msg_type!r}")
 
@@ -1121,6 +1124,23 @@ def _doc_result(section: Container, result: Result, tmp_dir: pathlib.Path, figur
         with section.create(LstListing()) as failure_message:
             for message in result.failure_messages:
                 failure_message.append(message)
+
+    if result.spead2_statistics:
+        stat_names = {
+            "Heaps": "heaps",
+            "Too old": "too_old_heaps",
+            "Incomplete": "incomplete_heaps_evicted",
+            "Worker blocked": "worker_blocked",
+        }
+        with section.create(LongTable(r"|l|" + "r|" * len(stat_names))) as stats_table:
+            stats_table.add_hline()
+            stats_table.add_row((MultiColumn(len(stat_names) + 1, align="|c|", data=bold("spead2 statistics")),))
+            stats_table.add_hline()
+            stats_table.add_row([bold("Stream")] + [bold(name) for name in stat_names])
+            stats_table.add_hline()
+            for name, stats in result.spead2_statistics.items():
+                stats_table.add_row([name] + [stats.get(value, "-") for value in stat_names.values()])
+                stats_table.add_hline()
 
 
 def _doc_result_set(

--- a/src/katgpucbf/pytest_plugins/reporter.py
+++ b/src/katgpucbf/pytest_plugins/reporter.py
@@ -198,6 +198,18 @@ class Reporter:
             value["data"] = data
         self._cur_step.append(value)
 
+    def spead2_statistics(self, name: str, stats: dict[str, int]) -> None:
+        """Add record of statistics from spead2's receive system.
+
+        Parameters
+        ----------
+        name
+            The receiver for which statistics are being reported.
+        stats
+            Statistics returned by :func:`qualification.recv.diff_stats`.
+        """
+        self._data.append({"$msg_type": "spead2_statistics", "name": name, "stats": stats})
+
 
 def custom_report_log(pytestconfig: pytest.Config, data) -> None:
     """Log a custom JSON line in the report log."""

--- a/src/katgpucbf/recv.py
+++ b/src/katgpucbf/recv.py
@@ -24,7 +24,7 @@ import weakref
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator, Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, ClassVar, Self
+from typing import Any, ClassVar, Self, override
 
 import aiokatcp
 import numba.core.ccallback
@@ -37,7 +37,13 @@ from prometheus_client import REGISTRY, CollectorRegistry, Counter, Metric
 from prometheus_client.core import CounterMetricFamily
 from prometheus_client.registry import Collector
 
-from .utils import DeviceStatusSensor, TimeConverter, TimeoutSensorStatusObserver, make_rate_limited_sensor
+from .utils import (
+    DeviceStatusSensor,
+    DiscardingIterator,
+    TimeConverter,
+    TimeoutSensorStatusObserver,
+    make_rate_limited_sensor,
+)
 
 logger = logging.getLogger(__name__)
 user_data_type = types.Record.make_c_struct(
@@ -720,3 +726,11 @@ async def iter_chunks(
             yield chunk
     finally:
         stats_collector.update()  # Ensure final stats updates are captured
+
+
+class DiscardingChunkIterator(DiscardingIterator[Chunk]):
+    """Specialise :class:`.DiscardingIterator` to discard chunks by recycling them."""
+
+    @override
+    def discard(self, item: Chunk) -> None:
+        item.recycle()

--- a/src/katgpucbf/utils.py
+++ b/src/katgpucbf/utils.py
@@ -66,7 +66,7 @@ class DiscardingIterator[T](AsyncIterator[T]):
     may iterate one more item if it is ready).
 
     The implementation is currently not robust against the base iterator
-    raising exceptions. The exception will be logged by it will terminate
+    raising exceptions. The exception will be logged but it will terminate
     iteration.
     """
 

--- a/src/katgpucbf/vgpu/engine.py
+++ b/src/katgpucbf/vgpu/engine.py
@@ -21,7 +21,6 @@ import logging
 from collections.abc import AsyncIterator, Sequence
 from dataclasses import dataclass
 from fractions import Fraction
-from typing import override
 
 import aiokatcp
 import cupy as cp
@@ -43,20 +42,12 @@ from astropy.time import Time, TimeDelta
 from .. import COMPLEX, N_POLS
 from .. import recv as base_recv
 from ..monitor import Monitor
-from ..recv import RECV_SENSOR_TIMEOUT_CHUNKS, RECV_SENSOR_TIMEOUT_MIN
+from ..recv import RECV_SENSOR_TIMEOUT_CHUNKS, RECV_SENSOR_TIMEOUT_MIN, DiscardingChunkIterator
 from ..ringbuffer import ChunkRingbuffer
-from ..utils import DiscardingIterator, Engine, TimeConverter
+from ..utils import Engine, TimeConverter
 from . import N_SIDEBANDS, recv, send
 
 logger = logging.getLogger(__name__)
-
-
-class DiscardingChunkIterator(DiscardingIterator[recv.Chunk]):
-    """Specialise :class:`.DiscardingIterator` to discard chunks by recycling them."""
-
-    @override
-    def discard(self, item: recv.Chunk) -> None:
-        item.recycle()
 
 
 class RecvStream:


### PR DESCRIPTION
There are two changes here:
1. Use DiscardingChunkIterator (originally developed for vgpu) in the qualification test, so that when we're e.g. waiting for dsim signals to be set, we're discarding chunks instead of them backing up in the ringbuffer and leading to dropped packets. This significantly reduces the amount of time in which the qualification test machine shows rdma out-of-buffer errors. It doesn't completely eliminate it, which I think is because the qualification test has some bits of code that hog the CPU for significant time and prevent the discarding iterator from doing its discarding. That can be improved later by identifying such code and either farming it out to another thread or introducing yields to the event loop.
2. Capture the stream statistics before and after each test, and report the number of heaps that were incomplete or too old, and the number of times the worker thread was blocked.

Between the two of these, it should become easier to diagnose why tests sometimes lose heaps: there should be fewer cases of "qualification test host has RDMA out-of-buffer errors, but we don't know if it was while trying to capture contiguous data for the test". If there were no out-of-buffer errors, we can also detect heaps that arrived too late (in which case we need to increase the size of the reorder buffer (there have been failures in the lab where I've hypothesized that this was the case, but I had no data).

This doesn't cover reporting of incomplete chunks, which might be a useful further addition.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`.
- [x] (n/a) If new source files are added: add copyright notices dated with the current year.
- [x] If qualification tests are changed: attach or link to a sample qualification report: [report.pdf](https://github.com/user-attachments/files/31425127/report.pdf) (some figures might be wonky because I didn't have fonts installed when I ran this manually); full nightly: https://jenkins.cbf.kat.ac.za/job/qualification_katgpucbf_karoo/705/
- [x] (n/a) If design has changed: ensure documentation is up to date.
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match.
- [x] (n/a) If the interface between the product controller and an engine has changed, update the
      VERSION constant for the engine (update the major number if sensors/requests have been
      removed/changed, minor number if only backwards-compatible changes have been done).
      Also, update doc/control.rst with the new version.

See NGC-1813.
