### PR TITLE
vgpu: increase reorder tolerance

### DIFF
--- a/src/katgpucbf/vgpu/engine.py
+++ b/src/katgpucbf/vgpu/engine.py
@@ -159,6 +159,7 @@ class RecvConfig:
     comp_vector: int
     buffer_size: int
     pols: tuple[str, str]
+    reorder_tol_bytes: int
 
     @property
     def pol_labels(self) -> list[str]:
@@ -362,7 +363,12 @@ class VEngine(Engine):
         layout = config.recv_config.layout
         dtype = np.dtype(f"int{layout.sample_bits}")
         recv_group = recv.make_stream_group(
-            layout, data_ringbuffer, free_ringbuffer, config.recv_config.affinity, config.recv_config.pol_labels
+            layout,
+            data_ringbuffer,
+            free_ringbuffer,
+            config.recv_config.affinity,
+            config.recv_config.pol_labels,
+            config.recv_config.reorder_tol_bytes,
         )
         for _ in range(recv_chunks):
             chunk = recv.Chunk(

--- a/src/katgpucbf/vgpu/engine.py
+++ b/src/katgpucbf/vgpu/engine.py
@@ -18,6 +18,7 @@
 
 import asyncio
 import logging
+import math
 from collections.abc import AsyncIterator, Sequence
 from dataclasses import dataclass
 from fractions import Fraction
@@ -354,10 +355,13 @@ class VEngine(Engine):
 
     def _init_recv(self) -> None:
         """Initialise the receiver state."""
-        config = self.config
-        layout = config.recv_config.layout
+        recv_config = self.config.recv_config
+        layout = recv_config.layout
         data_ringbuffer_chunks = 2  # TODO: may need tuning
-        max_active_chunks = recv.max_active_chunks(layout, config.recv_config.reorder_tol_bytes)
+        # The + 1 is because we want the distance from the end of the oldest chunk
+        # to the start of the newest chunk (a distance of n-1 chunks) to be at
+        # least REORDER_BYTES.
+        max_active_chunks = math.ceil(recv_config.reorder_tol_bytes / layout.chunk_bytes) + 1
         total_chunks = data_ringbuffer_chunks + max_active_chunks
         data_ringbuffer = ChunkRingbuffer(
             data_ringbuffer_chunks, name="recv_data_ringbuffer", task_name="run", monitor=self.monitor
@@ -368,9 +372,9 @@ class VEngine(Engine):
             layout,
             data_ringbuffer,
             free_ringbuffer,
-            config.recv_config.affinity,
-            config.recv_config.pol_labels,
-            config.recv_config.reorder_tol_bytes,
+            recv_config.affinity,
+            recv_config.pol_labels,
+            max_active_chunks,
         )
         for _ in range(total_chunks):
             chunk = recv.Chunk(
@@ -389,11 +393,11 @@ class VEngine(Engine):
         for i, stream in enumerate(recv_group):
             base_recv.add_reader(
                 stream,
-                src=config.recv_config.srcs[i],
-                interface=config.recv_config.interface,
-                ibv=config.recv_config.ibv,
-                comp_vector=config.recv_config.comp_vector,
-                buffer_size=config.recv_config.buffer_size // len(recv_group),
+                src=recv_config.srcs[i],
+                interface=recv_config.interface,
+                ibv=recv_config.ibv,
+                comp_vector=recv_config.comp_vector,
+                buffer_size=recv_config.buffer_size // len(recv_group),
             )
 
         self._recv_group = recv_group
@@ -402,8 +406,8 @@ class VEngine(Engine):
                 data_ringbuffer,
                 layout,
                 self.sensors,
-                config.recv_config.time_converter,
-                config.recv_config.pol_labels,
+                recv_config.time_converter,
+                recv_config.pol_labels,
             )
         )
 

--- a/src/katgpucbf/vgpu/engine.py
+++ b/src/katgpucbf/vgpu/engine.py
@@ -355,12 +355,14 @@ class VEngine(Engine):
     def _init_recv(self) -> None:
         """Initialise the receiver state."""
         config = self.config
-        recv_chunks = 4  # TODO: may need tuning?
-        data_ringbuffer = ChunkRingbuffer(
-            recv_chunks, name="recv_data_ringbuffer", task_name="run", monitor=self.monitor
-        )
-        free_ringbuffer = spead2.recv.ChunkRingbuffer(recv_chunks)
         layout = config.recv_config.layout
+        data_ringbuffer_chunks = 2  # TODO: may need tuning
+        max_active_chunks = recv.max_active_chunks(layout, config.recv_config.reorder_tol_bytes)
+        total_chunks = data_ringbuffer_chunks + max_active_chunks
+        data_ringbuffer = ChunkRingbuffer(
+            data_ringbuffer_chunks, name="recv_data_ringbuffer", task_name="run", monitor=self.monitor
+        )
+        free_ringbuffer = spead2.recv.ChunkRingbuffer(total_chunks)
         dtype = np.dtype(f"int{layout.sample_bits}")
         recv_group = recv.make_stream_group(
             layout,
@@ -370,7 +372,7 @@ class VEngine(Engine):
             config.recv_config.pol_labels,
             config.recv_config.reorder_tol_bytes,
         )
-        for _ in range(recv_chunks):
+        for _ in range(total_chunks):
             chunk = recv.Chunk(
                 present=np.empty(
                     (N_POLS, layout.n_batches_per_chunk, layout.n_pol_substreams),

--- a/src/katgpucbf/vgpu/main.py
+++ b/src/katgpucbf/vgpu/main.py
@@ -89,6 +89,13 @@ def parse_args(arglist: Sequence[str] | None = None) -> argparse.Namespace:
         required=True,
         help="Input polarisations (±x, ±y, ±L or ±R)",
     )
+    parser.add_argument(
+        "--recv-reorder-tol-bytes",
+        type=int,
+        metavar="BYTES",
+        default=128 * 1024 * 1024,
+        help="Size of reorder buffer for handling out-of-order incoming data",
+    )
     parser.add_argument("--send-bandwidth", type=float, metavar="HZ", required=True, help="Output bandwidth")
     parser.add_argument(
         "--send-pols",
@@ -190,6 +197,7 @@ def make_engine(args: argparse.Namespace) -> VEngine:
         comp_vector=args.recv_comp_vector,
         buffer_size=args.recv_buffer,
         pols=tuple(args.recv_pols),
+        reorder_tol_bytes=args.recv_reorder_tol_bytes,
     )
     send_config = SendConfig(
         pols=tuple(args.send_pols),

--- a/src/katgpucbf/vgpu/recv.py
+++ b/src/katgpucbf/vgpu/recv.py
@@ -17,7 +17,6 @@
 """Handle receiving tied-array-channelised-voltage data."""
 
 import functools
-import math
 from collections.abc import AsyncGenerator, Sequence
 from dataclasses import dataclass
 from enum import IntEnum
@@ -37,9 +36,6 @@ from ..recv import BaseLayout, Chunk, Counters, StatsCollector
 from ..spead import BEAM_ANTS_ID, FREQUENCY_ID, TIMESTAMP_ID
 from ..utils import TimeConverter
 from . import METRIC_NAMESPACE
-
-#: Number of bytes to allow for chunks under construction
-REORDER_BYTES = 64 * 1024 * 1024
 
 counters = Counters(
     heaps=Counter("input_heaps", "number of heaps received", ["pol"], namespace=METRIC_NAMESPACE),
@@ -203,21 +199,13 @@ class Layout(BaseLayout):
         return chunk_place_impl
 
 
-def max_active_chunks(layout: Layout, reorder_tol_bytes: int) -> int:
-    """Compute the number of chunks for the reordering buffer."""
-    # The + 1 is because we want the distance from the end of the oldest chunk
-    # to the start of the newest chunk (a distance of n-1 chunks) to be at
-    # least REORDER_BYTES.
-    return math.ceil(reorder_tol_bytes / layout.chunk_bytes) + 1
-
-
 def make_stream_group(
     layout: Layout,
     data_ringbuffer: spead2.recv.asyncio.ChunkRingbuffer,
     free_ringbuffer: spead2.recv.ChunkRingbuffer,
     recv_affinity: int,
     pol_labels: Sequence[str],
-    reorder_tol_bytes: int,
+    max_active_chunks: int,
 ) -> spead2.recv.ChunkStreamRingGroup:
     """Create a stream group for receiving dual-polarised beam data.
 
@@ -236,9 +224,8 @@ def make_stream_group(
         Use -1 to indicate no affinity.
     pol_labels
         Prometheus labels to apply to the polarisations (must have length 2).
-    reorder_tol_bytes
-        Maximum tolerance for input data reordering, expressed in terms of
-        bytes in the reordering buffer.
+    max_active_chunks
+        Maximum number of chunks that can be under construction at a time.
     """
     # Reference counters to make the labels exist before the first scrape
     assert len(pol_labels) == N_POLS
@@ -250,7 +237,7 @@ def make_stream_group(
     group = base_recv.make_stream_group(
         layout=layout,
         spead_items=[TIMESTAMP_ID, FREQUENCY_ID, BEAM_ANTS_ID, spead2.HEAP_LENGTH_ID],
-        max_active_chunks=max_active_chunks(layout, reorder_tol_bytes),
+        max_active_chunks=max_active_chunks,
         data_ringbuffer=data_ringbuffer,
         free_ringbuffer=free_ringbuffer,
         affinity=[recv_affinity] * N_POLS,

--- a/src/katgpucbf/vgpu/recv.py
+++ b/src/katgpucbf/vgpu/recv.py
@@ -17,6 +17,7 @@
 """Handle receiving tied-array-channelised-voltage data."""
 
 import functools
+import math
 from collections.abc import AsyncGenerator, Sequence
 from dataclasses import dataclass
 from enum import IntEnum
@@ -37,8 +38,8 @@ from ..spead import BEAM_ANTS_ID, FREQUENCY_ID, TIMESTAMP_ID
 from ..utils import TimeConverter
 from . import METRIC_NAMESPACE
 
-#: Number of chunks to allow to be under construction
-MAX_CHUNKS = 2  # TODO: may need to increase to tolerate reordering
+#: Number of bytes to allow for chunks under construction
+REORDER_BYTES = 64 * 1024 * 1024
 
 counters = Counters(
     heaps=Counter("input_heaps", "number of heaps received", ["pol"], namespace=METRIC_NAMESPACE),
@@ -208,6 +209,7 @@ def make_stream_group(
     free_ringbuffer: spead2.recv.ChunkRingbuffer,
     recv_affinity: int,
     pol_labels: Sequence[str],
+    reorder_tol_bytes: int,
 ) -> spead2.recv.ChunkStreamRingGroup:
     """Create a stream group for receiving dual-polarised beam data.
 
@@ -226,6 +228,9 @@ def make_stream_group(
         Use -1 to indicate no affinity.
     pol_labels
         Prometheus labels to apply to the polarisations (must have length 2).
+    reorder_tol_bytes
+        Maximum tolerance for input data reordering, expressed in terms of
+        bytes in the reordering buffer.
     """
     # Reference counters to make the labels exist before the first scrape
     assert len(pol_labels) == N_POLS
@@ -234,10 +239,14 @@ def make_stream_group(
 
     user_data = np.zeros(N_POLS, dtype=user_data_type.dtype)
     user_data["pol"] = np.arange(N_POLS)
+    # The + 1 is because we want the distance from the end of the oldest chunk
+    # to the start of the newest chunk (a distance of n-1 chunks) to be at
+    # least REORDER_BYTES.
+    max_active_chunks = math.ceil(reorder_tol_bytes / layout.chunk_bytes) + 1
     group = base_recv.make_stream_group(
         layout=layout,
         spead_items=[TIMESTAMP_ID, FREQUENCY_ID, BEAM_ANTS_ID, spead2.HEAP_LENGTH_ID],
-        max_active_chunks=MAX_CHUNKS,
+        max_active_chunks=max_active_chunks,
         data_ringbuffer=data_ringbuffer,
         free_ringbuffer=free_ringbuffer,
         affinity=[recv_affinity] * N_POLS,

--- a/src/katgpucbf/vgpu/recv.py
+++ b/src/katgpucbf/vgpu/recv.py
@@ -203,6 +203,14 @@ class Layout(BaseLayout):
         return chunk_place_impl
 
 
+def max_active_chunks(layout: Layout, reorder_tol_bytes: int) -> int:
+    """Compute the number of chunks for the reordering buffer."""
+    # The + 1 is because we want the distance from the end of the oldest chunk
+    # to the start of the newest chunk (a distance of n-1 chunks) to be at
+    # least REORDER_BYTES.
+    return math.ceil(reorder_tol_bytes / layout.chunk_bytes) + 1
+
+
 def make_stream_group(
     layout: Layout,
     data_ringbuffer: spead2.recv.asyncio.ChunkRingbuffer,
@@ -239,14 +247,10 @@ def make_stream_group(
 
     user_data = np.zeros(N_POLS, dtype=user_data_type.dtype)
     user_data["pol"] = np.arange(N_POLS)
-    # The + 1 is because we want the distance from the end of the oldest chunk
-    # to the start of the newest chunk (a distance of n-1 chunks) to be at
-    # least REORDER_BYTES.
-    max_active_chunks = math.ceil(reorder_tol_bytes / layout.chunk_bytes) + 1
     group = base_recv.make_stream_group(
         layout=layout,
         spead_items=[TIMESTAMP_ID, FREQUENCY_ID, BEAM_ANTS_ID, spead2.HEAP_LENGTH_ID],
-        max_active_chunks=max_active_chunks,
+        max_active_chunks=max_active_chunks(layout, reorder_tol_bytes),
         data_ringbuffer=data_ringbuffer,
         free_ringbuffer=free_ringbuffer,
         affinity=[recv_affinity] * N_POLS,

--- a/test/vgpu/test_engine.py
+++ b/test/vgpu/test_engine.py
@@ -122,6 +122,7 @@ class TestVEngine:
             f"--recv-samples-between-spectra={NB_DECIMATION * RECV_CHANNELS * 2}",
             "--recv-jones-per-batch=16384",  # Reduce batch sizes to speed up test
             "--recv-batches-per-chunk=1",  # Reduce chunk sizes to speed up test
+            "--recv-reorder-tol-bytes=131072",  # Reduce to match other reductions
             "--send-interface=lo",
             f"--send-bandwidth={SEND_BANDWIDTH}",
             "--send-pols=x,y",

--- a/test/vgpu/test_recv.py
+++ b/test/vgpu/test_recv.py
@@ -16,6 +16,7 @@
 
 """Unit tests for :mod:`katgpucbf.vgpu.recv`."""
 
+import math
 from collections.abc import Generator
 from unittest import mock
 
@@ -98,7 +99,11 @@ def stream_group(
     It is connected to the :func:`queues` fixture for input and
     :func:`data_ringbuffer` for output.
     """
-    stream_group = recv.make_stream_group(layout, data_ringbuffer, free_ringbuffer, -1, POL_LABELS)
+    # We want this to be larger than the entire input in test_recv, so that
+    # the test doesn't depend on the two receiving threads making progress at
+    # the same rate.
+    reorder_tol_bytes = math.ceil(30 / layout.chunk_batches) * layout.chunk_bytes
+    stream_group = recv.make_stream_group(layout, data_ringbuffer, free_ringbuffer, -1, POL_LABELS, reorder_tol_bytes)
     for _ in range(free_ringbuffer.maxsize):
         data = np.empty(
             (N_POLS, layout.n_batches_per_chunk, layout.n_channels, layout.n_spectra_per_heap, COMPLEX), np.int8
@@ -180,15 +185,6 @@ class TestStreamGroup:
         # This is an async fixture because make_sensors requires a running event loop
         # Large timeout so that it doesn't affect the test
         return make_sensors(sensor_timeout=1e6, prefixes=[f"{pol}." for pol in POL_LABELS])
-
-    @pytest.fixture(autouse=True)
-    def patch_max_chunks(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Replace MAX_CHUNKS with a large number.
-
-        This prevents heaps being evicted if one of the receiving threads runs
-        faster than the other.
-        """
-        monkeypatch.setattr("katgpucbf.vgpu.recv.MAX_CHUNKS", 10)
 
     @pytest.mark.parametrize("missing", [pytest.param(False, id="nomissing"), pytest.param(True, id="missing")])
     @pytest.mark.parametrize("reorder", [pytest.param(False, id="noreorder"), pytest.param(True, id="reorder")])

--- a/test/vgpu/test_recv.py
+++ b/test/vgpu/test_recv.py
@@ -102,8 +102,8 @@ def stream_group(
     # We want this to be larger than the entire input in test_recv, so that
     # the test doesn't depend on the two receiving threads making progress at
     # the same rate.
-    reorder_tol_bytes = math.ceil(30 / layout.chunk_batches) * layout.chunk_bytes
-    stream_group = recv.make_stream_group(layout, data_ringbuffer, free_ringbuffer, -1, POL_LABELS, reorder_tol_bytes)
+    max_active_chunks = math.ceil(30 / layout.chunk_batches)
+    stream_group = recv.make_stream_group(layout, data_ringbuffer, free_ringbuffer, -1, POL_LABELS, max_active_chunks)
     for _ in range(free_ringbuffer.maxsize):
         data = np.empty(
             (N_POLS, layout.n_batches_per_chunk, layout.n_channels, layout.n_spectra_per_heap, COMPLEX), np.int8


### PR DESCRIPTION
It was previously hardcoded to 2 chunks, with no consideration for how
big a chunk is, and in practice this seems to be too small in some cases
(NGC-2099).

Replace it by having the user specify the tolerance in bytes (which
makes the memory usage predictable), and compute the number of chunks
from that. It's also made a command-line parameter so that it'll be
easier to experiment with in future.

The default value is 128 MiB, which is 4x the previous effective
value, while still being reasonably modest.

Additionally, the calculation of the total number of chunks to allocate had to be updated. It was previously hard-coded to 4, allowing for 2 chunks in the reorder buffer plus 2 being worked on or queued. I've changed that to 2 plus the reorder buffer size.

<!-- Add a description of your change here -->

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`.
- [x] (n/a) If new source files are added: add copyright notices dated with the current year.
- [x] If qualification tests are changed: attach or link to a sample qualification report: https://jenkins.cbf.kat.ac.za/job/qualification_katgpucbf_karoo/740/ (it includes some extra commits, but it gives me confidence that this is working)
- [x] (n/a) If design has changed: ensure documentation is up to date.
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match.
- [x] (n/a) If the interface between the product controller and an engine has changed, update the
      VERSION constant for the engine (update the major number if sensors/requests have been
      removed/changed, minor number if only backwards-compatible changes have been done).
      Also, update doc/control.rst with the new version.
- [x] Re-test latest version on site

Closes NGC-2099.
