### PR TITLE
Prime the pipeline on startup

### DIFF
--- a/src/katgpucbf/vgpu/engine.py
+++ b/src/katgpucbf/vgpu/engine.py
@@ -22,6 +22,7 @@ import math
 from collections.abc import AsyncIterator, Sequence
 from dataclasses import dataclass
 from fractions import Fraction
+from typing import override
 
 import aiokatcp
 import cupy as cp
@@ -120,6 +121,24 @@ class RecvStream:
                     yield zero_arr
                 last_chunk_id = chunk.chunk_id
                 yield arr
+
+
+class DummyStream(AsyncIterator[xr.DataArray]):
+    """Provide the same iteration interface as RecvStream, but with dummy data."""
+
+    def __init__(self, arr: xr.DataArray, time_base: Time, time_scale: Fraction) -> None:
+        self._arr = arr
+        self._next_time_bias = arr.attrs["time_bias"]
+        self.channels = arr.sizes["channel"]
+        self.is_cupy = True
+        self.time_base = time_base
+        self.time_scale = time_scale
+
+    async def __anext__(self) -> xr.DataArray:
+        arr = self._arr.copy(deep=False)
+        arr.attrs["time_bias"] = self._next_time_bias
+        self._next_time_bias += arr.sizes["time"]
+        return arr
 
 
 class RecordPower(katcbf_vlbi_resample.power.RecordPower):
@@ -259,16 +278,39 @@ class _CaptureSession:
         """
         pass
 
+    @staticmethod
+    def frameset_iterator(
+        config: CaptureConfig, sensors: aiokatcp.SensorSet, it: katcbf_vlbi_resample.stream.Stream[xr.DataArray]
+    ) -> katcbf_vlbi_resample.stream.Stream[list[katcbf_vlbi_resample.vdif_writer.VDIFFrame]]:
+        """Generate nested iterators to build the data processing pipeline."""
+        # Copy some references just to make the code shorter
+        recv_config = config.recv_config
+        send_config = config.send_config
+        it = katcbf_vlbi_resample.cupy_bridge.AsCupy(it)
+        it = katcbf_vlbi_resample.resample.IFFT(it)
+        it = katcbf_vlbi_resample.polarisation.ConvertPolarisation(
+            it, config.pol_matrix, recv_config.pols, send_config.pols
+        )
+        it = katcbf_vlbi_resample.resample.Resample(send_config.bandwidth, 0.0, config.resample_parameters, it)
+        it = katcbf_vlbi_resample.rechunk.Rechunk.align_utc_seconds(it)
+        it_rms: katcbf_vlbi_resample.stream.Stream[xr.Dataset] = katcbf_vlbi_resample.power.MeasurePower(it)
+        it_rms = RecordPower(it_rms, sensors=sensors)
+        it = katcbf_vlbi_resample.power.NormalisePower(it_rms, 1.0)
+        it = katcbf_vlbi_resample.vdif_writer.VDIFEncode2Bit(
+            it, samples_per_frame=send_config.n_samples_per_frame, threshold=config.threshold
+        )
+        it = katcbf_vlbi_resample.cupy_bridge.AsNumpy(it)
+        return katcbf_vlbi_resample.vdif_writer.VDIFFormatter(
+            it, config.threads, station=send_config.station, samples_per_frame=send_config.n_samples_per_frame
+        )
+
     async def _capture(self) -> None:
         """Do all the primary work of the engine.
 
         This is an asyncio task that runs as a service task of the device server.
         """
-        # Copy some references just to make the code shorter
-        config = self.config
-        recv_config = config.recv_config
-        send_config = config.send_config
-
+        # Copy a reference just to make the code shorter
+        recv_config = self.config.recv_config
         it: katcbf_vlbi_resample.stream.Stream[xr.DataArray] = RecvStream(
             recv_config.layout,
             recv_config.time_converter,
@@ -278,23 +320,7 @@ class _CaptureSession:
             recv_config.pols,
             self._min_timestamp,
         )
-        it = katcbf_vlbi_resample.cupy_bridge.AsCupy(it)
-        it = katcbf_vlbi_resample.resample.IFFT(it)
-        it = katcbf_vlbi_resample.polarisation.ConvertPolarisation(
-            it, config.pol_matrix, recv_config.pols, send_config.pols
-        )
-        it = katcbf_vlbi_resample.resample.Resample(send_config.bandwidth, 0.0, config.resample_parameters, it)
-        it = katcbf_vlbi_resample.rechunk.Rechunk.align_utc_seconds(it)
-        it_rms: katcbf_vlbi_resample.stream.Stream[xr.Dataset] = katcbf_vlbi_resample.power.MeasurePower(it)
-        it_rms = RecordPower(it_rms, sensors=self._sensors)
-        it = katcbf_vlbi_resample.power.NormalisePower(it_rms, 1.0)
-        it = katcbf_vlbi_resample.vdif_writer.VDIFEncode2Bit(
-            it, samples_per_frame=send_config.n_samples_per_frame, threshold=config.threshold
-        )
-        it = katcbf_vlbi_resample.cupy_bridge.AsNumpy(it)
-        frameset_it = katcbf_vlbi_resample.vdif_writer.VDIFFormatter(
-            it, config.threads, station=send_config.station, samples_per_frame=send_config.n_samples_per_frame
-        )
+        frameset_it = self.frameset_iterator(self.config, self._sensors, it)
         async for frameset in frameset_it:
             await self._sender.send(frameset)
         self._recv_iter.start_discarding()
@@ -352,6 +378,31 @@ class VEngine(Engine):
         # Reference counters to make the labels exist before the first scrape
         for pol in recv_config.pol_labels:
             recv.counters.labels(str(pol))
+
+    async def _prime_memory_pool(self) -> None:
+        """Run a dummy capture session to force memory to be allocated."""
+        recv_config = self.config.recv_config
+        layout = recv_config.layout
+        n_spectra_per_chunk = layout.n_spectra_per_heap * layout.chunk_batches
+        samples_between_spectra = layout.heap_timestamp_step // layout.n_spectra_per_heap
+        data = cp.zeros((N_POLS, n_spectra_per_chunk, layout.n_channels), np.complex64)
+        arr = xr.DataArray(
+            data,
+            dims=("pol", "time", "channel"),
+            coords={"pol": list(recv_config.pols)},
+            attrs={"time_bias": 0},
+        )
+        # It's arbitrary, but needs to be in the past so that it's in the
+        # scope of leap second tables.
+        time_base = Time("2020-01-01T00:00:00", scale="utc")
+        time_scale = Fraction(samples_between_spectra) / Fraction(recv_config.time_converter.adc_sample_rate)
+        it = DummyStream(arr, time_base, time_scale)
+        dummy_sensors = aiokatcp.SensorSet()
+        # Use a large value for sensor timeout, since we're not actually interested
+        self._populate_sensors(dummy_sensors, recv_config.pol_labels, self.config.send_config.pols, 1e6)
+        frameset_it = _CaptureSession.frameset_iterator(self.config, dummy_sensors, it)
+        # Run it until we start getting some output
+        await anext(aiter(frameset_it))
 
     def _init_recv(self) -> None:
         """Initialise the receiver state."""
@@ -445,7 +496,13 @@ class VEngine(Engine):
         for sensor in base_recv.make_sensors(recv_sensor_timeout, prefixes).values():
             sensors.add(sensor)
 
-    async def on_stop(self) -> None:  # noqa: D102
+    @override
+    async def start(self) -> None:
+        await self._prime_memory_pool()
+        await super().start()
+
+    @override
+    async def on_stop(self) -> None:
         if self._capture is not None:
             await self._stop_capture()
         self._recv_group.stop()

--- a/src/katgpucbf/vgpu/engine.py
+++ b/src/katgpucbf/vgpu/engine.py
@@ -461,9 +461,8 @@ class VEngine(Engine):
                 recv_config.pol_labels,
             )
         )
-
-        for stream in recv_group:
-            stream.start()
+        # We do not start the streams yet; that's done in start() so that
+        # it's done only once we're 100% ready to start receiving data.
 
     def _populate_sensors(
         self,
@@ -499,6 +498,8 @@ class VEngine(Engine):
     @override
     async def start(self) -> None:
         await self._prime_memory_pool()
+        for stream in self._recv_group:
+            stream.start()
         await super().start()
 
     @override

--- a/src/katgpucbf/vgpu/engine.py
+++ b/src/katgpucbf/vgpu/engine.py
@@ -123,7 +123,7 @@ class RecvStream:
                 yield arr
 
 
-class DummyStream(AsyncIterator[xr.DataArray]):
+class DummyRecvStream(AsyncIterator[xr.DataArray]):
     """Provide the same iteration interface as RecvStream, but with dummy data."""
 
     def __init__(self, arr: xr.DataArray, time_base: Time, time_scale: Fraction) -> None:
@@ -396,7 +396,7 @@ class VEngine(Engine):
         # scope of leap second tables.
         time_base = Time("2020-01-01T00:00:00", scale="utc")
         time_scale = Fraction(samples_between_spectra) / Fraction(recv_config.time_converter.adc_sample_rate)
-        it = DummyStream(arr, time_base, time_scale)
+        it = DummyRecvStream(arr, time_base, time_scale)
         dummy_sensors = aiokatcp.SensorSet()
         # Use a large value for sensor timeout, since we're not actually interested
         self._populate_sensors(dummy_sensors, recv_config.pol_labels, self.config.send_config.pols, 1e6)


### PR DESCRIPTION
cupy uses memory pooling to avoid having to reallocate GPU memory when arrays of the same size are allocated over and over. That means that the first capture-start has to do a lot of extra work to do the initial allocations, which stalls the pipeline on the first capture-start and tends to lead to a few seconds of data loss.

To reduce this (it doesn't seem to eliminate it completely), create a dummy pipeline on startup and push some dummy data through it, to get some suitably-sized chunks into the pool.

NGC-2126 will take this a bit further, but I'm leaving that for now to avoid conflicts with NGC-1689.

Checklist (if not applicable, edit to add `(N/A)` and mark as done):

- [x] (n/a) If dependencies are added/removed: update `pyproject.toml` and `.pre-commit-config.yaml`.
- [x] (n/a) If new source files are added: add copyright notices dated with the current year.
- [x] (n/a) If qualification tests are changed: attach or link to a sample qualification report.
- [ ] If design has changed: ensure documentation is up to date (**still TODO**)
- [x] (n/a) If ICD-defined sensors have been added: update `fake_servers.py` in katsdpcontroller to match.
- [x] (n/a) If the interface between the product controller and an engine has changed, update the
      VERSION constant for the engine (update the major number if sensors/requests have been
      removed/changed, minor number if only backwards-compatible changes have been done).
      Also, update doc/control.rst with the new version.

Helps with NGC-2099.
